### PR TITLE
[Test] Add setup init device before test case

### DIFF
--- a/test/cpp/npu/npu_generator_test.cpp
+++ b/test/cpp/npu/npu_generator_test.cpp
@@ -1,13 +1,20 @@
 #include <gtest/gtest.h>
 #include "csrc/npu/NPUGeneratorImpl.h"
 
-TEST(NPUGeneratorImpl, TestSingletonDefaultGenerator) {
+class NPUGeneratorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    at::globalContext().lazyInitPrivateUse1();
+  }
+};
+
+TEST(NPUGeneratorTest, TestSingletonDefaultGenerator) {
   auto gen = at_npu::detail::getDefaultNPUGenerator();
   auto other = at_npu::detail::getDefaultNPUGenerator();
   EXPECT_EQ(gen, other);
 }
 
-TEST(NPUGeneratorImpl, TestCloning) {
+TEST(NPUGeneratorTest, TestCloning) {
   auto gen1 = at_npu::detail::createNPUGenerator();
   auto npu_gen1 = at::check_generator<at_npu::NPUGeneratorImpl>(gen1);
 
@@ -21,26 +28,26 @@ TEST(NPUGeneratorImpl, TestCloning) {
       npu_gen2->philox_offset_per_thread());
 }
 
-TEST(NPUGeneratorImpl, TestGetSetCurrentSeed) {
+TEST(NPUGeneratorTest, TestGetSetCurrentSeed) {
   auto gen = at_npu::detail::createNPUGenerator();
   auto npu_gen = at::check_generator<at_npu::NPUGeneratorImpl>(gen);
   npu_gen->set_current_seed(10);
   EXPECT_EQ(npu_gen->current_seed(), 10);
 }
 
-TEST(NPUGeneratorImpl, TestDeviceType) {
+TEST(NPUGeneratorTest, TestDeviceType) {
   EXPECT_EQ(
       at_npu::NPUGeneratorImpl::device_type(), c10::DeviceType::PrivateUse1);
 }
 
-TEST(NPUGeneratorImpl, TestGetSetOffset) {
+TEST(NPUGeneratorTest, TestGetSetOffset) {
   auto gen = at_npu::detail::createNPUGenerator();
   auto npu_gen = at::check_generator<at_npu::NPUGeneratorImpl>(gen);
   npu_gen->set_offset(100);
   EXPECT_EQ(npu_gen->get_offset(), 100);
 }
 
-TEST(NPUGeneratorImpl, TestGetSetPhiloxOffset) {
+TEST(NPUGeneratorTest, TestGetSetPhiloxOffset) {
   auto gen = at_npu::detail::createNPUGenerator();
   auto npu_gen = at::check_generator<at_npu::NPUGeneratorImpl>(gen);
   npu_gen->set_philox_offset_per_thread(200);


### PR DESCRIPTION
Init device before running test case, avoiding calling device error.