### PR TITLE
[Refactor] Refactor exception to eliminate npu relative logic

### DIFF
--- a/csrc/core/Exception.h
+++ b/csrc/core/Exception.h
@@ -17,29 +17,24 @@ void warn_(const ::c10::Warning& warning);
         return true;                                                          \
       }()
 
-#define TORCH_BACKEND_FORMAT_ERROR(error_code, error_code_map, ...) \
-  TORCH_CHECK(                                                      \
-      false,                                                        \
-      __func__,                                                     \
-      ":",                                                          \
-      __FILE__,                                                     \
-      ":",                                                          \
-      __LINE__,                                                     \
-      "\nBackend Error, error code is ",                            \
-      error_code,                                                   \
-      (error_code_map.find(error_code) != error_code_map.end()      \
-           ? "\n[Error]: " + error_code_map[error_code]             \
-           : "."),                                                  \
-      "\n",                                                         \
+#define TORCH_BACKEND_FORMAT_ERROR(error_code, code_message, ...) \
+  TORCH_CHECK(                                                    \
+      false,                                                      \
+      __func__,                                                   \
+      ":",                                                        \
+      __FILE__,                                                   \
+      ":",                                                        \
+      __LINE__,                                                   \
+      "\nBackend Error, error code is ",                          \
+      error_code,                                                 \
+      code_message,                                               \
+      "\n",                                                       \
       ::c10::str(__VA_ARGS__));
 
-#define TORCH_BACKEND_FORMAT_WARN(error_code, error_code_map, ...) \
-  TORCH_BACKEND_WARN(                                              \
-      "\nBackend warning, error code is ",                         \
-      error_code,                                                  \
-      "[Error]: ",                                                 \
-      (error_code_map.find(error_code) != error_code_map.end()     \
-           ? "\n[Error]: " + error_code_map[error_code]            \
-           : "."),                                                 \
-      "\n",                                                        \
+#define TORCH_BACKEND_FORMAT_WARN(error_code, code_message, ...) \
+  TORCH_BACKEND_WARN(                                            \
+      "\nBackend warning, error code is ",                       \
+      error_code,                                                \
+      code_message,                                              \
+      "\n",                                                      \
       ::c10::str(__VA_ARGS__));

--- a/csrc/core/Exception.h
+++ b/csrc/core/Exception.h
@@ -25,8 +25,9 @@ void warn_(const ::c10::Warning& warning);
       __FILE__,                                                   \
       ":",                                                        \
       __LINE__,                                                   \
-      "\nBackend Error, error code is ",                          \
+      "\nBackend error, error code is ",                          \
       error_code,                                                 \
+      "\n",                                                       \
       code_message,                                               \
       "\n",                                                       \
       ::c10::str(__VA_ARGS__));
@@ -35,6 +36,7 @@ void warn_(const ::c10::Warning& warning);
   TORCH_BACKEND_WARN(                                            \
       "\nBackend warning, error code is ",                       \
       error_code,                                                \
+      "\n",                                                      \
       code_message,                                              \
       "\n",                                                      \
       ::c10::str(__VA_ARGS__));

--- a/npu/core/NPUException.cpp
+++ b/npu/core/NPUException.cpp
@@ -62,8 +62,17 @@ static std::string getCurrentTimestamp() {
 
 namespace c10_npu {
 
-const char* c10_npu_get_error_message() {
+const char* getDeviceErrorMessage() {
   return c10_npu::acl::AclGetErrMsg();
+}
+
+const std::string getErrorMessage(int error_code) {
+  static c10_npu::acl::AclErrorCode aclErrorCode;
+  auto itr = aclErrorCode.error_code_map.find(error_code);
+  if (itr == aclErrorCode.error_code_map.end()) {
+    return "";
+  }
+  return "\n[Error]: " + itr->second;
 }
 
 } // namespace c10_npu

--- a/npu/core/NPUException.h
+++ b/npu/core/NPUException.h
@@ -16,21 +16,20 @@
 #include "npu/core/NPUErrorCodes.h"
 #include "npu/core/interface/AclInterface.h"
 
-#define C10_NPU_SHOW_ERR_MSG()                                      \
-  do {                                                              \
-    std::cout << c10_npu::c10_npu_get_error_message() << std::endl; \
+#define C10_NPU_SHOW_ERR_MSG()                                  \
+  do {                                                          \
+    std::cout << c10_npu::getDeviceErrorMessage() << std::endl; \
   } while (0)
 
-#define NPU_CHECK_WARN(err_code)                 \
-  do {                                           \
-    auto Error = err_code;                       \
-    static c10_npu::acl::AclErrorCode err_map;   \
-    if ((Error) != ACL_ERROR_NONE) {             \
-      TORCH_BACKEND_FORMAT_WARN(                 \
-          err_code,                              \
-          err_map.error_code_map,                \
-          c10_npu::c10_npu_get_error_message()); \
-    }                                            \
+#define NPU_CHECK_WARN(err_code)             \
+  do {                                       \
+    auto Error = err_code;                   \
+    if ((Error) != ACL_ERROR_NONE) {         \
+      TORCH_BACKEND_FORMAT_WARN(             \
+          err_code,                          \
+          c10_npu::getErrorMessage(Error),   \
+          c10_npu::getDeviceErrorMessage()); \
+    }                                        \
   } while (0)
 
 #define TORCH_NPU_WARN(...) TORCH_BACKEND_WARN(__VA_ARGS__)
@@ -79,30 +78,28 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
 #define NPU_CHECK_ERROR(err_code, ...)                \
   do {                                                \
     auto Error = err_code;                            \
-    static c10_npu::acl::AclErrorCode err_map;        \
     if ((Error) != ACL_ERROR_NONE) {                  \
       TORCH_BACKEND_FORMAT_ERROR(                     \
-          err_code,                                   \
-          err_map.error_code_map,                     \
+          Error,                                      \
+          c10_npu::getErrorMessage(Error),            \
           " NPU function error: ",                    \
           getErrorFunction(#err_code, ##__VA_ARGS__), \
           PTA_ERROR(ErrCode::ACL),                    \
-          c10_npu::c10_npu_get_error_message());      \
+          c10_npu::getDeviceErrorMessage());          \
     }                                                 \
   } while (0)
 
 #define OPS_CHECK_ERROR(err_code, ...)                \
   do {                                                \
     auto Error = err_code;                            \
-    static c10_npu::acl::AclErrorCode err_map;        \
     if ((Error) != ACL_ERROR_NONE) {                  \
       TORCH_BACKEND_FORMAT_ERROR(                     \
-          err_code,                                   \
-          err_map.error_code_map,                     \
+          Error,                                      \
+          c10_npu::getErrorMessage(Error),            \
           " OPS function error: ",                    \
           getErrorFunction(#err_code, ##__VA_ARGS__), \
           OPS_ERROR(ErrCode::ACL),                    \
-          c10_npu::c10_npu_get_error_message())       \
+          c10_npu::getDeviceErrorMessage())           \
     }                                                 \
   } while (0)
 
@@ -124,14 +121,16 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
         }();                                                        \
       } else {                                                      \
         TORCH_BACKEND_FORMAT_ERROR(                                 \
-            err_code,                                               \
-            err_map.error_code_map,                                 \
-            c10_npu::c10_npu_get_error_message());                  \
+            Error,                                                  \
+            c10_npu::getErrorMessage(Error),                        \
+            c10_npu::getDeviceErrorMessage());                      \
       }                                                             \
     }                                                               \
   } while (0)
 namespace c10_npu {
 
-C10_BACKEND_API const char* c10_npu_get_error_message();
+C10_BACKEND_API const char* getDeviceErrorMessage();
+
+C10_BACKEND_API const std::string getErrorMessage(int error_code);
 
 } // namespace c10_npu

--- a/test/cpp/core/CMakeLists.txt
+++ b/test/cpp/core/CMakeLists.txt
@@ -1,7 +1,8 @@
 if(BUILD_TEST)
   set(TORCH_BACKEND_CORE_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/test/cpp/common/main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/exception_test.cpp)
 
   add_executable(test_core ${TORCH_BACKEND_CORE_TEST_SOURCES})
   target_link_libraries(test_core PRIVATE torch_npu gtest_main gtest)

--- a/test/cpp/core/exception_test.cpp
+++ b/test/cpp/core/exception_test.cpp
@@ -1,0 +1,33 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "csrc/core/Exception.h"
+
+namespace {
+
+template <class Functor>
+inline void expectThrows(Functor&& functor, const char* expectedMessage) {
+  try {
+    std::forward<Functor>(functor)();
+  } catch (const c10::Error& e) {
+    EXPECT_THAT(
+        e.what_without_backtrace(), ::testing::HasSubstr(expectedMessage));
+    return;
+  }
+  ADD_FAILURE() << "Expected to throw exception with message \""
+                << expectedMessage << "\" but didn't throw";
+}
+} // namespace
+
+TEST(ExceptionTest, TestPrintWarning) {
+  TORCH_BACKEND_WARN("Backend warning.");
+}
+
+TEST(ExceptionTest, TestFormatWarning) {
+  EXPECT_NO_THROW(TORCH_BACKEND_FORMAT_WARN(1, "Test format warning."));
+}
+
+TEST(ExceptionTest, TestFormatError) {
+  expectThrows(
+      []() { TORCH_BACKEND_FORMAT_ERROR(1, "Test format error."); },
+      "\nBackend error, error code is 1\nTest format error.");
+}


### PR DESCRIPTION
Eliminate NPU relative logic from core/Exception files
- Move error_code_map logic from Exception to NPUException
- Rename `c10_npu_get_error_message` function, make consistent with other method names
- Add test cases