### PR TITLE
refactor cache host allocator

### DIFF
--- a/csrc/core/EventPool.h
+++ b/csrc/core/EventPool.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <c10/core/Device.h>
+#include <c10/util/Exception.h>
+#include <mutex>
+
+namespace c10_backend {
+
+// Note: create device events when concurrently invoked from multiple threads
+// can be very expensive (at least on certain device/driver combinations). Thus,
+// we a) serialize event creation at a per-device level, and b) pool the events
+// to avoid constantly calling `create event`/`destroy event`. This results in
+// significant improvements in multithreaded workloads with high allocation
+// rates.
+template <typename T>
+class EventPool {
+ public:
+  using Event = std::unique_ptr<T, std::function<void(T*)>>;
+  EventPool(int device_cout, std::function<std::unique_ptr<T>()> create_event)
+      : pools_(device_cout), create_event_(create_event) {}
+
+  Event get(c10::DeviceIndex device) {
+    TORCH_INTERNAL_ASSERT(0 <= device);
+    TORCH_INTERNAL_ASSERT(
+        device < static_cast<c10::DeviceIndex>(pools_.size()));
+    auto& pool = pools_[device];
+    auto destructor = [&pool](T* event) {
+      std::lock_guard<std::mutex> g(pool.mutex_);
+      pool.event_pool_.push_back(std::unique_ptr<T>(event));
+    };
+
+    // Try to acquire an event from the per-device pool.
+    {
+      std::lock_guard<std::mutex> g(pool.mutex_);
+      if (!pool.event_pool_.empty()) {
+        auto* event = pool.event_pool_.back().release();
+        pool.event_pool_.pop_back();
+        return Event(event, destructor);
+      }
+    }
+    // otherwise, allocate a new event that will be returned to the pool on
+    // destruction.
+    return Event(create_event_().release(), destructor);
+  }
+
+  void empty_cache() {
+    for (auto& pool : pools_) {
+      std::lock_guard<std::mutex> g(pool.mutex_);
+      pool.event_pool_.clear();
+    }
+  }
+
+ private:
+  struct PerDevicePool {
+    alignas(64) std::mutex mutex_;
+    std::vector<std::unique_ptr<T>> event_pool_;
+  };
+  std::vector<PerDevicePool> pools_;
+  std::function<std::unique_ptr<T>()> create_event_;
+};
+} // namespace c10_backend

--- a/csrc/npu/THNPUCachingHostAllocator.cpp
+++ b/csrc/npu/THNPUCachingHostAllocator.cpp
@@ -10,7 +10,6 @@
 
 #include <cstdint>
 #include <deque>
-#include <iostream>
 #include <memory>
 #include <set>
 #include <shared_mutex>

--- a/csrc/npu/THNPUCachingHostAllocator.cpp
+++ b/csrc/npu/THNPUCachingHostAllocator.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/util/Logging.h>
+#include "csrc/core/EventPool.h"
 #include "csrc/npu/NPUFunctions.h"
 #include "npu/core/interface/AclInterface.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
@@ -9,329 +10,113 @@
 
 #include <cstdint>
 #include <deque>
+#include <iostream>
 #include <memory>
-#include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
+#include <ATen/core/CachingHostAllocator.h>
 #include "csrc/npu/NPUEvent.h"
 #include "csrc/npu/THNPUCachingHostAllocator.h"
 
-namespace {
-struct BlockSize {
-  size_t size; // allocation size
-  void* ptr; // host memory pointer
-
-  explicit BlockSize(size_t size, void* ptr = nullptr) : size(size), ptr(ptr) {}
-};
-
-struct Block : public BlockSize {
-  bool allocated; // true if the block is currently allocated
-  int event_count; // number of outstanding npu events
-  std::unordered_set<c10_npu::NPUStream> streams;
-  Block(size_t size, void* ptr, bool allocated)
-      : BlockSize(size, ptr), allocated(allocated), event_count(0), streams() {}
-};
-
-class EventPool {
+namespace c10_npu {
+using Block = at::HostBlock<NPUStream>;
+struct HostAllocator : public at::CachingHostAllocatorImpl<
+                           NPUStream,
+                           c10_backend::EventPool<NPUEvent>::Event> {
  public:
-  using Event = std::
-      unique_ptr<c10_npu::NPUEvent, std::function<void(c10_npu::NPUEvent*)>>;
-  EventPool() : pools_(c10_npu::device_count()) {}
-
-  Event get(at::DeviceIndex device) {
-    TORCH_INTERNAL_ASSERT(0 <= device, PTA_ERROR(ErrCode::PARAM));
-    TORCH_INTERNAL_ASSERT(
-        device < static_cast<at::DeviceIndex>(pools_.size()),
-        PTA_ERROR(ErrCode::PARAM));
-    auto& pool = pools_[device];
-    auto destructor = [&pool](c10_npu::NPUEvent* event) {
-      std::lock_guard<std::mutex> g(pool.mutex_);
-      pool.event_pool_.push_back(std::unique_ptr<c10_npu::NPUEvent>(event));
-    };
-
-    // Try to acquire an event from the per-device pool.
-    {
-      std::lock_guard<std::mutex> g(pool.mutex_);
-      if (!pool.event_pool_.empty()) {
-        auto* event = pool.event_pool_.back().release();
-        pool.event_pool_.pop_back();
-        return Event(event, destructor);
-      }
-    }
-    // otherwise, allocate a new event that will be returned to the pool on
-    // destruction.
-    return Event(
-        std::make_unique<c10_npu::NPUEvent>(ACL_EVENT_CAPTURE_STREAM_PROGRESS)
-            .release(),
-        destructor);
-  }
-
-  void empty_cache() {
-    for (auto& pool : pools_) {
-      std::lock_guard<std::mutex> g(pool.mutex_);
-      pool.event_pool_.clear();
-    }
+  bool isPinndPtr(void* ptr) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return pinned_ptrs.find(ptr) != pinned_ptrs.end();
   }
 
  private:
-  struct PerDevicePool {
-    alignas(64) std::mutex mutex_;
-    std::vector<std::unique_ptr<c10_npu::NPUEvent>> event_pool_;
-  };
-  std::vector<PerDevicePool> pools_;
-};
-
-static bool BlockComparator(const BlockSize& a, const BlockSize& b) {
-  // sort by size, break ties with pointer
-  if (a.size != b.size) {
-    return a.size < b.size;
-  }
-  return reinterpret_cast<uintptr_t>(a.ptr) <
-      reinterpret_cast<uintptr_t>(b.ptr);
-}
-
-struct HostAllocator {
-  using Comparison = bool (*)(const BlockSize&, const BlockSize&);
-
-  HostAllocator() : available(BlockComparator) {}
-
-  aclError malloc(void** ptr, size_t size) {
-    std::lock_guard<std::mutex> lock(mutex);
-
-    // process outstanding npu events which may have occurred
-    aclError err = processEvents();
-    if (err != ACL_ERROR_NONE) {
-      return err;
-    }
-
-    // search for the smallest block which can hold this allocation
-    BlockSize search_key(size);
-    auto it = available.lower_bound(search_key);
-    if (it != available.end()) {
-      Block& block = blocks.at(it->ptr);
-      AT_ASSERT(
-          !block.allocated && block.event_count == 0,
-          PTA_ERROR(ErrCode::PARAM));
-      block.allocated = true;
-      *ptr = block.ptr;
-      available.erase(it);
-      return ACL_ERROR_NONE;
-    }
-
-    *ptr = nullptr;
+  void allocate_host_memory(size_t size, void** ptr) override {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     // for pin_memory in dataloader, it should be set device first when new a
     // thread
-    c10_npu::SetCurrentDevice();
-
+    SetCurrentDevice();
     // allocate a new block if no cached allocation is found
-    err = aclrtMallocHost(ptr, size);
-    if (err != ACL_ERROR_NONE) {
-      return err;
-    }
-
-    blocks.insert({*ptr, Block(size, *ptr, true)});
-    return ACL_ERROR_NONE;
+    NPU_CHECK_ERROR(aclrtMallocHost(ptr, size));
+    pinned_ptrs.insert(*ptr);
   }
 
-  aclError free(void* ptr) {
-    std::lock_guard<std::mutex> lock(mutex);
-    if (!ptr) {
-      return ACL_ERROR_NONE;
-    }
-
-    auto it = blocks.find(ptr);
-    AT_ASSERT(it != blocks.end(), PTA_ERROR(ErrCode::VALUE));
-
-    Block& block = it->second;
-    AT_ASSERT(block.allocated, PTA_ERROR(ErrCode::VALUE));
-
-    // free (on valid memory) shouldn't fail, so mark unallocated before
-    // we process the streams.
-    block.allocated = false;
-
-    // insert npu events for each stream on which this block was used. This
-    aclError err = insertEvents(block);
-    if (err != ACL_ERROR_NONE) {
-      return err;
-    }
-
-    if (block.event_count == 0) {
-      // the block can be re-used if there are no outstanding npu events
-      available.insert(block);
-    }
-    return ACL_ERROR_NONE;
+  void free_block(Block* block) override {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    NPU_CHECK_ERROR(aclrtFreeHost(block->ptr_));
+    pinned_ptrs.erase(block->ptr_);
   }
 
-  aclError recordEvent(void* ptr, c10_npu::NPUStream stream) {
-    std::lock_guard<std::mutex> lock(mutex);
-
-    auto it = blocks.find(ptr);
-    if (it == blocks.end()) {
-      // Sync when host memory is allocated by malloc
-      aclError error = c10_npu::acl::AclrtSynchronizeStreamWithTimeout(stream);
-      if (error != ACL_ERROR_NONE) {
-        C10_NPU_SHOW_ERR_MSG();
-        AT_ERROR("ACL stream synchronize failed.");
-        return error;
-      }
-      return ACL_ERROR_NONE;
-    }
-
-    Block& block = it->second;
-    AT_ASSERT(block.allocated, PTA_ERROR(ErrCode::VALUE));
-
-    block.streams.insert(stream);
-    return ACL_ERROR_NONE;
+  void record_stream(
+      std::optional<std::vector<c10_backend::EventPool<NPUEvent>::Event>>&
+          events,
+      NPUStream stream) override {
+    auto event = create_event_internal(stream.device_index());
+    event->record(stream);
+    events->push_back(std::move(event));
   }
 
-  bool isPinndPtr(void* ptr) {
-    std::lock_guard<std::mutex> lock(mutex);
-    return blocks.find(ptr) != blocks.end();
+  bool query_event(c10_backend::EventPool<NPUEvent>::Event& event) override {
+    return event->query();
   }
 
-  aclError processEvents() {
-    // Process outstanding npuEvents. Events that are completed are removed
-    // from the queue, and the 'event_count' for the corresponding allocation
-    // is decremented. Stops at the first event which has not been completed.
-    // Since events on different devices or streams may occur out of order,
-    // the processing of some events may be delayed.
-    while (!npu_events.empty()) {
-      auto& e = npu_events.front();
-      EventPool::Event event = std::move(e.first);
-      if (!event->query()) {
-        e.first = std::move(event);
-        break;
-      }
-
-      Block& block = blocks.at(e.second);
-      block.event_count--;
-      if (block.event_count == 0 && !block.allocated) {
-        available.insert(block);
-      }
-      npu_events.pop_front();
-    }
-    return ACL_ERROR_NONE;
+  c10_backend::EventPool<NPUEvent>::Event create_event_internal(
+      c10::DeviceIndex idx) {
+    // Leak the event pool to avoid shutdown issue.
+    static auto* event_pool =
+        new c10_backend::EventPool<NPUEvent>(device_count(), []() {
+          return std::make_unique<NPUEvent>(ACL_EVENT_CAPTURE_STREAM_PROGRESS);
+        });
+    return event_pool->get(idx);
   }
 
-  void emptyCache() {
-    std::lock_guard<std::mutex> lock(mutex);
-
-    // process outstanding npu events which may have occurred
-    processEvents();
-
-    // Release cached events from the event pool.
-    event_pool_.empty_cache();
-
-    // clear list of available blocks
-    available.clear();
-
-    // free and erase non-allocated blocks
-    for (auto it = blocks.begin(); it != blocks.end();) {
-      Block& block = it->second;
-      if (aclrtFreeHost(block.ptr) != ACL_ERROR_NONE) {
-        ASCEND_LOGE("free host pin failed!");
-      }
-      if (!block.allocated) {
-        it = blocks.erase(it);
-      } else {
-        block.streams.clear();
-        ++it;
-      }
-    }
-  }
-
-  aclError insertEvents(Block& block) {
-    aclError err = ACL_ERROR_NONE;
-
-    c10::DeviceIndex prev_device = 0;
-    err = c10_npu::GetDevice(&prev_device);
-    if (err != ACL_ERROR_NONE) {
-      return err;
-    }
-
-    std::unordered_set<c10_npu::NPUStream> streams(std::move(block.streams));
-    for (auto it = streams.begin(); it != streams.end(); ++it) {
-      err = c10_npu::SetDevice(it->device_index());
-      if (err != ACL_ERROR_NONE) {
-        C10_NPU_SHOW_ERR_MSG();
-        break;
-      }
-
-      EventPool::Event event = event_pool_.get(it->device_index());
-      event->record(*it);
-      ASCEND_LOGI(
-          "Event: record HostAllocator is successfully executed, event=%p",
-          event.get());
-
-      block.event_count++;
-      npu_events.emplace_back(std::move(event), block.ptr);
-    }
-
-    c10_npu::SetDevice(prev_device);
-
-    return err;
-  }
-
- private:
-  EventPool event_pool_;
-
-  // lock around all operations
-  std::mutex mutex;
-
-  // blocks by pointer
-  std::unordered_map<void*, Block> blocks;
-
-  // pointers that are ready to be allocated (event_count=0)
-  std::set<BlockSize, Comparison> available;
-
-  // outstanding ACL events
-  std::deque<std::pair<EventPool::Event, void*>> npu_events;
+  std::shared_mutex mutex_{};
+  std::set<void*> pinned_ptrs{};
 };
-} // namespace
+} // namespace c10_npu
 
-static HostAllocator allocator;
+void raw_local_deleter(void* ptr);
 
-aclError THNPUCachingHostAllocator_recordEvent(
-    void* ptr,
-    c10_npu::NPUStream stream) {
-  return allocator.recordEvent(ptr, stream);
-}
-
-bool THNPUCachingHostAllocator_isPinndPtr(void* ptr) {
-  return allocator.isPinndPtr(ptr);
-}
-
-void THNPUCachingHostAllocator_emptyCache() {
-  allocator.emptyCache();
-}
-
-static void THNPUCachingHostDeleter(void* ptr) {
-  allocator.free(ptr);
-}
-
-struct THNPUCachingHostAllocator final : public at::Allocator {
+struct THNPUCachingHostAllocator final
+    : public at::CachingHostAllocatorInterface<c10_npu::HostAllocator> {
   at::DataPtr allocate(size_t size) override {
-    AT_ASSERT(size >= 0, PTA_ERROR(ErrCode::VALUE));
-    void* ptr = nullptr;
-    if (allocator.malloc(&ptr, size) != ACL_ERROR_NONE) {
-      ASCEND_LOGE("allocate host pinned memory fail");
-    }
-    return {ptr, ptr, &THNPUCachingHostDeleter, at::DeviceType::CPU};
+    auto ptr_and_ctx = impl_->allocate(size);
+    return {
+        ptr_and_ctx.first,
+        ptr_and_ctx.second,
+        &raw_local_deleter,
+        at::DeviceType::CPU};
   }
-  at::DeleterFnPtr raw_deleter() const override {
-    return &THNPUCachingHostDeleter;
-  }
-  // Note [COW/lazy_clone is not supported yet]
-  void copy_data(void* dest, const void* src, std::size_t count) const {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false, "Not implemented for THNPUCachingHostAllocator");
+
+  bool isPinnedPtr(void* ptr) {
+    return impl_->isPinndPtr(ptr);
   }
 };
 
 static THNPUCachingHostAllocator thnpu_caching_host_allocator;
+
+aclError THNPUCachingHostAllocator_recordEvent(
+    void* ptr,
+    void* ctx,
+    c10_npu::NPUStream stream) {
+  return thnpu_caching_host_allocator.record_event(ptr, ctx, stream);
+}
+
+bool THNPUCachingHostAllocator_isPinndPtr(void* ptr) {
+  return thnpu_caching_host_allocator.isPinnedPtr(ptr);
+}
+
+void THNPUCachingHostAllocator_emptyCache() {
+  thnpu_caching_host_allocator.empty_cache();
+}
+
+void raw_local_deleter(void* ptr) {
+  thnpu_caching_host_allocator.free(ptr);
+}
+
 at::Allocator* getTHNPUCachingHostAllocator() {
   return &thnpu_caching_host_allocator;
 }

--- a/csrc/npu/THNPUCachingHostAllocator.h
+++ b/csrc/npu/THNPUCachingHostAllocator.h
@@ -2,14 +2,15 @@
 #include <c10/util/SmallVector.h>
 
 #include <npu/acl/include/acl/acl.h>
+#include "csrc/npu/NPUStream.h"
 #include "npu/core/NPUException.h"
 #include "npu/core/NPUMacros.h"
-#include "csrc/npu/NPUStream.h"
 
 c10::Allocator* getTHNPUCachingHostAllocator(void);
 
 aclError THNPUCachingHostAllocator_recordEvent(
     void* ptr,
+    void* ctx,
     c10_npu::NPUStream stream);
 
 bool THNPUCachingHostAllocator_isPinndPtr(void* ptr);


### PR DESCRIPTION
1. extract event pool to be device-agnostic;
2. inherit `at::CachingHostAllocatorImpl` to reuse host block caching mechanism.