### PR TITLE
Refactor macros

### DIFF
--- a/csrc/core/Macros.h
+++ b/csrc/core/Macros.h
@@ -1,0 +1,4 @@
+#include <c10/macros/Macros.h>
+
+#define C10_BACKEND_API C10_EXPORT
+#define TORCH_BACKEND_API C10_BACKEND_API

--- a/csrc/npu/NPUStream.cpp
+++ b/csrc/npu/NPUStream.cpp
@@ -9,14 +9,16 @@
 #include <sstream>
 #include <vector>
 
-#include "npu/core/NPUException.h"
 #include "csrc/npu/NPUFunctions.h"
+#include "csrc/npu/NPUStream.h"
+#include "npu/acl/include/acl/acl_rt.h"
+#include "npu/core/NPUException.h"
 #include "npu/core/NPUGuard.h"
 #include "npu/core/NPUQueue.h"
-#include "csrc/npu/NPUStream.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
 #include "npu/core/register/OptionsManager.h"
-#include "npu/acl/include/acl/acl_rt.h"
+
+#define C10_COMPILE_TIME_MAX_NPUS 16
 
 namespace c10_npu {
 namespace {

--- a/csrc/npu/NPUStream.h
+++ b/csrc/npu/NPUStream.h
@@ -7,12 +7,12 @@
 #include <mutex>
 
 #include "csrc/aten/generated/NPUNativeFunctions.h"
+#include "npu/acl/include/acl/acl.h"
+#include "npu/acl/include/acl/acl_op.h"
 #include "npu/core/NPUException.h"
 #include "npu/core/NPUMacros.h"
 #include "npu/core/NPUQueue.h"
 #include "npu/core/npu_log.h"
-#include "npu/acl/include/acl/acl.h"
-#include "npu/acl/include/acl/acl_op.h"
 
 namespace c10_npu {
 
@@ -138,7 +138,7 @@ C10_NPU_API bool npuSynchronizeDevice(bool check_error = true);
 
 void enCurrentNPUStream(void* cur_paras, c10::DeviceIndex device_index = -1);
 
-C10_NPU_EXPORT bool npuSynchronizeUsedDevices(bool check_error = true);
+C10_NPU_API bool npuSynchronizeUsedDevices(bool check_error = true);
 
 C10_NPU_API void setCurrentNPUStream(NPUStream stream);
 

--- a/npu/core/NPUMacros.h
+++ b/npu/core/NPUMacros.h
@@ -1,34 +1,6 @@
 #pragma once
-// See c10/macros/Export.h for a detailed explanation of what the function
-// of these macros are.  We need one set of macros for every separate library
-// we build.
 
-#ifdef _WIN32
-#if defined(C10_NPU_BUILD_SHARED_LIBS)
-#define C10_NPU_EXPORT __declspec(dllexport)
-#define C10_NPU_IMPORT __declspec(dllimport)
-#else
-#define C10_NPU_EXPORT
-#define C10_NPU_IMPORT
-#endif
-#else // _WIN32
-#if defined(__GNUC__)
-#define C10_NPU_EXPORT __attribute__((__visibility__("default")))
-#else // defined(__GNUC__)
-#define C10_NPU_EXPORT
-#endif // defined(__GNUC__)
-#define C10_NPU_IMPORT C10_NPU_EXPORT
-#endif // _WIN32
+#include "csrc/core/Macros.h"
 
-// This one is being used by libc10_cuda.so
-#ifdef C10_NPU_BUILD_MAIN_LIB
-#define C10_NPU_API C10_NPU_EXPORT
-#else
-#define C10_NPU_API C10_NPU_IMPORT
-#endif
-
-#define TORCH_NPU_API C10_NPU_API
-
-#define C10_COMPILE_TIME_MAX_NPUS 16
-// A maximum of 8 P2P links can be created on a NPU device
-#define C10_P2P_ACCESS_MAX_NPUS 8
+#define C10_NPU_API C10_BACKEND_API
+#define TORCH_NPU_API TORCH_BACKEND_API

--- a/npu/core/NPUPeerToPeerAccess.cpp
+++ b/npu/core/NPUPeerToPeerAccess.cpp
@@ -4,6 +4,9 @@
 #include <npu/acl/include/acl/acl_rt.h>
 #include "npu/core/NPUGuard.h"
 
+// A maximum of 8 P2P links can be created on a NPU device
+#define C10_P2P_ACCESS_MAX_NPUS 8
+
 namespace at_npu {
 namespace native {
 


### PR DESCRIPTION
修改内容如下

- 使用pytorch macros已有定义替换重复逻辑
- 增加BACKEND API macros公共定义至csrc/core路径
- 因常量均只有一个文件代码在使用，移动macros中常量定义至使用处

NPUMacros.h文件消减待csrc/core路径文件定型后进行，防止存在大量冲突影响效率