### PR TITLE
Optimize backend namespace

### DIFF
--- a/csrc/core/BaseGeneratorImpl.cpp
+++ b/csrc/core/BaseGeneratorImpl.cpp
@@ -2,7 +2,7 @@
 #include <ATen/EmptyTensor.h>
 #include <ATen/Utils.h>
 
-namespace at {
+namespace c10::backend {
 
 BaseGeneratorImpl::BaseGeneratorImpl(DeviceIndex device_index)
     : GeneratorImpl{
@@ -31,4 +31,4 @@ uint64_t BaseGeneratorImpl::seed() {
   this->set_current_seed(random);
   return random;
 }
-} // namespace at
+} // namespace c10::backend

--- a/csrc/core/BaseGeneratorImpl.h
+++ b/csrc/core/BaseGeneratorImpl.h
@@ -2,7 +2,7 @@
 
 #include <ATen/core/Generator.h>
 
-namespace at {
+namespace c10::backend {
 struct C10_API BaseGeneratorImpl : public GeneratorImpl {
   BaseGeneratorImpl(DeviceIndex device_index);
 
@@ -25,4 +25,4 @@ struct C10_API BaseGeneratorImpl : public GeneratorImpl {
   uint64_t seed_ = default_rng_seed_val;
 };
 
-} // namespace at
+} // namespace c10::backend

--- a/csrc/core/CachingAllocator.cpp
+++ b/csrc/core/CachingAllocator.cpp
@@ -22,7 +22,7 @@
 #include "csrc/core/EventPool.h"
 #include "csrc/npu/NPUFunctions.h"
 
-namespace c10_backend::CachingAllocator {
+namespace c10::backend::CachingAllocator {
 
 C10_DEFINE_REGISTRY(FreeNPUMemoryCallbacksRegistry, FreeMemoryCallback);
 
@@ -2033,7 +2033,8 @@ class DeviceCachingAllocator {
       for (auto& stream : streams) {
         setDevice(stream.device_index());
 
-        EventPool<c10::Event>::Event event = create_event_internal(stream.device_index());
+        EventPool<c10::Event>::Event event =
+            create_event_internal(stream.device_index());
         event->record(stream);
 
         block->event_count++;
@@ -2435,4 +2436,4 @@ BackendStaticInitializer backend_static_initializer;
 void registerHelper(CachingAllocatorHelper* helper_) {
   helper = helper_;
 }
-} // namespace c10_backend::CachingAllocator
+} // namespace c10::backend::CachingAllocator

--- a/csrc/core/CachingAllocator.h
+++ b/csrc/core/CachingAllocator.h
@@ -6,7 +6,7 @@
 #include <c10/util/SmallVector.h>
 #include <atomic>
 
-namespace c10_backend::CachingAllocator {
+namespace c10::backend::CachingAllocator {
 
 // Caching allocator will execute every registered callback if it unable to find
 // block inside of already allocated area.
@@ -295,4 +295,4 @@ inline void attachOutOfMemoryObserver(OutOfMemoryObserver observer) {
   return get()->attachOutOfMemoryObserver(observer);
 }
 
-} // namespace c10_backend::CachingAllocator
+} // namespace c10::backend::CachingAllocator

--- a/csrc/core/CachingAllocatorHelper.h
+++ b/csrc/core/CachingAllocatorHelper.h
@@ -1,6 +1,6 @@
 #include <c10/core/Device.h>
 #include <c10/util/irange.h>
-namespace c10_backend::CachingAllocator {
+namespace c10::backend::CachingAllocator {
 static const int MEM_SUCCESS = 0;
 static const int MEM_ALLOCATION_ERROR = 1;
 
@@ -90,4 +90,4 @@ class CachingAllocatorHelper {
 
 // register CachingAllocatorHelper for DefaultCachingAllocator.
 void registerHelper(CachingAllocatorHelper* helper);
-} // namespace c10_backend::CachingAllocator
+} // namespace c10::backend::CachingAllocator

--- a/csrc/core/EventPool.h
+++ b/csrc/core/EventPool.h
@@ -4,7 +4,7 @@
 #include <c10/util/Exception.h>
 #include <mutex>
 
-namespace c10_backend {
+namespace c10::backend {
 
 // Note: create device events when concurrently invoked from multiple threads
 // can be very expensive (at least on certain device/driver combinations). Thus,
@@ -58,4 +58,4 @@ class EventPool {
   std::vector<PerDevicePool> pools_;
   std::function<std::unique_ptr<T>()> create_event_;
 };
-} // namespace c10_backend
+} // namespace c10::backend

--- a/csrc/core/PrivateUse1Guard.h
+++ b/csrc/core/PrivateUse1Guard.h
@@ -6,7 +6,7 @@
 
 #include "csrc/core/impl/PrivateUse1GuardImpl.h"
 
-namespace c10_backend {
+namespace c10::backend {
 
 // This code is kind of boilerplatey.  See Note [Whither the DeviceGuard
 // boilerplate]
@@ -143,4 +143,4 @@ struct OptionalPrivateUse1Guard {
   c10::impl::InlineOptionalDeviceGuard<T> guard_;
 };
 
-} // namespace c10_backend
+} // namespace c10::backend

--- a/csrc/core/impl/PrivateUse1GuardImpl.h
+++ b/csrc/core/impl/PrivateUse1GuardImpl.h
@@ -4,7 +4,7 @@
 #include <c10/core/impl/InlineDeviceGuard.h>
 #include <c10/macros/Macros.h>
 
-namespace c10_backend::impl {
+namespace c10::backend::impl {
 
 /**
  * All classes which inherit from PrivateUse1GuardImpl should be declared
@@ -24,4 +24,4 @@ struct PrivateUse1GuardImpl : public c10::impl::DeviceGuardImplInterface {
   }
 };
 
-} // namespace c10_backend::impl
+} // namespace c10::backend::impl

--- a/csrc/npu/NPUCachingAllocator.cpp
+++ b/csrc/npu/NPUCachingAllocator.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include "csrc/core/CachingAllocator.h"
 
-namespace c10_npu::NPUCachingAllocator {
+namespace c10::npu::NPUCachingAllocator {
 class DefaultNPUAllocator final : public NPUAllocator {
  public:
   void init(CachingAllocator* delegate) {
@@ -77,4 +77,4 @@ REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &defaultNPUAllocator);
 void init(CachingAllocator* delegate) {
   defaultNPUAllocator.init(delegate);
 }
-} // namespace c10_npu::NPUCachingAllocator
+} // namespace c10::npu::NPUCachingAllocator

--- a/csrc/npu/NPUCachingAllocator.h
+++ b/csrc/npu/NPUCachingAllocator.h
@@ -2,7 +2,7 @@
 
 #include "csrc/core/CachingAllocator.h"
 
-namespace c10_npu::NPUCachingAllocator {
+namespace c10::npu::NPUCachingAllocator {
 
 using namespace c10::backend::CachingAllocator;
 
@@ -98,4 +98,4 @@ inline bool isHistoryEnabled() {
 inline void attachOutOfMemoryObserver(OutOfMemoryObserver observer) {
   return get()->attachOutOfMemoryObserver(observer);
 }
-} // namespace c10_npu::NPUCachingAllocator
+} // namespace c10::npu::NPUCachingAllocator

--- a/csrc/npu/NPUCachingAllocator.h
+++ b/csrc/npu/NPUCachingAllocator.h
@@ -4,7 +4,7 @@
 
 namespace c10_npu::NPUCachingAllocator {
 
-using namespace c10_backend::CachingAllocator;
+using namespace c10::backend::CachingAllocator;
 
 class NPUAllocator : public c10::Allocator {
  public:

--- a/csrc/npu/NPUCachingAllocatorHelper.h
+++ b/csrc/npu/NPUCachingAllocatorHelper.h
@@ -12,7 +12,7 @@
 namespace c10_npu::NPUCachingAllocator {
 
 class CachingAllocatorHelper
-    : public c10_backend::CachingAllocator::CachingAllocatorHelper {
+    : public c10::backend::CachingAllocator::CachingAllocatorHelper {
  public:
   void insertEventWrapper(c10::DeviceIndex device, std::function<void()> fn)
       override {

--- a/csrc/npu/NPUCachingAllocatorHelper.h
+++ b/csrc/npu/NPUCachingAllocatorHelper.h
@@ -9,7 +9,7 @@
 #include "npu/acl/include/acl/acl_rt.h"
 #include "npu/core/npu_log.h"
 
-namespace c10_npu::NPUCachingAllocator {
+namespace c10::npu::NPUCachingAllocator {
 
 class CachingAllocatorHelper
     : public c10::backend::CachingAllocator::CachingAllocatorHelper {
@@ -18,7 +18,7 @@ class CachingAllocatorHelper
       override {
     aclrtContext compiler_ctx = aclrtContext();
     aclError ret_ctx = aclrtGetCurrentContext(&compiler_ctx);
-    NPU_CHECK_ERROR(aclrtSetCurrentContext(c10_npu::GetDeviceContext(device)));
+    NPU_CHECK_ERROR(aclrtSetCurrentContext(c10::npu::GetDeviceContext(device)));
     fn();
     if (ret_ctx == ACL_ERROR_NONE) {
       NPU_CHECK_ERROR(aclrtSetCurrentContext(compiler_ctx));
@@ -26,7 +26,7 @@ class CachingAllocatorHelper
   }
 
   void* getCurrentStream(c10::DeviceIndex device_index) override {
-    return c10_npu::getCurrentNPUStream(device_index);
+    return c10::npu::getCurrentNPUStream(device_index);
   }
 
   int synchronizeStream(void* stream) override {
@@ -34,7 +34,7 @@ class CachingAllocatorHelper
   }
 
   virtual void deviceSynchronize() override {
-    c10_npu::device_synchronize();
+    c10::npu::device_synchronize();
   }
 
   int memFree(void* devPtr) override {
@@ -103,4 +103,4 @@ class CachingAllocatorHelper
     return aclrtUnmapMem(ptr);
   }
 };
-} // namespace c10_npu::NPUCachingAllocator
+} // namespace c10::npu::NPUCachingAllocator

--- a/csrc/npu/NPUCachingHostAllocator.cpp
+++ b/csrc/npu/NPUCachingHostAllocator.cpp
@@ -17,7 +17,7 @@
 #include "csrc/npu/NPUFunctions.h"
 #include "npu/core/sys_ctrl/npu_sys_ctrl.h"
 
-namespace c10_npu {
+namespace c10::npu {
 using Block = at::HostBlock<NPUStream>;
 struct HostAllocator : public at::CachingHostAllocatorImpl<
                            NPUStream,
@@ -34,7 +34,7 @@ struct HostAllocator : public at::CachingHostAllocatorImpl<
 
     // TODO(FFFrog): implement aclrtMallocHost which don`t need explicitly
     // to create context
-    c10_npu::current_device();
+    c10::npu::current_device();
     NPU_CHECK_ERROR(aclrtMallocHost(ptr, size));
     pinned_ptrs.insert(*ptr);
   }
@@ -71,12 +71,12 @@ struct HostAllocator : public at::CachingHostAllocatorImpl<
   std::shared_mutex mutex_{};
   std::set<const void*> pinned_ptrs{};
 };
-} // namespace c10_npu
+} // namespace c10::npu
 
 void raw_local_deleter(void* ptr);
 
 struct NPUCachingHostAllocator final
-    : public at::CachingHostAllocatorInterface<c10_npu::HostAllocator> {
+    : public at::CachingHostAllocatorInterface<c10::npu::HostAllocator> {
   at::DataPtr allocate(size_t size) override {
     auto ptr_and_ctx = impl_->allocate(size);
     return {
@@ -104,7 +104,7 @@ void raw_local_deleter(void* ptr) {
 bool NPUCachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
-    c10_npu::NPUStream stream) {
+    c10::npu::NPUStream stream) {
   return npu_caching_host_allocator.record_event(ptr, ctx, stream);
 }
 

--- a/csrc/npu/NPUCachingHostAllocator.cpp
+++ b/csrc/npu/NPUCachingHostAllocator.cpp
@@ -21,7 +21,7 @@ namespace c10_npu {
 using Block = at::HostBlock<NPUStream>;
 struct HostAllocator : public at::CachingHostAllocatorImpl<
                            NPUStream,
-                           c10_backend::EventPool<NPUEvent>::Event> {
+                           c10::backend::EventPool<NPUEvent>::Event> {
  public:
   bool isPinndPtr(const void* ptr) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -46,7 +46,7 @@ struct HostAllocator : public at::CachingHostAllocatorImpl<
   }
 
   void record_stream(
-      std::optional<std::vector<c10_backend::EventPool<NPUEvent>::Event>>&
+      std::optional<std::vector<c10::backend::EventPool<NPUEvent>::Event>>&
           events,
       NPUStream stream) override {
     auto event = create_event_internal(stream.device_index());
@@ -54,15 +54,15 @@ struct HostAllocator : public at::CachingHostAllocatorImpl<
     events->push_back(std::move(event));
   }
 
-  bool query_event(c10_backend::EventPool<NPUEvent>::Event& event) override {
+  bool query_event(c10::backend::EventPool<NPUEvent>::Event& event) override {
     return event->query();
   }
 
-  c10_backend::EventPool<NPUEvent>::Event create_event_internal(
+  c10::backend::EventPool<NPUEvent>::Event create_event_internal(
       c10::DeviceIndex idx) {
     // Leak the event pool to avoid shutdown issue.
     static auto* event_pool =
-        new c10_backend::EventPool<NPUEvent>(device_count(), []() {
+        new c10::backend::EventPool<NPUEvent>(device_count(), []() {
           return std::make_unique<NPUEvent>(ACL_EVENT_CAPTURE_STREAM_PROGRESS);
         });
     return event_pool->get(idx);

--- a/csrc/npu/NPUCachingHostAllocator.h
+++ b/csrc/npu/NPUCachingHostAllocator.h
@@ -11,7 +11,7 @@ c10::Allocator* getNPUCachingHostAllocator(void);
 bool NPUCachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
-    c10_npu::NPUStream stream);
+    c10::npu::NPUStream stream);
 
 void NPUCachingHostAllocator_emptyCache(void);
 

--- a/csrc/npu/NPUContext.cpp
+++ b/csrc/npu/NPUContext.cpp
@@ -4,7 +4,7 @@
 #include <c10/util/CallOnce.h>
 #include "csrc/npu/NPUContext.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace {
 
 /*
@@ -20,13 +20,13 @@ std::deque<c10::once_flag> device_prop_flags;
 std::vector<NPUDeviceProp> device_properties;
 
 void initNPUContextVectors() {
-  num_npus = c10_npu::device_count();
+  num_npus = c10::npu::device_count();
   device_prop_flags.resize(num_npus);
   device_properties.resize(num_npus);
 }
 
 void initDeviceProperty(c10::DeviceIndex device) {
-  c10_npu::get_device_properties(&device_properties[device], device);
+  c10::npu::get_device_properties(&device_properties[device], device);
 }
 
 inline void check_device(c10::DeviceIndex device) {
@@ -43,10 +43,10 @@ inline void check_device(c10::DeviceIndex device) {
 NPUDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
   c10::call_once(init_flag, initNPUContextVectors);
   if (device == -1)
-    device = c10_npu::current_device();
+    device = c10::npu::current_device();
   check_device(device);
   c10::call_once(device_prop_flags[device], initDeviceProperty, device);
   return &device_properties[device];
 }
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUContext.h
+++ b/csrc/npu/NPUContext.h
@@ -3,13 +3,13 @@
 #include "csrc/npu/NPUDeviceProp.h"
 #include "csrc/npu/NPUFunctions.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
 // NPU is available if we compiled with NPU.
 inline bool is_available() {
-  return c10_npu::device_count() > 0;
+  return c10::npu::device_count() > 0;
 }
 
 NPUDeviceProp* getDeviceProperties(c10::DeviceIndex device);
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUDeviceProp.h
+++ b/csrc/npu/NPUDeviceProp.h
@@ -2,11 +2,11 @@
 
 #include <string>
 
-namespace c10_npu {
+namespace c10::npu {
 
 struct NPUDeviceProp {
   std::string name{};
   size_t totalGlobalMem = 0;
 };
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUEvent.h
+++ b/csrc/npu/NPUEvent.h
@@ -3,13 +3,13 @@
 #include <cstdint>
 #include <utility>
 #include "csrc/core/Macros.h"
-#include "csrc/npu/NPUStream.h"
 #include "csrc/npu/NPUGuard.h"
+#include "csrc/npu/NPUStream.h"
 #include "npu/acl/include/acl/acl.h"
 #include "npu/core/NPUException.h"
 #include "npu/core/sys_ctrl/npu_sys_ctrl.h"
 
-namespace c10_npu {
+namespace c10::npu {
 /*
  * NPUEvents are movable not copyable wrappers around NPU's events.
  * NPUEvents are constructed lazily when first recorded.
@@ -26,13 +26,16 @@ struct C10_BACKEND_API NPUEvent {
         NPUGuard guard(device_index_);
         NPU_CHECK_ERROR(aclrtDestroyEvent(event_));
       }
-    } catch (...) { /* No throw */ }
+    } catch (...) { /* No throw */
+    }
   }
 
   NPUEvent(const NPUEvent&) = delete;
   NPUEvent& operator=(const NPUEvent&) = delete;
 
-  NPUEvent(NPUEvent&& other) noexcept { moveHelper(std::move(other)); }
+  NPUEvent(NPUEvent&& other) noexcept {
+    moveHelper(std::move(other));
+  }
   NPUEvent& operator=(NPUEvent&& other) noexcept {
     if (this != &other) {
       moveHelper(std::move(other));
@@ -40,7 +43,9 @@ struct C10_BACKEND_API NPUEvent {
     return *this;
   }
 
-  operator aclrtEvent() const { return event(); }
+  operator aclrtEvent() const {
+    return event();
+  }
 
   // aclrtEvent do not support Less than operator until now
 
@@ -52,9 +57,15 @@ struct C10_BACKEND_API NPUEvent {
     }
   }
 
-  bool isCreated() const { return is_created_; }
-  c10::DeviceIndex device_index() const { return device_index_; }
-  aclrtEvent event() const { return event_; }
+  bool isCreated() const {
+    return is_created_;
+  }
+  c10::DeviceIndex device_index() const {
+    return device_index_;
+  }
+  aclrtEvent event() const {
+    return event_;
+  }
 
   bool query() const {
     if (!is_created_) {
@@ -69,10 +80,13 @@ struct C10_BACKEND_API NPUEvent {
     return false;
   }
 
-  void record() { record(getCurrentNPUStream()); }
+  void record() {
+    record(getCurrentNPUStream());
+  }
 
   void recordOnce(const NPUStream& stream) {
-    if (!was_recorded_) record(stream);
+    if (!was_recorded_)
+      record(stream);
   }
 
   void record(const NPUStream& stream) {
@@ -101,7 +115,8 @@ struct C10_BACKEND_API NPUEvent {
   }
 
   float elapsed_time(const NPUEvent& other) const {
-    TORCH_CHECK(is_created_ && other.isCreated(),
+    TORCH_CHECK(
+        is_created_ && other.isCreated(),
         "Both events must be recorded before calculating elapsed time.",
         PTA_ERROR(ErrCode::INTERNAL));
     float time_ms = 0;
@@ -151,4 +166,4 @@ struct C10_BACKEND_API NPUEvent {
   }
 };
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUFunctions.cpp
+++ b/csrc/npu/NPUFunctions.cpp
@@ -4,7 +4,7 @@
 #include "csrc/npu/NPUStream.h"
 #include "npu/adapter/acl_device_adapter.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
 int device_count_impl() {
   int count = 0;
@@ -44,12 +44,12 @@ c10::DeviceIndex device_count_ensure_non_zero() {
 
 c10::DeviceIndex current_device() {
   c10::DeviceIndex cur_device = -1;
-  NPU_CHECK_ERROR(c10_npu::GetDevice(&cur_device));
+  NPU_CHECK_ERROR(c10::npu::GetDevice(&cur_device));
   return cur_device;
 }
 
 void set_device(c10::DeviceIndex device) {
-  NPU_CHECK_ERROR(c10_npu::SetDevice(device));
+  NPU_CHECK_ERROR(c10::npu::SetDevice(device));
 }
 
 void device_synchronize() {
@@ -143,7 +143,7 @@ aclError SetDevice(c10::DeviceIndex device) {
 
 aclError MaybeSetDevice(c10::DeviceIndex device) {
   if (hasPrimaryContext(device)) {
-    return c10_npu::SetDevice(device);
+    return c10::npu::SetDevice(device);
   }
   targetDeviceIndex = device;
   return ACL_ERROR_NONE;
@@ -190,7 +190,7 @@ c10::DeviceIndex MaybeExchangeDevice(c10::DeviceIndex to_device) {
 
 void SetTargetDevice() {
   if (targetDeviceIndex >= 0) {
-    NPU_CHECK_ERROR(c10_npu::SetDevice(targetDeviceIndex));
+    NPU_CHECK_ERROR(c10::npu::SetDevice(targetDeviceIndex));
   }
 }
 
@@ -208,7 +208,7 @@ std::mutex* getFreeMutex() {
 }
 
 void get_device_properties(
-    c10_npu::NPUDeviceProp* device_prop,
+    c10::npu::NPUDeviceProp* device_prop,
     c10::DeviceIndex device) {
   const char* device_name;
   device_name = aclrtGetSocName();
@@ -220,4 +220,4 @@ void get_device_properties(
   }
 }
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUFunctions.h
+++ b/csrc/npu/NPUFunctions.h
@@ -18,7 +18,7 @@
 #include "npu/core/NPUException.h"
 #include "npu/core/npu_log.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
 C10_BACKEND_API c10::DeviceIndex device_count() noexcept;
 
@@ -82,12 +82,13 @@ C10_BACKEND_API __inline__ WarningState& warning_state() {
 }
 
 C10_BACKEND_API bool hasPrimaryContext(c10::DeviceIndex device_index);
-C10_BACKEND_API std::optional<c10::DeviceIndex> getDeviceIndexWithPrimaryContext();
+C10_BACKEND_API std::optional<c10::DeviceIndex>
+getDeviceIndexWithPrimaryContext();
 
 C10_BACKEND_API std::mutex* getFreeMutex();
 
 C10_BACKEND_API void get_device_properties(
-    c10_npu::NPUDeviceProp* device_prop,
+    c10::npu::NPUDeviceProp* device_prop,
     c10::DeviceIndex device);
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUGeneratorImpl.cpp
+++ b/csrc/npu/NPUGeneratorImpl.cpp
@@ -27,7 +27,7 @@ static std::vector<at::Generator> default_gens_npu;
  * Warning: this function must only be called once!
  */
 static void initNPUGenVector() {
-  num_npus = c10_npu::device_count();
+  num_npus = c10::npu::device_count();
   npu_gens_init_flag.resize(num_npus);
   default_gens_npu.resize(num_npus);
 }
@@ -46,7 +46,7 @@ const at::Generator& getDefaultNPUGenerator(c10::DeviceIndex device_index) {
   std::call_once(num_npu_init_flag, initNPUGenVector);
   c10::DeviceIndex idx = device_index;
   if (idx == -1) {
-    idx = c10_npu::current_device();
+    idx = c10::npu::current_device();
   } else {
     TORCH_CHECK(idx >= 0 && idx < num_npus, PTA_ERROR(ErrCode::VALUE));
   }
@@ -64,7 +64,7 @@ at::Generator createNPUGenerator(c10::DeviceIndex device_index) {
   std::call_once(num_npu_init_flag, initNPUGenVector);
   c10::DeviceIndex idx = device_index;
   if (idx == -1) {
-    idx = c10_npu::current_device();
+    idx = c10::npu::current_device();
   }
   TORCH_CHECK(
       idx >= 0 && idx < num_npus,

--- a/csrc/npu/NPUGeneratorImpl.h
+++ b/csrc/npu/NPUGeneratorImpl.h
@@ -118,7 +118,8 @@ struct PhiloxNpuState {
   bool captured_ = false;
 };
 
-struct TORCH_BACKEND_API NPUGeneratorImpl : public at::BaseGeneratorImpl {
+struct TORCH_BACKEND_API NPUGeneratorImpl
+    : public c10::backend::BaseGeneratorImpl {
   // Constructors
   NPUGeneratorImpl(c10::DeviceIndex device_index = -1);
   ~NPUGeneratorImpl() = default;

--- a/csrc/npu/NPUGuard.h
+++ b/csrc/npu/NPUGuard.h
@@ -8,7 +8,7 @@
 
 #include <cstddef>
 
-namespace c10_npu {
+namespace c10::npu {
 
 // This code is kind of boilerplatey.  See Note [Whither the DeviceGuard
 // boilerplate]
@@ -109,7 +109,7 @@ struct NPUStreamGuard {
   }
 
  private:
-  c10::impl::InlineStreamGuard<c10_npu::impl::NPUGuardImpl> guard_;
+  c10::impl::InlineStreamGuard<c10::npu::impl::NPUGuardImpl> guard_;
 };
 
 /// A variant of OptionalStreamGuard that is specialized for NPU.  See NPUGuard
@@ -178,7 +178,7 @@ struct OptionalNPUStreamGuard {
   }
 
  private:
-  c10::impl::InlineOptionalStreamGuard<c10_npu::impl::NPUGuardImpl> guard_;
+  c10::impl::InlineOptionalStreamGuard<c10::npu::impl::NPUGuardImpl> guard_;
 };
 
 /// A variant of MultiStreamGuard that is specialized for NPU.
@@ -197,7 +197,7 @@ struct NPUMultiStreamGuard {
   NPUMultiStreamGuard& operator=(NPUMultiStreamGuard&& other) = delete;
 
  private:
-  c10::impl::InlineMultiStreamGuard<c10_npu::impl::NPUGuardImpl> guard_;
+  c10::impl::InlineMultiStreamGuard<c10::npu::impl::NPUGuardImpl> guard_;
 
   static std::vector<c10::Stream> unwrapStreams(
       at::ArrayRef<NPUStream> NPUStreams) {
@@ -210,4 +210,4 @@ struct NPUMultiStreamGuard {
   }
 };
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUGuard.h
+++ b/csrc/npu/NPUGuard.h
@@ -18,8 +18,8 @@ namespace c10_npu {
 /// more efficient than DeviceGuard (it compiles to straight line
 /// NPUSetDevice/NPUGetDevice calls); however, it can only be used
 /// from code that links against NPU directly.
-struct NPUGuard : public c10_backend::PrivateUse1Guard<impl::NPUGuardImpl> {
-  using PrivateUse1Guard = c10_backend::PrivateUse1Guard<impl::NPUGuardImpl>;
+struct NPUGuard : public c10::backend::PrivateUse1Guard<impl::NPUGuardImpl> {
+  using PrivateUse1Guard = c10::backend::PrivateUse1Guard<impl::NPUGuardImpl>;
   using PrivateUse1Guard::PrivateUse1Guard;
 
   // Copy is not allowed
@@ -34,9 +34,9 @@ struct NPUGuard : public c10_backend::PrivateUse1Guard<impl::NPUGuardImpl> {
 /// A variant of OptionalDeviceGuard that is specialized for NPU.  See
 /// NPUGuard for when you can use this.
 struct OptionalNPUGuard
-    : public c10_backend::OptionalPrivateUse1Guard<impl::NPUGuardImpl> {
+    : public c10::backend::OptionalPrivateUse1Guard<impl::NPUGuardImpl> {
   using OptionalPrivateUse1Guard =
-      c10_backend::OptionalPrivateUse1Guard<impl::NPUGuardImpl>;
+      c10::backend::OptionalPrivateUse1Guard<impl::NPUGuardImpl>;
   using OptionalPrivateUse1Guard::OptionalPrivateUse1Guard;
 
   // Copy is not allowed

--- a/csrc/npu/NPUGuardImpl.cpp
+++ b/csrc/npu/NPUGuardImpl.cpp
@@ -1,7 +1,7 @@
 #include "csrc/npu/NPUGuardImpl.h"
 
-namespace c10_npu::impl {
+namespace c10::npu::impl {
 
 C10_REGISTER_GUARD_IMPL(PrivateUse1, NPUGuardImpl);
 
-} // namespace c10_npu::impl
+} // namespace c10::npu::impl

--- a/csrc/npu/NPUGuardImpl.h
+++ b/csrc/npu/NPUGuardImpl.h
@@ -12,7 +12,7 @@
 #include "npu/core/NPUException.h"
 #include "npu/core/sys_ctrl/npu_sys_ctrl.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace impl {
 struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
   NPUGuardImpl() = default;
@@ -32,13 +32,13 @@ struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
         PTA_ERROR(ErrCode::PARAM));
     c10::Device old_device = getDevice();
     if (old_device.index() != d.index()) {
-      NPU_CHECK_ERROR(c10_npu::SetDevice(d.index()));
+      NPU_CHECK_ERROR(c10::npu::SetDevice(d.index()));
     }
     return old_device;
   }
   c10::Device getDevice() const override {
     c10::DeviceIndex device = 0;
-    NPU_CHECK_ERROR(c10_npu::GetDevice(&device));
+    NPU_CHECK_ERROR(c10::npu::GetDevice(&device));
     return c10::Device(c10::DeviceType::PrivateUse1, device);
   }
   void setDevice(c10::Device d) const override {
@@ -47,31 +47,31 @@ struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
         "DeviceType must be 'c10::DeviceType::PrivateUse1'. Actual DeviceType is: ",
         d.type(),
         PTA_ERROR(ErrCode::PARAM));
-    NPU_CHECK_ERROR(c10_npu::SetDevice(d.index()));
+    NPU_CHECK_ERROR(c10::npu::SetDevice(d.index()));
   }
   void uncheckedSetDevice(c10::Device d) const noexcept override {
-    NPU_CHECK_WARN(c10_npu::SetDevice(d.index()));
+    NPU_CHECK_WARN(c10::npu::SetDevice(d.index()));
   }
   c10::Stream getStream(c10::Device d) const noexcept override {
-    return c10_npu::getCurrentNPUStream(d.index()).unwrap();
+    return c10::npu::getCurrentNPUStream(d.index()).unwrap();
   }
   c10::Stream getDefaultStream(c10::Device d) const override {
-    return c10_npu::getDefaultNPUStream(d.index());
+    return c10::npu::getDefaultNPUStream(d.index());
   }
   c10::Stream getStreamFromGlobalPool(
       c10::Device d,
       bool isHighPriority = false) const override {
-    return c10_npu::getStreamFromPool(isHighPriority, d.index());
+    return c10::npu::getStreamFromPool(isHighPriority, d.index());
   }
   // NB: These do NOT set the current device
   c10::Stream exchangeStream(c10::Stream s) const noexcept override {
     NPUStream cs(s);
-    auto old_stream = c10_npu::getCurrentNPUStream(s.device().index());
-    c10_npu::setCurrentNPUStream(cs);
+    auto old_stream = c10::npu::getCurrentNPUStream(s.device().index());
+    c10::npu::setCurrentNPUStream(cs);
     return old_stream.unwrap();
   }
   c10::DeviceIndex deviceCount() const noexcept override {
-    static c10::DeviceIndex count = c10_npu::device_count();
+    static c10::DeviceIndex count = c10::npu::device_count();
     return count;
   }
 
@@ -90,10 +90,10 @@ struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
       return;
     auto acl_event = static_cast<aclrtEvent>(event);
     c10::DeviceIndex orig_device{-1};
-    NPU_CHECK_WARN(c10_npu::GetDevice(&orig_device));
-    NPU_CHECK_WARN(c10_npu::SetDevice(device_index));
+    NPU_CHECK_WARN(c10::npu::GetDevice(&orig_device));
+    NPU_CHECK_WARN(c10::npu::SetDevice(device_index));
     NPU_CHECK_WARN(aclrtDestroyEvent(acl_event));
-    NPU_CHECK_WARN(c10_npu::SetDevice(orig_device));
+    NPU_CHECK_WARN(c10::npu::SetDevice(orig_device));
     ASCEND_LOGI(
         "Event: aclrtDestroyEvent is successfully executed, event=%p",
         acl_event);
@@ -174,4 +174,4 @@ struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
 };
 
 } // namespace impl
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUGuardImpl.h
+++ b/csrc/npu/NPUGuardImpl.h
@@ -14,7 +14,7 @@
 
 namespace c10_npu {
 namespace impl {
-struct NPUGuardImpl final : public c10_backend::impl::PrivateUse1GuardImpl {
+struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
   NPUGuardImpl() = default;
 
   explicit NPUGuardImpl(c10::DeviceType t) {

--- a/csrc/npu/NPUHooks.cpp
+++ b/csrc/npu/NPUHooks.cpp
@@ -1,25 +1,25 @@
 #include "csrc/npu/NPUHooks.h"
+#include "csrc/core/Register.h"
 #include "csrc/npu/NPUCachingHostAllocator.h"
 #include "csrc/npu/NPUFunctions.h"
 #include "csrc/npu/NPUStorageImpl.h"
 #include "npu/aten/common/ResizeNpu.h"
 #include "npu/framework/FormatHelper.h"
-#include "csrc/core/Register.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
 TORCH_DECLARE_REGISTRY(PrivateUse1HooksRegistry, NPUHooks, NPUHooksArgs);
 
-AT_REGISTER_PRIVATEUSE1_HOOKS_INTERFACE(c10_npu::get_npu_hooks());
+AT_REGISTER_PRIVATEUSE1_HOOKS_INTERFACE(c10::npu::get_npu_hooks());
 
 C10_DEFINE_REGISTRY(PrivateUse1HooksRegistry, NPUHooks, NPUHooksArgs)
 
 void NPUHooks::initPrivateUse1() const {
-  c10_npu::TryInitDevice();
+  c10::npu::TryInitDevice();
 }
 
 bool NPUHooks::hasPrimaryContext(c10::DeviceIndex device_index) const {
-  return c10_npu::hasPrimaryContext(device_index);
+  return c10::npu::hasPrimaryContext(device_index);
 }
 
 void NPUHooks::resizePrivateUse1Bytes(
@@ -51,4 +51,4 @@ at::PrivateUse1HooksInterface* get_npu_hooks() {
   c10::call_once(once, [] { npu_hooks = new NPUHooks(); });
   return npu_hooks;
 }
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUHooks.h
+++ b/csrc/npu/NPUHooks.h
@@ -3,9 +3,9 @@
 #include <c10/core/Storage.h>
 #include "csrc/npu/NPUGeneratorImpl.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
-struct TORCH_API NPUHooks: public at::PrivateUse1HooksInterface {
+struct TORCH_API NPUHooks : public at::PrivateUse1HooksInterface {
   virtual ~NPUHooks() = default;
   const at::Generator& getDefaultGenerator(
       c10::DeviceIndex device_index) override {
@@ -25,4 +25,4 @@ struct TORCH_API NPUHooksArgs : public at::PrivateUse1HooksArgs {};
 
 // register to PrivateUse1HooksInterface
 at::PrivateUse1HooksInterface* get_npu_hooks();
-} // namespace c10_npu
+} // namespace c10::npu

--- a/csrc/npu/NPUStream.h
+++ b/csrc/npu/NPUStream.h
@@ -2,13 +2,12 @@
 
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/Stream.h>
-#include <c10/util/SmallVector.h>
 #include <c10/core/impl/GPUTrace.h>
+#include <c10/util/SmallVector.h>
 #include <cstdint>
 #include <mutex>
 
 #include "csrc/aten/generated/NPUNativeFunctions.h"
-#include "csrc/core/Macros.h"
 #include "csrc/core/Macros.h"
 #include "npu/acl/include/acl/acl.h"
 #include "npu/acl/include/acl/acl_op.h"
@@ -57,7 +56,7 @@
  * a kernel on the same stream from two different threads.
  */
 
-namespace c10_npu {
+namespace c10::npu {
 
 static constexpr int max_compile_time_stream_priorities = 2;
 
@@ -72,7 +71,8 @@ class C10_BACKEND_API NPUStream {
   /// Construct a NPUStream from a Stream.  This construction is checked,
   /// and will raise an error if the Stream is not, in fact, a NPU stream.
   explicit NPUStream(c10::Stream stream) : stream_(stream) {
-    TORCH_CHECK(stream_.device_type() == c10::DeviceType::PrivateUse1,
+    TORCH_CHECK(
+        stream_.device_type() == c10::DeviceType::PrivateUse1,
         PTA_ERROR(ErrCode::TYPE));
   }
 
@@ -180,10 +180,12 @@ class C10_BACKEND_API NPUStream {
  * isHighPriority to true, or a stream for a specific device by setting device
  * (defaulting to the current NPU stream.)
  */
-C10_BACKEND_API NPUStream getStreamFromPool(const bool isHighPriority = false, c10::DeviceIndex device = -1);
+C10_BACKEND_API NPUStream getStreamFromPool(
+    const bool isHighPriority = false,
+    c10::DeviceIndex device = -1);
 
-C10_BACKEND_API NPUStream getStreamFromPool(const int priority, c10::DeviceIndex device = -1);
-
+C10_BACKEND_API NPUStream
+getStreamFromPool(const int priority, c10::DeviceIndex device = -1);
 
 /**
  * Get a NPUStream from a externally allocated one.
@@ -192,7 +194,8 @@ C10_BACKEND_API NPUStream getStreamFromPool(const int priority, c10::DeviceIndex
  * want to operate on a non-torch allocated stream for data exchange or similar
  * purposes
  */
-C10_BACKEND_API NPUStream getStreamFromExternal(aclrtStream ext_stream, c10::DeviceIndex device_index);
+C10_BACKEND_API NPUStream
+getStreamFromExternal(aclrtStream ext_stream, c10::DeviceIndex device_index);
 
 /**
  * Get the default NPU stream, for the passed NPU device, or for the
@@ -200,7 +203,8 @@ C10_BACKEND_API NPUStream getStreamFromExternal(aclrtStream ext_stream, c10::Dev
  * where most computation occurs when you aren't explicitly using
  * streams.
  */
-C10_BACKEND_API NPUStream getDefaultNPUStream(c10::DeviceIndex device_index = -1);
+C10_BACKEND_API NPUStream
+getDefaultNPUStream(c10::DeviceIndex device_index = -1);
 
 /**
  * Get the current NPU stream, for the passed NPU device, or for the
@@ -209,8 +213,8 @@ C10_BACKEND_API NPUStream getDefaultNPUStream(c10::DeviceIndex device_index = -1
  * be different if someone called 'setCurrentNPUStream' or used 'StreamGuard'
  * or 'NPUStreamGuard'.
  */
-C10_BACKEND_API NPUStream getCurrentNPUStream(c10::DeviceIndex device_index = -1);
-
+C10_BACKEND_API NPUStream
+getCurrentNPUStream(c10::DeviceIndex device_index = -1);
 
 /**
  * Set the current stream on the device of the passed in stream to be
@@ -227,12 +231,12 @@ C10_BACKEND_API void setCurrentNPUStream(NPUStream stream);
 std::ostream& operator<<(std::ostream& stream, const NPUStream& s);
 
 aclError DestroyUsedStreams();
-} // namespace c10_npu
+} // namespace c10::npu
 
 namespace std {
 template <>
-struct hash<c10_npu::NPUStream> {
-  size_t operator()(c10_npu::NPUStream s) const noexcept {
+struct hash<c10::npu::NPUStream> {
+  size_t operator()(c10::npu::NPUStream s) const noexcept {
     return std::hash<c10::Stream>{}(s.unwrap());
   }
 };

--- a/npu/aten/common/CopyKernelNpu.cpp
+++ b/npu/aten/common/CopyKernelNpu.cpp
@@ -1,15 +1,15 @@
 #include <ATen/record_function.h>
 #include <c10/core/Scalar.h>
 
-#include "npu/aten/common/InnerNpuNativeFunction.h"
-#include "npu/core/NPUBridge.h"
 #include "csrc/npu/NPUStorageImpl.h"
 #include "csrc/npu/NPUStream.h"
+#include "npu/aten/OpInterface.h"
+#include "npu/aten/common/InnerNpuNativeFunction.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
 #include "npu/framework/StorageDescHelper.h"
 #include "npu/framework/utils/CalcuOpUtil.h"
 #include "npu/framework/utils/OpAdapter.h"
-#include "npu/aten/OpInterface.h"
 
 namespace at_npu {
 namespace native {
@@ -46,7 +46,7 @@ void copy_d2d_by_memcpy(
   }
 
   // The current logic is only used in single op mode.
-  aclError error = c10_npu::queue::LaunchAsyncCopyTask(
+  aclError error = c10::npu::queue::LaunchAsyncCopyTask(
       dst.data_ptr(),
       size * dst.element_size(),
       src.data_ptr(),

--- a/npu/aten/common/CopyMemoryKernel.cpp
+++ b/npu/aten/common/CopyMemoryKernel.cpp
@@ -1,13 +1,13 @@
 #include <ATen/ATen.h>
 
 #include "csrc/aten/generated/NPUNativeFunctions.h"
+#include "csrc/npu/NPUStream.h"
+#include "npu/acl/include/acl/acl.h"
 #include "npu/core/NPUBridge.h"
 #include "npu/core/NPUException.h"
-#include "csrc/npu/NPUStream.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/utils/CalcuOpUtil.h"
-#include "npu/acl/include/acl/acl.h"
 
 namespace at_npu {
 namespace native {
@@ -67,7 +67,7 @@ at::Tensor& NPUNativeFunctions::copy_memory_(
   NPU_CHECK_ERROR(ret);
 
   if (!non_blocking) {
-    c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
+    c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(stream, -1));
   }
   return self;

--- a/npu/aten/common/LocalScalarDenseNpu.cpp
+++ b/npu/aten/common/LocalScalarDenseNpu.cpp
@@ -3,9 +3,9 @@
 
 #include "csrc/aten/generated/NPUNativeFunctions.h"
 #include "csrc/npu/NPUStream.h"
-#include "npu/framework/utils/CalcuOpUtil.h"
 #include "npu/acl/include/acl/acl_base.h"
 #include "npu/acl/include/acl/acl_rt.h"
+#include "npu/framework/utils/CalcuOpUtil.h"
 
 namespace at_npu {
 namespace native {
@@ -20,7 +20,7 @@ c10::Scalar NPUNativeFunctions::_local_scalar_dense(const at::Tensor& self) {
       "_local_scalar_dense_npu",
       [&] {
         scalar_t value = 0;
-        c10_npu::NPUStream copy_stream = c10_npu::getCurrentNPUStream();
+        c10::npu::NPUStream copy_stream = c10::npu::getCurrentNPUStream();
         // Synchronous copy after stream synchronization
         aclError error = aclrtSynchronizeStreamWithTimeout(copy_stream, -1);
         if (error != ACL_ERROR_NONE) {

--- a/npu/aten/common/SetNpu.cpp
+++ b/npu/aten/common/SetNpu.cpp
@@ -65,8 +65,8 @@ at::Tensor& NPUNativeFunctions::set_(at::Tensor& self) {
       c10::make_intrusive<torch_npu::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
           0,
-          c10_npu::NPUCachingAllocator::get()->allocate(0),
-          c10_npu::NPUCachingAllocator::get(),
+          c10::npu::NPUCachingAllocator::get()->allocate(0),
+          c10::npu::NPUCachingAllocator::get(),
           true);
   c10::Storage storage(npu_storage_impl);
   set_storage_nd_npu(self, storage, 0, 1, {0}, {});

--- a/npu/aten/common/TensorFactories.cpp
+++ b/npu/aten/common/TensorFactories.cpp
@@ -16,13 +16,13 @@
 #include <c10/util/irange.h>
 
 #include "csrc/aten/generated/NPUNativeFunctions.h"
+#include "csrc/npu/NPUCachingAllocator.h"
+#include "csrc/npu/NPUStorageImpl.h"
+#include "csrc/npu/NPUTensorImpl.h"
 #include "npu/aten/common/FormatCastHelper.h"
 #include "npu/aten/common/InnerNpuNativeFunction.h"
 #include "npu/aten/common/ResizeNpu.h"
 #include "npu/core/NPUBridge.h"
-#include "csrc/npu/NPUStorageImpl.h"
-#include "csrc/npu/NPUTensorImpl.h"
-#include "csrc/npu/NPUCachingAllocator.h"
 #include "npu/core/NPUException.h"
 #include "npu/framework/InferFormat.h"
 #include "npu/framework/StorageDescHelper.h"
@@ -121,7 +121,7 @@ at::Tensor NPUNativeFunctions::empty(
       OPS_ERROR(ErrCode::NOT_SUPPORT));
   check_size_nonnegative(size);
   c10::DeviceGuard guard_(device_);
-  c10::Allocator* allocator = c10_npu::NPUCachingAllocator::get();
+  c10::Allocator* allocator = c10::npu::NPUCachingAllocator::get();
   int64_t nelements = c10::multiply_integers(size);
   auto dtype = c10::scalarTypeToTypeMeta(dtype_or_default(dtype_opt));
   int64_t size_bytes = nelements * dtype.itemsize();
@@ -312,7 +312,7 @@ at::Tensor NPUNativeFunctions::empty_with_format(
       OPS_ERROR(ErrCode::NOT_SUPPORT));
   check_size_nonnegative(size);
   c10::DeviceGuard guard_(device_);
-  c10::Allocator* allocator = c10_npu::NPUCachingAllocator::get();
+  c10::Allocator* allocator = c10::npu::NPUCachingAllocator::get();
   // when the shape and format are not match, fix format here.
   aclFormat format =
       InferFormat::GuessStorageFormat(size, (aclFormat)dst_format);

--- a/npu/aten/common/from_blob.cpp
+++ b/npu/aten/common/from_blob.cpp
@@ -1,10 +1,10 @@
+#include "npu/aten/common/from_blob.h"
 #include <ATen/Utils.h>
 #include <c10/core/Allocator.h>
-#include "csrc/npu/NPUStorageImpl.h"
 #include "csrc/npu/NPUCachingAllocator.h"
 #include "csrc/npu/NPUFunctions.h"
+#include "csrc/npu/NPUStorageImpl.h"
 #include "npu/aten/common/TensorFactories.h"
-#include "npu/aten/common/from_blob.h"
 #include "npu/core/NPUException.h"
 #include "npu/framework/StorageDescHelper.h"
 #include "npu/framework/utils/OpAdapter.h"
@@ -16,7 +16,7 @@ namespace native {
 at::Tensor TensorMaker::make_tensor() {
   if (device_ == c10::nullopt) {
     device_ =
-        c10::Device(at::DeviceType::PrivateUse1, c10_npu::current_device());
+        c10::Device(at::DeviceType::PrivateUse1, c10::npu::current_device());
   }
 
   if (opts_.device().has_index()) {
@@ -36,7 +36,7 @@ at::Tensor TensorMaker::make_tensor() {
       dtype_or_default(c10::optTypeMetaToScalarType(opts_.dtype_opt())));
   at_npu::native::check_size_nonnegative(sizes_);
   c10::DeviceGuard guard(*device_);
-  c10::Allocator* allocator = c10_npu::NPUCachingAllocator::get();
+  c10::Allocator* allocator = c10::npu::NPUCachingAllocator::get();
 
   std::size_t size_bytes = computeStorageSize();
 

--- a/npu/aten/ops/StreamAndEventKernelNpu.cpp
+++ b/npu/aten/ops/StreamAndEventKernelNpu.cpp
@@ -6,9 +6,9 @@ namespace native {
 
 void NPUNativeFunctions::record_stream(at::Tensor& self, c10::Stream stream) {
   struct c10::StreamData3 data = stream.pack3();
-  c10_npu::NPUCachingAllocator::recordStream(
+  c10::npu::NPUCachingAllocator::recordStream(
       self.storage().data_ptr(),
-      c10_npu::NPUStream::unpack3(
+      c10::npu::NPUStream::unpack3(
           data.stream_id, data.device_index, data.device_type));
 }
 

--- a/npu/aten/ops/base/aclops/AddKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/AddKernelNpu.cpp
@@ -23,228 +23,285 @@ using npu_preparation = at_npu::native::OpPreparation;
 using npu_utils = at_npu::native::NpuUtils;
 
 namespace {
-inline void alpha_check_npu(const at::ScalarType dtype, at::Scalar alpha)
-{
-    TORCH_CHECK(!alpha.isBoolean() || dtype == at::kBool, "Boolean alpha only supported for Boolean results."
-        + OPS_ERROR(ErrCode::TYPE));
-    TORCH_CHECK(isFloatingType(dtype) || alpha.isIntegral(true),
-        "For integral input tensors, argument alpha must not be a floating point number."
-        + OPS_ERROR(ErrCode::TYPE));
+inline void alpha_check_npu(const at::ScalarType dtype, at::Scalar alpha) {
+  TORCH_CHECK(
+      !alpha.isBoolean() || dtype == at::kBool,
+      "Boolean alpha only supported for Boolean results." +
+          OPS_ERROR(ErrCode::TYPE));
+  TORCH_CHECK(
+      isFloatingType(dtype) || alpha.isIntegral(true),
+      "For integral input tensors, argument alpha must not be a floating point number." +
+          OPS_ERROR(ErrCode::TYPE));
 }
 
-at::Tensor add_dest_output(const at::Tensor &self, const at::Tensor &other)
-{
-    bool is_self_wrapped = npu_preparation::is_scalar_wrapped_to_tensor(self);
-    return is_self_wrapped ? other : self;
+at::Tensor add_dest_output(const at::Tensor& self, const at::Tensor& other) {
+  bool is_self_wrapped = npu_preparation::is_scalar_wrapped_to_tensor(self);
+  return is_self_wrapped ? other : self;
 }
 
-at::Tensor &adds_out_npu_nocheck(at::Tensor &result, const at::Tensor &self, const at::Scalar other,
-                                 const at::Scalar alpha)
-{
+at::Tensor& adds_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Scalar other,
+    const at::Scalar alpha) {
+  alpha_check_npu(self.scalar_type(), alpha);
+  float other_value = op_plugin::utils::get_scalar_float_value(other);
+  float alpha_value = op_plugin::utils::get_scalar_float_value(alpha);
+  float value = other_value * alpha_value;
+  at_npu::native::OpCommand cmd;
+  std::string real_type = "";
+  if (self.scalar_type() == at::kBool) {
+    auto unified_result =
+        npu_preparation::binary_op_check(result, self, other, true);
+    if (unified_result.common_type == at::kBool) {
+      unified_result.common_type = at::kByte;
+      unified_result.result_type_defined = true;
+      real_type = "uint8";
+    }
+    cmd.Expect(unified_result);
+  }
+  cmd.Name("Add")
+      .Input(self)
+      .Input(at::Scalar(value), self.scalar_type())
+      .Output(result, "", c10::nullopt, real_type)
+      .Run();
+
+  return result;
+}
+
+at::Tensor& add_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Tensor& other,
+    at::Scalar alpha) {
+  auto unified_result =
+      npu_preparation::binary_op_check(result, self, other, true);
+  if (npu_preparation::IsCPUScalar(other)) {
+    adds_out_npu_nocheck(result, self, other.item(), alpha);
+  } else if (npu_preparation::IsCPUScalar(self)) {
+    adds_out_npu_nocheck(result, other, self.item(), alpha);
+  } else {
     alpha_check_npu(self.scalar_type(), alpha);
-    float other_value = op_plugin::utils::get_scalar_float_value(other);
-    float alpha_value = op_plugin::utils::get_scalar_float_value(alpha);
-    float value = other_value * alpha_value;
     at_npu::native::OpCommand cmd;
-    std::string real_type = "";
-    if (self.scalar_type() == at::kBool) {
-        auto unified_result = npu_preparation::binary_op_check(result, self, other, true);
-        if (unified_result.common_type == at::kBool) {
-            unified_result.common_type = at::kByte;
-            unified_result.result_type_defined = true;
-            real_type = "uint8";
-        }
+    cmd.Expect(unified_result);
+
+    if (op_plugin::utils::is_scalar_one(alpha)) {
+      if (self.scalar_type() == at::kLong) {
+        TORCH_NPU_WARN_ONCE(
+            "The oprator of add is executed, Currently High Accuracy but Low Performance OP with 64-bit has "
+            "been used, Please Do Some Cast at Python Functions with 32-bit for Better Performance!");
+      }
+
+      std::string real_type = "";
+      if (self.scalar_type() == at::kBool && other.scalar_type() == at::kBool) {
+        unified_result.common_type = at::kByte;
+        unified_result.result_type_defined = true;
         cmd.Expect(unified_result);
-    }
-    cmd.Name("Add")
-        .Input(self)
-        .Input(at::Scalar(value), self.scalar_type())
-        .Output(result, "", c10::nullopt, real_type)
-        .Run();
-
-    return result;
-}
-
-at::Tensor &add_out_npu_nocheck(at::Tensor &result, const at::Tensor &self, const at::Tensor &other, at::Scalar alpha)
-{
-    auto unified_result = npu_preparation::binary_op_check(result, self, other, true);
-    if (npu_preparation::IsCPUScalar(other)) {
-        adds_out_npu_nocheck(result, self, other.item(), alpha);
-    } else if (npu_preparation::IsCPUScalar(self)) {
-        adds_out_npu_nocheck(result, other, self.item(), alpha);
+        real_type = "uint8";
+      }
+      cmd.Name("Add")
+          .Input(self)
+          .Input(other)
+          .Output(result, "", c10::nullopt, real_type)
+          .Run();
     } else {
-        alpha_check_npu(self.scalar_type(), alpha);
-        at_npu::native::OpCommand cmd;
-        cmd.Expect(unified_result);
-
-        if (op_plugin::utils::is_scalar_one(alpha)) {
-            if (self.scalar_type() == at::kLong) {
-                TORCH_NPU_WARN_ONCE(
-                    "The oprator of add is executed, Currently High Accuracy but Low Performance OP with 64-bit has "
-                    "been used, Please Do Some Cast at Python Functions with 32-bit for Better Performance!");
-            }
-
-            std::string real_type = "";
-            if (self.scalar_type() == at::kBool && other.scalar_type() == at::kBool) {
-                unified_result.common_type = at::kByte;
-                unified_result.result_type_defined = true;
-                cmd.Expect(unified_result);
-                real_type = "uint8";
-            }
-            cmd.Name("Add").Input(self).Input(other).Output(result, "", c10::nullopt, real_type).Run();
-        } else {
-            cmd.Name("AxpyV2").Input(self).Input(other).Input(alpha, self.scalar_type()).Output(result).Run();
-        }
+      cmd.Name("AxpyV2")
+          .Input(self)
+          .Input(other)
+          .Input(alpha, self.scalar_type())
+          .Output(result)
+          .Run();
     }
-    return result;
+  }
+  return result;
 }
 
-bool check_size(const at::Tensor &self, const at::Tensor &other)
-{
-    if (self.dim() != other.dim()) {
-        return false;
+bool check_size(const at::Tensor& self, const at::Tensor& other) {
+  if (self.dim() != other.dim()) {
+    return false;
+  }
+  for (size_t i = 0; i < static_cast<uint64_t>(self.dim()); i++) {
+    if (self.size(i) != other.size(i)) {
+      return false;
     }
-    for (size_t i = 0; i < static_cast<uint64_t>(self.dim()); i++) {
-        if (self.size(i) != other.size(i)) {
-            return false;
-        }
-    }
-    return true;
+  }
+  return true;
 }
 
-at::Tensor stride_add_tensor_get(const at::Tensor &src)
-{
-    if (src.is_contiguous()) {
-        return src;
-    } else {
-        auto src_desc = torch_npu::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
-        at::Tensor src_new =
-            npu_preparation::apply_tensor_with_format(src_desc.base_sizes_, src.options(), ACL_FORMAT_NC1HWC0);
-        src_new.set_(src.storage(), src_new.storage_offset(), src_new.sizes(), src_new.strides());
-        return src_new;
-    }
+at::Tensor stride_add_tensor_get(const at::Tensor& src) {
+  if (src.is_contiguous()) {
+    return src;
+  } else {
+    auto src_desc = torch_npu::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+    at::Tensor src_new = npu_preparation::apply_tensor_with_format(
+        src_desc.base_sizes_, src.options(), ACL_FORMAT_NC1HWC0);
+    src_new.set_(
+        src.storage(),
+        src_new.storage_offset(),
+        src_new.sizes(),
+        src_new.strides());
+    return src_new;
+  }
 }
 } // namespace
 
-at::Tensor add(const at::Tensor &self, const at::Tensor &other, const at::Scalar &alpha)
-{
-    alpha_check_npu(self.scalar_type(), alpha);
-    if ((!(self.is_contiguous() && other.is_contiguous())) &&
-        (npu_utils::check_5d_5d_match(self) || npu_utils::check_5d_5d_match(other)) && check_size(self, other)) {
-        int64_t c0_len = 16;
-        at::Tensor self_use = stride_add_tensor_get(self);
-        TORCH_CHECK(self.numel() > 0, "self must be non-empty tensor" + OPS_ERROR(ErrCode::PARAM));
-        TORCH_CHECK(other.numel() > 0, "other must be non-empty tensor" + OPS_ERROR(ErrCode::PARAM));
-        at::Scalar self_c1_offset(self.storage_offset() / (self.size(2) * self.size(3) * c0_len));
-        at::Tensor other_use = stride_add_tensor_get(other);
-        at::Scalar other_c1_offset(other.storage_offset() / (other.size(2) * other.size(3) * c0_len));
-        at::Scalar stride_len(self.size(1) / c0_len);
-        at::Tensor result = acl_op::npu_stride_add(self_use, other_use, self_c1_offset, other_c1_offset, stride_len);
-        return result;
-    }
-    at::Tensor output_tensor = add_dest_output(self, other);
-    auto output_size = op_infer::broadcast_ops_npu_output_size(self, other);
-    at::ScalarType result_type = at::native::result_type(self, other);
-    at::Tensor self_cp = (self.scalar_type() != result_type && !npu_preparation::is_scalar_wrapped_to_tensor(self)) ?
-                             at_npu::native::custom_ops::npu_dtype_cast(self, result_type) :
-                             self;
-    at::Tensor other_cp = (other.scalar_type() != result_type && !npu_preparation::is_scalar_wrapped_to_tensor(other)) ?
-                              at_npu::native::custom_ops::npu_dtype_cast(other, result_type) :
-                              other;
+at::Tensor add(
+    const at::Tensor& self,
+    const at::Tensor& other,
+    const at::Scalar& alpha) {
+  alpha_check_npu(self.scalar_type(), alpha);
+  if ((!(self.is_contiguous() && other.is_contiguous())) &&
+      (npu_utils::check_5d_5d_match(self) ||
+       npu_utils::check_5d_5d_match(other)) &&
+      check_size(self, other)) {
+    int64_t c0_len = 16;
+    at::Tensor self_use = stride_add_tensor_get(self);
+    TORCH_CHECK(
+        self.numel() > 0,
+        "self must be non-empty tensor" + OPS_ERROR(ErrCode::PARAM));
+    TORCH_CHECK(
+        other.numel() > 0,
+        "other must be non-empty tensor" + OPS_ERROR(ErrCode::PARAM));
+    at::Scalar self_c1_offset(
+        self.storage_offset() / (self.size(2) * self.size(3) * c0_len));
+    at::Tensor other_use = stride_add_tensor_get(other);
+    at::Scalar other_c1_offset(
+        other.storage_offset() / (other.size(2) * other.size(3) * c0_len));
+    at::Scalar stride_len(self.size(1) / c0_len);
+    at::Tensor result = acl_op::npu_stride_add(
+        self_use, other_use, self_c1_offset, other_c1_offset, stride_len);
+    return result;
+  }
+  at::Tensor output_tensor = add_dest_output(self, other);
+  auto output_size = op_infer::broadcast_ops_npu_output_size(self, other);
+  at::ScalarType result_type = at::native::result_type(self, other);
+  at::Tensor self_cp = (self.scalar_type() != result_type &&
+                        !npu_preparation::is_scalar_wrapped_to_tensor(self))
+      ? at_npu::native::custom_ops::npu_dtype_cast(self, result_type)
+      : self;
+  at::Tensor other_cp = (other.scalar_type() != result_type &&
+                         !npu_preparation::is_scalar_wrapped_to_tensor(other))
+      ? at_npu::native::custom_ops::npu_dtype_cast(other, result_type)
+      : other;
 
-    at::Tensor result = npu_preparation::apply_tensor_with_format(
-        output_size, output_tensor.options().dtype(result_type), npu_preparation::get_tensor_npu_format(output_tensor));
+  at::Tensor result = npu_preparation::apply_tensor_with_format(
+      output_size,
+      output_tensor.options().dtype(result_type),
+      npu_preparation::get_tensor_npu_format(output_tensor));
+  add_out_npu_nocheck(result, self_cp, other_cp, alpha);
+  return result;
+}
+
+at::Tensor add(
+    const at::Tensor& self,
+    const at::Scalar& other,
+    const at::Scalar& alpha) {
+  alpha_check_npu(self.scalar_type(), alpha);
+  at::Tensor result = npu_preparation::apply_tensor(self);
+  adds_out_npu_nocheck(result, self, other, alpha);
+  return result;
+}
+
+at::Tensor& add_(
+    at::Tensor& self,
+    const at::Tensor& other,
+    const at::Scalar& alpha) {
+  at::ScalarType result_type = at::native::result_type(self, other);
+  at::ScalarType self_type = self.scalar_type();
+  TORCH_CHECK(
+      canCast(result_type, self_type),
+      "result type ",
+      result_type,
+      " can't be cast to the desired output type ",
+      self_type,
+      OPS_ERROR(ErrCode::TYPE));
+  at::Tensor self_cp = (self_type != result_type &&
+                        !npu_preparation::is_scalar_wrapped_to_tensor(self))
+      ? at_npu::native::custom_ops::npu_dtype_cast(self, result_type)
+      : self;
+  at::Tensor other_cp = (other.scalar_type() != result_type &&
+                         !npu_preparation::is_scalar_wrapped_to_tensor(other))
+      ? at_npu::native::custom_ops::npu_dtype_cast(other, result_type)
+      : other;
+
+  npu_preparation::CheckMemory({self_cp, other_cp}, {self_cp});
+  if (!npu_utils::check_match(&self_cp)) {
+    at::Tensor contiguous_self;
+    if (c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+      contiguous_self = npu_utils::format_contiguous_add_copy_optimize(self_cp);
+    } else {
+      contiguous_self = npu_utils::format_contiguous(self_cp);
+    }
+    add_out_npu_nocheck(contiguous_self, contiguous_self, other_cp, alpha);
+    npu_utils::format_fresh_view(self_cp, contiguous_self);
+  } else {
+    add_out_npu_nocheck(self_cp, self_cp, other_cp, alpha);
+  }
+
+  if (self_type == result_type) {
+    self = self_cp;
+  } else {
+    self.copy_(self_cp);
+  }
+  return self;
+}
+
+at::Tensor& add_(
+    at::Tensor& self,
+    const at::Scalar& other,
+    const at::Scalar& alpha) {
+  if (!npu_utils::check_match(&self)) {
+    at::Tensor contiguous_self;
+    if (c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+      contiguous_self = npu_utils::format_contiguous_add_copy_optimize(self);
+    } else {
+      contiguous_self = npu_utils::format_contiguous(self);
+    }
+    adds_out_npu_nocheck(contiguous_self, contiguous_self, other, alpha);
+    npu_utils::format_fresh_view(self, contiguous_self);
+  } else {
+    adds_out_npu_nocheck(self, self, other, alpha);
+  }
+  return self;
+}
+
+at::Tensor& add_out(
+    const at::Tensor& self,
+    const at::Tensor& other,
+    const at::Scalar& alpha,
+    at::Tensor& result) {
+  at::Tensor output_tensor = add_dest_output(self, other);
+  auto output_size = op_infer::broadcast_ops_npu_output_size(self, other);
+  at::ScalarType result_type = at::native::result_type(self, other);
+  at::Tensor self_cp = (self.scalar_type() != result_type &&
+                        !npu_preparation::is_scalar_wrapped_to_tensor(self))
+      ? at_npu::native::custom_ops::npu_dtype_cast(self, result_type)
+      : self;
+  at::Tensor other_cp = (other.scalar_type() != result_type &&
+                         !npu_preparation::is_scalar_wrapped_to_tensor(other))
+      ? at_npu::native::custom_ops::npu_dtype_cast(other, result_type)
+      : other;
+
+  npu_preparation::CheckOut(
+      {self_cp, other_cp},
+      result,
+      npu_preparation::get_tensor_npu_format(result),
+      result_type,
+      output_size);
+
+  if (!npu_utils::check_match(&result)) {
+    at::Tensor contiguous_result;
+    if (c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+      contiguous_result =
+          npu_utils::format_contiguous_add_copy_optimize(result);
+    } else {
+      contiguous_result = npu_utils::format_contiguous(result);
+    }
+    add_out_npu_nocheck(contiguous_result, self_cp, other_cp, alpha);
+    npu_utils::format_fresh_view(result, contiguous_result);
+  } else {
     add_out_npu_nocheck(result, self_cp, other_cp, alpha);
-    return result;
-}
-
-at::Tensor add(const at::Tensor &self, const at::Scalar &other, const at::Scalar &alpha)
-{
-    alpha_check_npu(self.scalar_type(), alpha);
-    at::Tensor result = npu_preparation::apply_tensor(self);
-    adds_out_npu_nocheck(result, self, other, alpha);
-    return result;
-}
-
-at::Tensor &add_(at::Tensor &self, const at::Tensor &other, const at::Scalar &alpha)
-{
-    at::ScalarType result_type = at::native::result_type(self, other);
-    at::ScalarType self_type = self.scalar_type();
-    TORCH_CHECK(canCast(result_type, self_type), "result type ", result_type,
-        " can't be cast to the desired output type ", self_type, OPS_ERROR(ErrCode::TYPE));
-    at::Tensor self_cp = (self_type != result_type && !npu_preparation::is_scalar_wrapped_to_tensor(self)) ?
-                             at_npu::native::custom_ops::npu_dtype_cast(self, result_type) :
-                             self;
-    at::Tensor other_cp = (other.scalar_type() != result_type && !npu_preparation::is_scalar_wrapped_to_tensor(other)) ?
-                              at_npu::native::custom_ops::npu_dtype_cast(other, result_type) :
-                              other;
-
-    npu_preparation::CheckMemory({self_cp, other_cp}, {self_cp});
-    if (!npu_utils::check_match(&self_cp)) {
-        at::Tensor contiguous_self;
-        if (c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-            contiguous_self = npu_utils::format_contiguous_add_copy_optimize(self_cp);
-        } else {
-            contiguous_self = npu_utils::format_contiguous(self_cp);
-        }
-        add_out_npu_nocheck(contiguous_self, contiguous_self, other_cp, alpha);
-        npu_utils::format_fresh_view(self_cp, contiguous_self);
-    } else {
-        add_out_npu_nocheck(self_cp, self_cp, other_cp, alpha);
-    }
-
-    if (self_type == result_type) {
-        self = self_cp;
-    } else {
-        self.copy_(self_cp);
-    }
-    return self;
-}
-
-at::Tensor &add_(at::Tensor &self, const at::Scalar &other, const at::Scalar &alpha)
-{
-    if (!npu_utils::check_match(&self)) {
-        at::Tensor contiguous_self;
-        if (c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-            contiguous_self = npu_utils::format_contiguous_add_copy_optimize(self);
-        } else {
-            contiguous_self = npu_utils::format_contiguous(self);
-        }
-        adds_out_npu_nocheck(contiguous_self, contiguous_self, other, alpha);
-        npu_utils::format_fresh_view(self, contiguous_self);
-    } else {
-        adds_out_npu_nocheck(self, self, other, alpha);
-    }
-    return self;
-}
-
-at::Tensor &add_out(const at::Tensor &self, const at::Tensor &other, const at::Scalar &alpha, at::Tensor &result)
-{
-    at::Tensor output_tensor = add_dest_output(self, other);
-    auto output_size = op_infer::broadcast_ops_npu_output_size(self, other);
-    at::ScalarType result_type = at::native::result_type(self, other);
-    at::Tensor self_cp = (self.scalar_type() != result_type && !npu_preparation::is_scalar_wrapped_to_tensor(self)) ?
-                             at_npu::native::custom_ops::npu_dtype_cast(self, result_type) :
-                             self;
-    at::Tensor other_cp = (other.scalar_type() != result_type && !npu_preparation::is_scalar_wrapped_to_tensor(other)) ?
-                              at_npu::native::custom_ops::npu_dtype_cast(other, result_type) :
-                              other;
-
-    npu_preparation::CheckOut({self_cp, other_cp}, result, npu_preparation::get_tensor_npu_format(result), result_type,
-                              output_size);
-
-    if (!npu_utils::check_match(&result)) {
-        at::Tensor contiguous_result;
-        if (c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-            contiguous_result = npu_utils::format_contiguous_add_copy_optimize(result);
-        } else {
-            contiguous_result = npu_utils::format_contiguous(result);
-        }
-        add_out_npu_nocheck(contiguous_result, self_cp, other_cp, alpha);
-        npu_utils::format_fresh_view(result, contiguous_result);
-    } else {
-        add_out_npu_nocheck(result, self_cp, other_cp, alpha);
-    }
-    return result;
+  }
+  return result;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/AddbmmKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/AddbmmKernelNpu.cpp
@@ -22,25 +22,30 @@ namespace acl_op {
 using npu_preparation = at_npu::native::OpPreparation;
 using npu_utils = at_npu::native::NpuUtils;
 
+at::Tensor& addbmm_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Tensor& batch1,
+    const at::Tensor& batch2) {
+  bool is_batch1_t = op_plugin::utils::is_transpose_last_two_dims(batch1);
+  bool is_batch2_t = op_plugin::utils::is_transpose_last_two_dims(batch2);
+  at::Tensor contiguous_batch1 = is_batch1_t
+      ? batch1
+      : npu_utils::format_contiguous_add_copy_optimize(batch1);
+  at::Tensor contiguous_batch2 = is_batch2_t
+      ? batch2
+      : npu_utils::format_contiguous_add_copy_optimize(batch2);
 
-at::Tensor &addbmm_out_npu_nocheck(at::Tensor &result, const at::Tensor &self, const at::Tensor &batch1,
-                                   const at::Tensor &batch2)
-{
-    bool is_batch1_t = op_plugin::utils::is_transpose_last_two_dims(batch1);
-    bool is_batch2_t = op_plugin::utils::is_transpose_last_two_dims(batch2);
-    at::Tensor contiguous_batch1 = is_batch1_t ? batch1 : npu_utils::format_contiguous_add_copy_optimize(batch1);
-    at::Tensor contiguous_batch2 = is_batch2_t ? batch2 : npu_utils::format_contiguous_add_copy_optimize(batch2);
-
-    at_npu::native::OpCommand cmd;
-    cmd.Name("BatchMatMul")
-        .InputWithoutContiguous(contiguous_batch1)
-        .InputWithoutContiguous(contiguous_batch2)
-        .Input(self)
-        .Output(result)
-        .Attr("adj_x1", is_batch1_t)
-        .Attr("adj_x2", is_batch2_t)
-        .Run();
-    return result;
+  at_npu::native::OpCommand cmd;
+  cmd.Name("BatchMatMul")
+      .InputWithoutContiguous(contiguous_batch1)
+      .InputWithoutContiguous(contiguous_batch2)
+      .Input(self)
+      .Output(result)
+      .Attr("adj_x1", is_batch1_t)
+      .Attr("adj_x2", is_batch2_t)
+      .Run();
+  return result;
 }
 
 at::Tensor& addbmm_out(
@@ -49,34 +54,43 @@ at::Tensor& addbmm_out(
     const at::Tensor& batch2,
     const at::Scalar& beta,
     const at::Scalar& alpha,
-    at::Tensor& result)
-{
-    TORCH_CHECK(batch1.dim() >= 2 && batch2.dim() >= 3,
-        "batch1 is expected to be at least 2D and batch2 is expected to be at least 3D, but got batch1: ",
-        batch1.dim(), "D, batch2: ", batch2.dim(), "D" + OPS_ERROR(ErrCode::PARAM));
-    static const bool is_support_nd_out = c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1;
-    bool check_bias_shape = ((self.dim() == 1 || (self.dim() == 2 && self.size(0) == 1)) && batch1.size(0) == 1);
-    std::vector<int64_t> dims = {batch1.size(1), batch2.size(2)};
-    if (check_bias_shape && is_support_nd_out) {
-        auto output_size = {batch1.size(0), batch1.size(1), batch2.size(2)};
-        at::Tensor biasbmm_result = npu_preparation::apply_tensor(self, output_size);
-        if ((std::abs(beta.toFloat() - 1.0f) <= std::numeric_limits<float>::epsilon()) &&
-            (std::abs(alpha.toFloat() - 1.0f) <= std::numeric_limits<float>::epsilon())) {
-            acl_op::addbmm_out_npu_nocheck(biasbmm_result, self, batch1, batch2);
-        } else {
-            at::Tensor mul_result = at::mul(batch1, alpha);
-            at::Tensor bias = at::mul(self, beta);
-            acl_op::addbmm_out_npu_nocheck(biasbmm_result, bias, mul_result, batch2);
-        }
-        result = at::sum_to(biasbmm_result, dims);
+    at::Tensor& result) {
+  TORCH_CHECK(
+      batch1.dim() >= 2 && batch2.dim() >= 3,
+      "batch1 is expected to be at least 2D and batch2 is expected to be at least 3D, but got batch1: ",
+      batch1.dim(),
+      "D, batch2: ",
+      batch2.dim(),
+      "D" + OPS_ERROR(ErrCode::PARAM));
+  static const bool is_support_nd_out =
+      c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1;
+  bool check_bias_shape =
+      ((self.dim() == 1 || (self.dim() == 2 && self.size(0) == 1)) &&
+       batch1.size(0) == 1);
+  std::vector<int64_t> dims = {batch1.size(1), batch2.size(2)};
+  if (check_bias_shape && is_support_nd_out) {
+    auto output_size = {batch1.size(0), batch1.size(1), batch2.size(2)};
+    at::Tensor biasbmm_result =
+        npu_preparation::apply_tensor(self, output_size);
+    if ((std::abs(beta.toFloat() - 1.0f) <=
+         std::numeric_limits<float>::epsilon()) &&
+        (std::abs(alpha.toFloat() - 1.0f) <=
+         std::numeric_limits<float>::epsilon())) {
+      acl_op::addbmm_out_npu_nocheck(biasbmm_result, self, batch1, batch2);
     } else {
-        at::Tensor mul_result = at::mul(batch1, alpha);
-        at::Tensor bmm_result = at::bmm(mul_result, batch2);
-        at::Tensor sum_result = at::sum_to(bmm_result, dims);
-        // sum_result + self*beta
-        at::add_out(result, sum_result, self, beta);
+      at::Tensor mul_result = at::mul(batch1, alpha);
+      at::Tensor bias = at::mul(self, beta);
+      acl_op::addbmm_out_npu_nocheck(biasbmm_result, bias, mul_result, batch2);
     }
-    return result;
+    result = at::sum_to(biasbmm_result, dims);
+  } else {
+    at::Tensor mul_result = at::mul(batch1, alpha);
+    at::Tensor bmm_result = at::bmm(mul_result, batch2);
+    at::Tensor sum_result = at::sum_to(bmm_result, dims);
+    // sum_result + self*beta
+    at::add_out(result, sum_result, self, beta);
+  }
+  return result;
 }
 
 at::Tensor addbmm(
@@ -84,12 +98,12 @@ at::Tensor addbmm(
     const at::Tensor& batch1,
     const at::Tensor& batch2,
     const at::Scalar& beta,
-    const at::Scalar& alpha)
-{
-    auto output_size = op_infer::addbmm_npu_output_size(self, batch1, batch2, beta, alpha);
-    at::Tensor result = npu_preparation::apply_tensor(self, output_size);
-    acl_op::addbmm_out(self, batch1, batch2, beta, alpha, result);
-    return result;
+    const at::Scalar& alpha) {
+  auto output_size =
+      op_infer::addbmm_npu_output_size(self, batch1, batch2, beta, alpha);
+  at::Tensor result = npu_preparation::apply_tensor(self, output_size);
+  acl_op::addbmm_out(self, batch1, batch2, beta, alpha, result);
+  return result;
 }
 
 at::Tensor& addbmm_(
@@ -97,16 +111,16 @@ at::Tensor& addbmm_(
     const at::Tensor& batch1,
     const at::Tensor& batch2,
     const at::Scalar& beta,
-    const at::Scalar& alpha)
-{
-    npu_preparation::CheckMemory({self, batch1, batch2}, {self});
-    if (!npu_utils::check_match(&self)) {
-        at::Tensor contiguous_self = npu_utils::format_contiguous(self);
-        acl_op::addbmm_out(contiguous_self, batch1, batch2, beta, alpha, contiguous_self);
-        npu_utils::format_fresh_view(self, contiguous_self);
-    } else {
-        acl_op::addbmm_out(self, batch1, batch2, beta, alpha, self);
-    }
-    return self;
+    const at::Scalar& alpha) {
+  npu_preparation::CheckMemory({self, batch1, batch2}, {self});
+  if (!npu_utils::check_match(&self)) {
+    at::Tensor contiguous_self = npu_utils::format_contiguous(self);
+    acl_op::addbmm_out(
+        contiguous_self, batch1, batch2, beta, alpha, contiguous_self);
+    npu_utils::format_fresh_view(self, contiguous_self);
+  } else {
+    acl_op::addbmm_out(self, batch1, batch2, beta, alpha, self);
+  }
+  return self;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/AddmmKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/AddmmKernelNpu.cpp
@@ -23,150 +23,180 @@ using format_helper = at_npu::native::FormatHelper;
 using npu_preparation = at_npu::native::OpPreparation;
 using npu_utils = at_npu::native::NpuUtils;
 
-bool is_transpose_last_two_dims_flex(const at::Tensor &tensor)
-{
-    if (tensor.dim() != 2) {
-        return false;
-    }
+bool is_transpose_last_two_dims_flex(const at::Tensor& tensor) {
+  if (tensor.dim() != 2) {
+    return false;
+  }
 
-    int64_t dim1 = tensor.dim() - 1;
-    int64_t dim2 = tensor.dim() - 2;
-    if (tensor.stride(dim2) == 1 && tensor.stride(dim1) == tensor.size(dim2)) {
-        return true;
-    } else {
-        return false;
-    }
+  int64_t dim1 = tensor.dim() - 1;
+  int64_t dim2 = tensor.dim() - 2;
+  if (tensor.stride(dim2) == 1 && tensor.stride(dim1) == tensor.size(dim2)) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 // Pick out strict-transpose tensors from flex-transpose tensors.
-bool is_transpose_last_two_dims_strict(const at::Tensor &tensor, bool is_transpose_flex)
-{
-    auto base_sizes = torch_npu::NPUBridge::GetNpuStorageImpl(tensor)->get_npu_desc().base_sizes_;
-    if (is_transpose_flex && base_sizes.size() == static_cast<uint64_t>(tensor.dim()) &&
-        tensor.size(-1) == base_sizes[tensor.dim() - 2] && tensor.size(-2) == base_sizes[tensor.dim() - 1]) {
-        return true;
-    }
-    return false;
+bool is_transpose_last_two_dims_strict(
+    const at::Tensor& tensor,
+    bool is_transpose_flex) {
+  auto base_sizes = torch_npu::NPUBridge::GetNpuStorageImpl(tensor)
+                        ->get_npu_desc()
+                        .base_sizes_;
+  if (is_transpose_flex &&
+      base_sizes.size() == static_cast<uint64_t>(tensor.dim()) &&
+      tensor.size(-1) == base_sizes[tensor.dim() - 2] &&
+      tensor.size(-2) == base_sizes[tensor.dim() - 1]) {
+    return true;
+  }
+  return false;
 }
 
 // Refresh storage desc of view-transpose tensor.
-void set_transposed_npu_desc(at::Tensor &tensor)
-{
-    at::Tensor temp_transpose_Tensor = tensor.transpose(-1, -2);
-    at_npu::native::StorageDescHelper::SetDesc(tensor, temp_transpose_Tensor.sizes(), temp_transpose_Tensor.strides());
+void set_transposed_npu_desc(at::Tensor& tensor) {
+  at::Tensor temp_transpose_Tensor = tensor.transpose(-1, -2);
+  at_npu::native::StorageDescHelper::SetDesc(
+      tensor, temp_transpose_Tensor.sizes(), temp_transpose_Tensor.strides());
 }
 
-void mm_set_format_contiguous(at::Tensor &tensor, bool &is_tensor_trans_flex, bool &is_tensor_trans_strict)
-{
-    if (is_tensor_trans_flex) {
-        if (!is_tensor_trans_strict) {
-            // Matmul cannot directly deal with view+transposed tensor with NZ format,
-            // so Transdata is necessary
-            tensor = npu_preparation::CastBackToOriFormat(tensor);
-            // Storage desc of view-transpose tensors should be refreshed to be
-            // matched.
-            set_transposed_npu_desc(tensor);
-        }
+void mm_set_format_contiguous(
+    at::Tensor& tensor,
+    bool& is_tensor_trans_flex,
+    bool& is_tensor_trans_strict) {
+  if (is_tensor_trans_flex) {
+    if (!is_tensor_trans_strict) {
+      // Matmul cannot directly deal with view+transposed tensor with NZ format,
+      // so Transdata is necessary
+      tensor = npu_preparation::CastBackToOriFormat(tensor);
+      // Storage desc of view-transpose tensors should be refreshed to be
+      // matched.
+      set_transposed_npu_desc(tensor);
+    }
+  } else {
+    tensor = npu_utils::format_contiguous_add_copy_optimize(tensor);
+  }
+}
+
+bool is_transpose_both_inner_axis(
+    const at::Tensor& self,
+    const at::Tensor& mat2) {
+  const static int64_t kInnerAxisMaxLimit = 65535;
+  int64_t self_inner_axis = self.size(self.dim() - 1);
+  int64_t self_outer_axis = self.size(self.dim() - 2);
+  int64_t mat2_inner_axis = mat2.size(mat2.dim() - 1);
+  int64_t mat2_outer_axis = mat2.size(mat2.dim() - 2);
+  if (op_plugin::utils::is_transpose_last_two_dims(self)) {
+    self_inner_axis = self.size(self.dim() - 2);
+    self_outer_axis = self.size(self.dim() - 1);
+  }
+  if (op_plugin::utils::is_transpose_last_two_dims(mat2)) {
+    mat2_inner_axis = mat2.size(mat2.dim() - 2);
+    mat2_outer_axis = mat2.size(mat2.dim() - 1);
+  }
+  return self_inner_axis > kInnerAxisMaxLimit &&
+      self_outer_axis <= kInnerAxisMaxLimit &&
+      mat2_inner_axis > kInnerAxisMaxLimit &&
+      mat2_outer_axis <= kInnerAxisMaxLimit;
+}
+
+at::Tensor& addmm_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Tensor& mat1,
+    const at::Tensor& mat2) {
+  const auto mat1_desc =
+      torch_npu::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_;
+  const auto mat2_desc =
+      torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
+  bool is_mat1_t_flex = is_transpose_last_two_dims_flex(mat1);
+  bool is_mat2_t_flex = is_transpose_last_two_dims_flex(mat2);
+  bool is_mat1_t_strict =
+      is_transpose_last_two_dims_strict(mat1, is_mat1_t_flex);
+  bool is_mat2_t_strict =
+      is_transpose_last_two_dims_strict(mat2, is_mat2_t_flex);
+  at::Tensor contiguous_mat1 = mat1;
+  at::Tensor contiguous_mat2 = mat2;
+  mm_set_format_contiguous(contiguous_mat1, is_mat1_t_flex, is_mat1_t_strict);
+  mm_set_format_contiguous(contiguous_mat2, is_mat2_t_flex, is_mat2_t_strict);
+  at_npu::native::OpCommand cmd;
+  cmd.Name("MatMul")
+      .InputWithoutContiguous(contiguous_mat1)
+      .InputWithoutContiguous(contiguous_mat2)
+      .Input(self)
+      .Output(result)
+      .Attr("transpose_x1", is_mat1_t_flex)
+      .Attr("transpose_x2", is_mat2_t_flex)
+      .Run();
+  // Recover storage desc of view-transpose tensors, i.e. the inverse process of
+  // set_transposed_npu_desc
+  if (is_mat1_t_flex && (!is_mat1_t_strict)) {
+    torch_npu::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_ = mat1_desc;
+  }
+  if (is_mat2_t_flex && (!is_mat2_t_strict)) {
+    torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
+  }
+  return result;
+}
+
+at::Tensor& addmm_out(
+    const at::Tensor& self,
+    const at::Tensor& mat1,
+    const at::Tensor& mat2,
+    const at::Scalar& beta,
+    const at::Scalar& alpha,
+    at::Tensor& result) {
+  static const bool is_support_nd_out =
+      c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1;
+  bool check_bias_shape =
+      (self.dim() == 1 || (self.dim() == 2 && self.size(0) == 1));
+  if (check_bias_shape && is_support_nd_out) {
+    if (beta.toFloat() == 1.0 && alpha.toFloat() == 1.0) {
+      acl_op::addmm_out_npu_nocheck(result, self, mat1, mat2);
     } else {
-        tensor = npu_utils::format_contiguous_add_copy_optimize(tensor);
+      at::Tensor mul_result = at::mul(mat1, alpha);
+      at::Tensor bias = at::mul(self, beta);
+      acl_op::addmm_out_npu_nocheck(result, bias, mul_result, mat2);
     }
+  } else {
+    at::Tensor mul_result = at::mul(mat1, alpha);
+    at::Tensor mm_result = at::mm(mul_result, mat2);
+    // matmul*alpha+self*beta
+    at::add_out(result, mm_result, self, beta);
+  }
+  return result;
 }
 
-bool is_transpose_both_inner_axis(const at::Tensor &self, const at::Tensor &mat2)
-{
-    const static int64_t kInnerAxisMaxLimit = 65535;
-    int64_t self_inner_axis = self.size(self.dim() - 1);
-    int64_t self_outer_axis = self.size(self.dim() - 2);
-    int64_t mat2_inner_axis = mat2.size(mat2.dim() - 1);
-    int64_t mat2_outer_axis = mat2.size(mat2.dim() - 2);
-    if (op_plugin::utils::is_transpose_last_two_dims(self)) {
-        self_inner_axis = self.size(self.dim() - 2);
-        self_outer_axis = self.size(self.dim() - 1);
-    }
-    if (op_plugin::utils::is_transpose_last_two_dims(mat2)) {
-        mat2_inner_axis = mat2.size(mat2.dim() - 2);
-        mat2_outer_axis = mat2.size(mat2.dim() - 1);
-    }
-    return self_inner_axis > kInnerAxisMaxLimit && self_outer_axis <= kInnerAxisMaxLimit &&
-           mat2_inner_axis > kInnerAxisMaxLimit && mat2_outer_axis <= kInnerAxisMaxLimit;
+at::Tensor addmm(
+    const at::Tensor& self,
+    const at::Tensor& mat1,
+    const at::Tensor& mat2,
+    const at::Scalar& beta,
+    const at::Scalar& alpha) {
+  auto output_size =
+      op_infer::addmm_npu_output_size(self, mat1, mat2, beta, alpha);
+  at::Tensor result =
+      npu_preparation::apply_tensor(output_size, self.options(), self);
+
+  acl_op::addmm_out(self, mat1, mat2, beta, alpha, result);
+  return result;
 }
 
-at::Tensor &addmm_out_npu_nocheck(at::Tensor &result, const at::Tensor &self, const at::Tensor &mat1,
-                                  const at::Tensor &mat2)
-{
-    const auto mat1_desc = torch_npu::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_;
-    const auto mat2_desc = torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
-    bool is_mat1_t_flex = is_transpose_last_two_dims_flex(mat1);
-    bool is_mat2_t_flex = is_transpose_last_two_dims_flex(mat2);
-    bool is_mat1_t_strict = is_transpose_last_two_dims_strict(mat1, is_mat1_t_flex);
-    bool is_mat2_t_strict = is_transpose_last_two_dims_strict(mat2, is_mat2_t_flex);
-    at::Tensor contiguous_mat1 = mat1;
-    at::Tensor contiguous_mat2 = mat2;
-    mm_set_format_contiguous(contiguous_mat1, is_mat1_t_flex, is_mat1_t_strict);
-    mm_set_format_contiguous(contiguous_mat2, is_mat2_t_flex, is_mat2_t_strict);
-    at_npu::native::OpCommand cmd;
-    cmd.Name("MatMul")
-        .InputWithoutContiguous(contiguous_mat1)
-        .InputWithoutContiguous(contiguous_mat2)
-        .Input(self)
-        .Output(result)
-        .Attr("transpose_x1", is_mat1_t_flex)
-        .Attr("transpose_x2", is_mat2_t_flex)
-        .Run();
-    // Recover storage desc of view-transpose tensors, i.e. the inverse process of
-    // set_transposed_npu_desc
-    if (is_mat1_t_flex && (!is_mat1_t_strict)) {
-        torch_npu::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_ = mat1_desc;
-    }
-    if (is_mat2_t_flex && (!is_mat2_t_strict)) {
-        torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
-    }
-    return result;
-}
-
-at::Tensor &addmm_out(const at::Tensor &self, const at::Tensor &mat1, const at::Tensor &mat2, const at::Scalar &beta,
-                      const at::Scalar &alpha, at::Tensor &result)
-{
-    static const bool is_support_nd_out = c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1;
-    bool check_bias_shape = (self.dim() == 1 || (self.dim() == 2 && self.size(0) == 1));
-    if (check_bias_shape && is_support_nd_out) {
-        if (beta.toFloat() == 1.0 && alpha.toFloat() == 1.0) {
-            acl_op::addmm_out_npu_nocheck(result, self, mat1, mat2);
-        } else {
-            at::Tensor mul_result = at::mul(mat1, alpha);
-            at::Tensor bias = at::mul(self, beta);
-            acl_op::addmm_out_npu_nocheck(result, bias, mul_result, mat2);
-        }
-    } else {
-        at::Tensor mul_result = at::mul(mat1, alpha);
-        at::Tensor mm_result = at::mm(mul_result, mat2);
-        // matmul*alpha+self*beta
-        at::add_out(result, mm_result, self, beta);
-    }
-    return result;
-}
-
-at::Tensor addmm(const at::Tensor &self, const at::Tensor &mat1, const at::Tensor &mat2, const at::Scalar &beta,
-                 const at::Scalar &alpha)
-{
-    auto output_size = op_infer::addmm_npu_output_size(self, mat1, mat2, beta, alpha);
-    at::Tensor result = npu_preparation::apply_tensor(output_size, self.options(), self);
-
-    acl_op::addmm_out(self, mat1, mat2, beta, alpha, result);
-    return result;
-}
-
-at::Tensor &addmm_(at::Tensor &self, const at::Tensor &mat1, const at::Tensor &mat2, const at::Scalar &beta,
-                   const at::Scalar &alpha)
-{
-    npu_preparation::CheckMemory({self, mat1, mat2}, {self});
-    if (!npu_utils::check_match(&self)) {
-        at::Tensor contiguous_self = npu_utils::format_contiguous(self);
-        acl_op::addmm_out(contiguous_self, mat1, mat2, beta, alpha, contiguous_self);
-        npu_utils::format_fresh_view(self, contiguous_self);
-    } else {
-        acl_op::addmm_out(self, mat1, mat2, beta, alpha, self);
-    }
-    return self;
+at::Tensor& addmm_(
+    at::Tensor& self,
+    const at::Tensor& mat1,
+    const at::Tensor& mat2,
+    const at::Scalar& beta,
+    const at::Scalar& alpha) {
+  npu_preparation::CheckMemory({self, mat1, mat2}, {self});
+  if (!npu_utils::check_match(&self)) {
+    at::Tensor contiguous_self = npu_utils::format_contiguous(self);
+    acl_op::addmm_out(
+        contiguous_self, mat1, mat2, beta, alpha, contiguous_self);
+    npu_utils::format_fresh_view(self, contiguous_self);
+  } else {
+    acl_op::addmm_out(self, mat1, mat2, beta, alpha, self);
+  }
+  return self;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/AmpForeachNonFiniteCheckAndUnscaleKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/AmpForeachNonFiniteCheckAndUnscaleKernelNpu.cpp
@@ -27,7 +27,8 @@ const int FLOAT_STATUS_OP_DIMS_SIZE = 8;
 bool _amp_foreach_non_finite_check(at::TensorList scaled_grads) {
   TORCH_NPU_WARN_ONCE("Non finite check on NPU device!");
 
-  auto options = at::TensorOptions(torch_npu::utils::get_npu_device_type()).dtype(at::kFloat);
+  auto options = at::TensorOptions(torch_npu::utils::get_npu_device_type())
+                     .dtype(at::kFloat);
   at::Tensor float_status = at::zeros({FLOAT_STATUS_OP_DIMS_SIZE}, options);
   auto ans = acl_op::npu_get_float_status(float_status);
 
@@ -43,42 +44,59 @@ void _amp_foreach_non_finite_check_and_unscale_(
     at::TensorList scaled_grads,
     at::Tensor& found_inf,
     const at::Tensor& inv_scale) {
-    TORCH_NPU_WARN_ONCE("Non finite check and unscale on NPU device!");
-    TORCH_CHECK(torch_npu::utils::is_npu(inv_scale), "inv_scale must be NPU-Tensor" + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(inv_scale.numel() == 1, "inv_scale must be a 1-element tensor" + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(inv_scale.scalar_type() == at::ScalarType::Float, "inv_scale must be a float tensor" + OPS_ERROR(ErrCode::TYPE));
+  TORCH_NPU_WARN_ONCE("Non finite check and unscale on NPU device!");
+  TORCH_CHECK(
+      torch_npu::utils::is_npu(inv_scale),
+      "inv_scale must be NPU-Tensor" + OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      inv_scale.numel() == 1,
+      "inv_scale must be a 1-element tensor" + OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      inv_scale.scalar_type() == at::ScalarType::Float,
+      "inv_scale must be a float tensor" + OPS_ERROR(ErrCode::TYPE));
 
-    if (scaled_grads.empty()) {
-        return;
+  if (scaled_grads.empty()) {
+    return;
+  }
+
+  bool is_finite = true;
+  if (c10::npu::IsSupportInfNan()) {
+    for (const auto& scaled_grad : scaled_grads) {
+      auto res = acl_op::sum(scaled_grad, at::ScalarType::Float);
+      float cpu_sum = res.item().toFloat();
+      if (!std::isfinite(cpu_sum)) {
+        is_finite = false;
+        break;
+      }
     }
+  } else {
+    is_finite = !acl_op::_amp_foreach_non_finite_check(scaled_grads);
+  }
 
-    bool is_finite = true;
-    if (c10_npu::IsSupportInfNan()) {
-        for (const auto& scaled_grad : scaled_grads) {
-            auto res = acl_op::sum(scaled_grad, at::ScalarType::Float);
-            float cpu_sum = res.item().toFloat();
-            if (!std::isfinite(cpu_sum)) {
-                is_finite = false;
-                break;
-            }
-        }
-    } else {
-        is_finite = !acl_op::_amp_foreach_non_finite_check(scaled_grads);
+  if (is_finite) {
+    auto expected_device = scaled_grads[0].device();
+    auto expected_dtype = scaled_grads[0].dtype();
+    for (const auto& t : scaled_grads) {
+      TORCH_CHECK(
+          torch_npu::utils::is_npu(t),
+          "one of scaled_grads was not a NPU tensor." +
+              OPS_ERROR(ErrCode::PARAM));
+      TORCH_CHECK(
+          t.device() == expected_device,
+          "scaled_grads must be on the same device." +
+              OPS_ERROR(ErrCode::PARAM));
+      TORCH_CHECK(
+          t.dtype() == expected_dtype,
+          "scaled_grads must have the same dtype." + OPS_ERROR(ErrCode::TYPE));
+      TORCH_CHECK(
+          t.layout() == at::kStrided,
+          "one of scaled_grads was not a strided tensor." +
+              OPS_ERROR(ErrCode::PARAM));
+
+      t.mul_(inv_scale);
     }
-
-    if (is_finite) {
-        auto expected_device = scaled_grads[0].device();
-        auto expected_dtype = scaled_grads[0].dtype();
-        for (const auto& t : scaled_grads) {
-            TORCH_CHECK(torch_npu::utils::is_npu(t), "one of scaled_grads was not a NPU tensor." + OPS_ERROR(ErrCode::PARAM));
-            TORCH_CHECK(t.device() == expected_device, "scaled_grads must be on the same device." + OPS_ERROR(ErrCode::PARAM));
-            TORCH_CHECK(t.dtype() == expected_dtype, "scaled_grads must have the same dtype." + OPS_ERROR(ErrCode::TYPE));
-            TORCH_CHECK(t.layout() == at::kStrided, "one of scaled_grads was not a strided tensor." + OPS_ERROR(ErrCode::PARAM));
-
-            t.mul_(inv_scale);
-        }
-    } else {
-        found_inf.add_(1);
-    }
+  } else {
+    found_inf.add_(1);
+  }
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/BmmKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/BmmKernelNpu.cpp
@@ -21,99 +21,125 @@
 #include "npu/framework/utils/UtilForOpAdapter.h"
 
 namespace acl_op {
-    using npu_format_helper = at_npu::native::FormatHelper;
-    using npu_preparation = at_npu::native::OpPreparation;
-    using npu_utils = at_npu::native::NpuUtils;
+using npu_format_helper = at_npu::native::FormatHelper;
+using npu_preparation = at_npu::native::OpPreparation;
+using npu_utils = at_npu::native::NpuUtils;
 
 namespace {
-    at::Tensor &bmm_out_nocheck(at::Tensor &result, const at::Tensor &self, const at::Tensor &mat2) {
-        bool is_self_t = op_plugin::utils::is_transpose_last_two_dims(self);
-        bool is_mat2_t = op_plugin::utils::is_transpose_last_two_dims(mat2);
-        at::Tensor contiguous_self = is_self_t ? self : npu_utils::format_contiguous_add_copy_optimize(self);
-        at::Tensor contiguous_mat2 = is_mat2_t ? mat2 : npu_utils::format_contiguous_add_copy_optimize(mat2);
+at::Tensor& bmm_out_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Tensor& mat2) {
+  bool is_self_t = op_plugin::utils::is_transpose_last_two_dims(self);
+  bool is_mat2_t = op_plugin::utils::is_transpose_last_two_dims(mat2);
+  at::Tensor contiguous_self =
+      is_self_t ? self : npu_utils::format_contiguous_add_copy_optimize(self);
+  at::Tensor contiguous_mat2 =
+      is_mat2_t ? mat2 : npu_utils::format_contiguous_add_copy_optimize(mat2);
 
-        at_npu::native::OpCommand cmd;
-        cmd.Name("BatchMatMul")
-            .InputWithoutContiguous(contiguous_self)
-            .InputWithoutContiguous(contiguous_mat2)
-            .Output(result)
-            .Attr("adj_x1", is_self_t)
-            .Attr("adj_x2", is_mat2_t)
-            .Run();
-        return result;
-    }
+  at_npu::native::OpCommand cmd;
+  cmd.Name("BatchMatMul")
+      .InputWithoutContiguous(contiguous_self)
+      .InputWithoutContiguous(contiguous_mat2)
+      .Output(result)
+      .Attr("adj_x1", is_self_t)
+      .Attr("adj_x2", is_mat2_t)
+      .Run();
+  return result;
+}
 } // namespace
 
-at::Tensor &bmm_out(const at::Tensor &self, const at::Tensor &mat2, at::Tensor &result) {
-    TORCH_CHECK(self.device() == mat2.device(),
-        "Expected all tensors to be on the same device, but found at least two devices, ",
-        (torch_npu::utils::is_npu(self) ? "npu" : "cpu"),
-        " and ",
-        (torch_npu::utils::is_npu(mat2) ? "npu! " : "cpu! "),
-        OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(self.scalar_type() != at::ScalarType::Char && mat2.scalar_type() != at::ScalarType::Char,
-        "bmm_out is not support int8 dtype" + OPS_ERROR(ErrCode::TYPE))
-    auto output_size = {self.size(0), self.size(1), mat2.size(2)};
-    npu_preparation::CheckOut(
-        {self, mat2},
-        result,
-        self,
-        output_size);
+at::Tensor& bmm_out(
+    const at::Tensor& self,
+    const at::Tensor& mat2,
+    at::Tensor& result) {
+  TORCH_CHECK(
+      self.device() == mat2.device(),
+      "Expected all tensors to be on the same device, but found at least two devices, ",
+      (torch_npu::utils::is_npu(self) ? "npu" : "cpu"),
+      " and ",
+      (torch_npu::utils::is_npu(mat2) ? "npu! " : "cpu! "),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      self.scalar_type() != at::ScalarType::Char &&
+          mat2.scalar_type() != at::ScalarType::Char,
+      "bmm_out is not support int8 dtype" + OPS_ERROR(ErrCode::TYPE))
+  auto output_size = {self.size(0), self.size(1), mat2.size(2)};
+  npu_preparation::CheckOut({self, mat2}, result, self, output_size);
 
-    if (!result.is_contiguous()) {
-        at::Tensor contiguous_result = npu_utils::format_contiguous(result);
-        bmm_out_nocheck(contiguous_result, self, mat2);
-        npu_utils::format_fresh_view(result, contiguous_result);
-    } else {
-        bmm_out_nocheck(result, self, mat2);
-    }
-    return result;
+  if (!result.is_contiguous()) {
+    at::Tensor contiguous_result = npu_utils::format_contiguous(result);
+    bmm_out_nocheck(contiguous_result, self, mat2);
+    npu_utils::format_fresh_view(result, contiguous_result);
+  } else {
+    bmm_out_nocheck(result, self, mat2);
+  }
+  return result;
 }
 
-at::Tensor bmm(const at::Tensor &self, const at::Tensor &mat2) {
-    TORCH_CHECK(self.device() == mat2.device(),
-                "Expected all tensors to be on the same device, but found at least two devices, ",
-                (torch_npu::utils::is_npu(self) ? "npu" : "cpu"),
-                " and ",
-                (torch_npu::utils::is_npu(mat2) ? "npu! " : "cpu! "),
-                OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(self.dim() == 3 && mat2.dim() == 3, "bmm expect self 3D tensors, but got: ",
-        self.dim(), "D and ", mat2.dim(), "D" + OPS_ERROR(ErrCode::PARAM));
-    // 1、cann bmm support int8(input)->int32(out)
-    // 2、onnx can support because of change y dtype to be int32.
-    // 3、torch need int8(input)->int8(out), cann can not support.
-    TORCH_CHECK(self.scalar_type() != at::ScalarType::Char && mat2.scalar_type() != at::ScalarType::Char,
-                "bmm is not support int8 dtype" + OPS_ERROR(ErrCode::TYPE))
-    auto output_size = {self.size(0), self.size(1), mat2.size(2)};
+at::Tensor bmm(const at::Tensor& self, const at::Tensor& mat2) {
+  TORCH_CHECK(
+      self.device() == mat2.device(),
+      "Expected all tensors to be on the same device, but found at least two devices, ",
+      (torch_npu::utils::is_npu(self) ? "npu" : "cpu"),
+      " and ",
+      (torch_npu::utils::is_npu(mat2) ? "npu! " : "cpu! "),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      self.dim() == 3 && mat2.dim() == 3,
+      "bmm expect self 3D tensors, but got: ",
+      self.dim(),
+      "D and ",
+      mat2.dim(),
+      "D" + OPS_ERROR(ErrCode::PARAM));
+  // 1、cann bmm support int8(input)->int32(out)
+  // 2、onnx can support because of change y dtype to be int32.
+  // 3、torch need int8(input)->int8(out), cann can not support.
+  TORCH_CHECK(
+      self.scalar_type() != at::ScalarType::Char &&
+          mat2.scalar_type() != at::ScalarType::Char,
+      "bmm is not support int8 dtype" + OPS_ERROR(ErrCode::TYPE))
+  auto output_size = {self.size(0), self.size(1), mat2.size(2)};
 
-    at::Tensor result;
-    bool need_nd_out = false;
-    // Check if the mm output is specified as NCHW.
-    // It will be deleted after the overall strategy of the NLP model is formulated.
-    if ((self.scalar_type() == at::kHalf)) {
-        // check is 16-algined with high-performance
-        auto is_aligin = [&]() {
-            return (!(static_cast<uint64_t>(self.size(1)) & 0xF)) && (!(static_cast<uint64_t>(self.size(2)) & 0xF)) &&
-                    (!(static_cast<uint64_t>(mat2.size(1)) & 0xF)) && (!(static_cast<uint64_t>(mat2.size(2)) & 0xF));
-        };
-        static auto mm_bmm_nd = !at_npu::native::env::CheckMmBmmNDDisable();
-        static bool is_support_nd_out = c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1;
-        // There is a data trampling problem in non-aligned scenes. For the time being, only aligned scenes are supported.
-        if (npu_format_helper::IsBaseFormatType(self) && npu_format_helper::IsBaseFormatType(mat2) &&
-            mm_bmm_nd && ((is_support_nd_out && op_plugin::utils::is_nd_to_nz_on_fly(self, mat2)) || (!is_support_nd_out && is_aligin()))) {
-            result = npu_preparation::apply_tensor_with_format(output_size, self.options(), ACL_FORMAT_ND);
-        } else {
-            result = npu_preparation::apply_tensor_with_format(output_size, self.options(), ACL_FORMAT_FRACTAL_NZ, true);
-            need_nd_out = mm_bmm_nd;
-        }
+  at::Tensor result;
+  bool need_nd_out = false;
+  // Check if the mm output is specified as NCHW.
+  // It will be deleted after the overall strategy of the NLP model is
+  // formulated.
+  if ((self.scalar_type() == at::kHalf)) {
+    // check is 16-algined with high-performance
+    auto is_aligin = [&]() {
+      return (!(static_cast<uint64_t>(self.size(1)) & 0xF)) &&
+          (!(static_cast<uint64_t>(self.size(2)) & 0xF)) &&
+          (!(static_cast<uint64_t>(mat2.size(1)) & 0xF)) &&
+          (!(static_cast<uint64_t>(mat2.size(2)) & 0xF));
+    };
+    static auto mm_bmm_nd = !at_npu::native::env::CheckMmBmmNDDisable();
+    static bool is_support_nd_out =
+        c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1;
+    // There is a data trampling problem in non-aligned scenes. For the time
+    // being, only aligned scenes are supported.
+    if (npu_format_helper::IsBaseFormatType(self) &&
+        npu_format_helper::IsBaseFormatType(mat2) && mm_bmm_nd &&
+        ((is_support_nd_out &&
+          op_plugin::utils::is_nd_to_nz_on_fly(self, mat2)) ||
+         (!is_support_nd_out && is_aligin()))) {
+      result = npu_preparation::apply_tensor_with_format(
+          output_size, self.options(), ACL_FORMAT_ND);
     } else {
-        result = npu_preparation::apply_tensor_with_format(output_size, self.options(), ACL_FORMAT_ND);
+      result = npu_preparation::apply_tensor_with_format(
+          output_size, self.options(), ACL_FORMAT_FRACTAL_NZ, true);
+      need_nd_out = mm_bmm_nd;
     }
+  } else {
+    result = npu_preparation::apply_tensor_with_format(
+        output_size, self.options(), ACL_FORMAT_ND);
+  }
 
-    bmm_out_nocheck(result, self, mat2);
-    if (need_nd_out) {
-        result = at_npu::native::custom_ops::npu_format_cast(result, ACL_FORMAT_ND);
-    }
-    return result;
+  bmm_out_nocheck(result, self, mat2);
+  if (need_nd_out) {
+    result = at_npu::native::custom_ops::npu_format_cast(result, ACL_FORMAT_ND);
+  }
+  return result;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/FloatStatusKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/FloatStatusKernelNpu.cpp
@@ -25,76 +25,71 @@ namespace {
 static const int64_t FLOAT_STATUS_OP_DIMS_SIZE = 8;
 const c10::SmallVector<int64_t, SIZE> output_size = {FLOAT_STATUS_OP_DIMS_SIZE};
 enum CheckOverflowMode {
-    OVERFLOW_ORIGINAL_MODE = 0,
-    OVERFLOW_DEBUG_MODE = 1,
-    OVERFLOW_UNDEFINED_MODE
+  OVERFLOW_ORIGINAL_MODE = 0,
+  OVERFLOW_DEBUG_MODE = 1,
+  OVERFLOW_UNDEFINED_MODE
 };
 } // namespace
 
 at::Tensor npu_alloc_float_status(const at::Tensor& self) {
-  auto options = at::TensorOptions(torch_npu::utils::get_npu_device_type()).dtype(at::kFloat);
+  auto options = at::TensorOptions(torch_npu::utils::get_npu_device_type())
+                     .dtype(at::kFloat);
   at::Tensor result = npu_preparation::apply_tensor_with_format(
       output_size, options, npu_preparation::get_tensor_npu_format(self));
   npu_op_command cmd;
-  cmd.Name("NPUAllocFloatStatus")
-      .Output(result)
-      .Run();
+  cmd.Name("NPUAllocFloatStatus").Output(result).Run();
   return result;
 }
 
 at::Tensor npu_get_float_status(const at::Tensor& self, int64_t mode) {
-    TORCH_CHECK((mode >= OVERFLOW_ORIGINAL_MODE && mode < OVERFLOW_UNDEFINED_MODE),
-        "mode only supported for ORIGINAL_MODE(0) DEBUG_MODE(1), but got mode:", mode,
-        OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      (mode >= OVERFLOW_ORIGINAL_MODE && mode < OVERFLOW_UNDEFINED_MODE),
+      "mode only supported for ORIGINAL_MODE(0) DEBUG_MODE(1), but got mode:",
+      mode,
+      OPS_ERROR(ErrCode::PARAM));
 
-    npu_op_command cmd;
-    if (mode == OVERFLOW_ORIGINAL_MODE) {
-        if (c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-            at::Tensor out_tensor = npu_preparation::apply_tensor_with_format(
-                output_size, self.options().dtype(at::kInt), npu_preparation::get_tensor_npu_format(self));
-            cmd.Name("NPUGetFloatStatusV2")
-                .Output(out_tensor)
-                .Run();
-            return out_tensor;
-        } else {
-            at::Tensor out_tensor = npu_preparation::apply_tensor(self, output_size);
-            cmd.Name("NPUGetFloatStatus")
-                .Input(self)
-                .Output(out_tensor)
-                .Run();
-            return self;
-        }
+  npu_op_command cmd;
+  if (mode == OVERFLOW_ORIGINAL_MODE) {
+    if (c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+      at::Tensor out_tensor = npu_preparation::apply_tensor_with_format(
+          output_size,
+          self.options().dtype(at::kInt),
+          npu_preparation::get_tensor_npu_format(self));
+      cmd.Name("NPUGetFloatStatusV2").Output(out_tensor).Run();
+      return out_tensor;
     } else {
-        at::Tensor out_tensor = npu_preparation::apply_tensor_with_format(
-            output_size, self.options().dtype(at::kInt), npu_preparation::get_tensor_npu_format(self));
-        cmd.Name("NPUGetFloatDebugStatus")
-            .Output(out_tensor)
-            .Run();
-       return out_tensor;
+      at::Tensor out_tensor = npu_preparation::apply_tensor(self, output_size);
+      cmd.Name("NPUGetFloatStatus").Input(self).Output(out_tensor).Run();
+      return self;
     }
+  } else {
+    at::Tensor out_tensor = npu_preparation::apply_tensor_with_format(
+        output_size,
+        self.options().dtype(at::kInt),
+        npu_preparation::get_tensor_npu_format(self));
+    cmd.Name("NPUGetFloatDebugStatus").Output(out_tensor).Run();
+    return out_tensor;
+  }
 }
 
 at::Tensor npu_clear_float_status(const at::Tensor& self, int64_t mode) {
-    TORCH_CHECK((mode >= OVERFLOW_ORIGINAL_MODE && mode < OVERFLOW_UNDEFINED_MODE),
-        "mode only supported for ORIGINAL_MODE(0) DEBUG_MODE(1), but got mode:", mode,
-        OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      (mode >= OVERFLOW_ORIGINAL_MODE && mode < OVERFLOW_UNDEFINED_MODE),
+      "mode only supported for ORIGINAL_MODE(0) DEBUG_MODE(1), but got mode:",
+      mode,
+      OPS_ERROR(ErrCode::PARAM));
 
-    at::Tensor result = npu_preparation::apply_tensor(self, output_size);
-    npu_op_command cmd;
-    if (mode == OVERFLOW_ORIGINAL_MODE) {
-        if (c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-            cmd.Name("NPUClearFloatStatusV2")
-                .Run();
-        } else {
-            cmd.Name("NPUClearFloatStatus")
-                .Input(self)
-                .Output(result)
-                .Run();
-        }
+  at::Tensor result = npu_preparation::apply_tensor(self, output_size);
+  npu_op_command cmd;
+  if (mode == OVERFLOW_ORIGINAL_MODE) {
+    if (c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+      cmd.Name("NPUClearFloatStatusV2").Run();
     } else {
-        cmd.Name("NPUClearFloatDebugStatus")
-            .Run();
+      cmd.Name("NPUClearFloatStatus").Input(self).Output(result).Run();
     }
-    return result;
+  } else {
+    cmd.Name("NPUClearFloatDebugStatus").Run();
+  }
+  return result;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/FusedAttentionScoreKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/FusedAttentionScoreKernelNpu.cpp
@@ -24,29 +24,41 @@ using npu_preparation = at_npu::native::OpPreparation;
 using npu_compile_type = at_npu::native::CompileType;
 
 namespace {
-std::tuple<c10::SmallVector<int64_t, SIZE>, c10::SmallVector<int64_t, SIZE>> fused_attention_score_infer_shape(
+std::tuple<c10::SmallVector<int64_t, SIZE>, c10::SmallVector<int64_t, SIZE>>
+fused_attention_score_infer_shape(
     const at::Tensor& query_layer,
     const at::Tensor& attention_mask) {
   c10::SmallVector<int64_t, SIZE> attention_score_output_shape = {
-      query_layer.size(0) * query_layer.size(2), query_layer.size(1) * query_layer.size(3)};
+      query_layer.size(0) * query_layer.size(2),
+      query_layer.size(1) * query_layer.size(3)};
   c10::SmallVector<int64_t, SIZE> softmax_output_shape = {
-      query_layer.size(0), query_layer.size(1), query_layer.size(2), query_layer.size(2)};
-  return std::tuple<c10::SmallVector<int64_t, SIZE>, c10::SmallVector<int64_t, SIZE>>(
-      attention_score_output_shape, softmax_output_shape);
+      query_layer.size(0),
+      query_layer.size(1),
+      query_layer.size(2),
+      query_layer.size(2)};
+  return std::
+      tuple<c10::SmallVector<int64_t, SIZE>, c10::SmallVector<int64_t, SIZE>>(
+          attention_score_output_shape, softmax_output_shape);
 }
 
-at::Tensor dropout_gen_mask_nocheck(const at::Tensor& self, const at::Scalar& prob) {
+at::Tensor dropout_gen_mask_nocheck(
+    const at::Tensor& self,
+    const at::Scalar& prob) {
   at::Tensor mask = npu_preparation::apply_tensor_with_format(
-      {self.numel()},
-      self.options().dtype(at::kByte),
-      ACL_FORMAT_ND);
+      {self.numel()}, self.options().dtype(at::kByte), ACL_FORMAT_ND);
   const auto gen = at_npu::detail::getDefaultNPUGenerator();
   const int64_t seed = static_cast<int64_t>(gen.current_seed());
   const int64_t seed2 = 0;
   at_npu::native::OpCommand cmd;
   cmd.Name("DropOutGenMaskV3")
-      .Input(self.sizes(), at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-      .Input(prob, self.scalar_type(), npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(
+          self.sizes(),
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(
+          prob,
+          self.scalar_type(),
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
       .Output(mask)
       .Attr("seed", seed)
       .Attr("seed2", seed2)
@@ -88,7 +100,8 @@ std::tuple<at::Tensor&, at::Tensor&> npu_fused_attention_score_nocheck(
 }
 } // namespace
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_fused_attention_score_backward(
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+npu_fused_attention_score_backward(
     const at::Tensor& grad_output,
     const at::Tensor& softmax_output,
     const at::Tensor& query_layer,
@@ -104,8 +117,13 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_fused_attention_score_backwar
   at::Tensor query_dx = npu_preparation::apply_tensor(grad_output);
   at::Tensor key_dw = npu_preparation::apply_tensor(grad_output);
   at::Tensor value_dw = npu_preparation::apply_tensor(grad_output);
-  at::Tensor grad_output_permute = grad_output.reshape(
-      {query_layer.size(0), query_layer.size(2), query_layer.size(1), query_layer.size(3)}).permute({0, 2, 1, 3});
+  at::Tensor grad_output_permute = grad_output
+                                       .reshape(
+                                           {query_layer.size(0),
+                                            query_layer.size(2),
+                                            query_layer.size(1),
+                                            query_layer.size(3)})
+                                       .permute({0, 2, 1, 3});
 
   at_npu::native::OpCommand cmd;
   cmd.Name("AttentionScoreGrad")
@@ -125,12 +143,27 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_fused_attention_score_backwar
       .Attr("value_transpose", value_transpose)
       .Attr("dx_transpose", dx_transpose)
       .Run();
-  query_dx = query_dx.reshape({query_layer.size(0), query_layer.size(2), query_layer.size(1), query_layer.size(3)})
-                     .permute({0, 2, 1, 3});
-  key_dw = key_dw.reshape({query_layer.size(0), query_layer.size(2), query_layer.size(1), query_layer.size(3)})
-                     .permute({0, 2, 1, 3});
-  value_dw = value_dw.reshape({query_layer.size(0), query_layer.size(2), query_layer.size(1), query_layer.size(3)})
-                     .permute({0, 2, 1, 3});
+  query_dx = query_dx
+                 .reshape(
+                     {query_layer.size(0),
+                      query_layer.size(2),
+                      query_layer.size(1),
+                      query_layer.size(3)})
+                 .permute({0, 2, 1, 3});
+  key_dw = key_dw
+               .reshape(
+                   {query_layer.size(0),
+                    query_layer.size(2),
+                    query_layer.size(1),
+                    query_layer.size(3)})
+               .permute({0, 2, 1, 3});
+  value_dw = value_dw
+                 .reshape(
+                     {query_layer.size(0),
+                      query_layer.size(2),
+                      query_layer.size(1),
+                      query_layer.size(3)})
+                 .permute({0, 2, 1, 3});
   return std::tie(query_dx, key_dw, value_dw);
 }
 
@@ -147,11 +180,22 @@ at::Tensor npu_fused_attention_score(
     bool bmm_score_transpose_b,
     bool value_transpose,
     bool dx_transpose) {
-    TORCH_CHECK(query_layer.dim() >= 4, "query_layer must be at least 4-dimensional"
-        + OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      query_layer.dim() >= 4,
+      "query_layer must be at least 4-dimensional" + OPS_ERROR(ErrCode::PARAM));
   auto results = at_npu::native::custom_ops::npu_fused_attention_score_fwd(
-      query_layer, key_layer, value_layer, attention_mask, scale, keep_prob, query_transpose,
-      key_transpose, bmm_score_transpose_a, bmm_score_transpose_b, value_transpose, dx_transpose);
+      query_layer,
+      key_layer,
+      value_layer,
+      attention_mask,
+      scale,
+      keep_prob,
+      query_transpose,
+      key_transpose,
+      bmm_score_transpose_a,
+      bmm_score_transpose_b,
+      value_transpose,
+      dx_transpose);
   return std::get<0>(results);
 }
 
@@ -168,15 +212,29 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_fused_attention_score_fwd(
     bool bmm_score_transpose_b,
     bool value_transpose,
     bool dx_transpose) {
-  auto output_sizes = fused_attention_score_infer_shape(query_layer, attention_mask);
-  at::Tensor attention_score = npu_preparation::apply_tensor(query_layer, std::get<0>(output_sizes));
-  at::Tensor softmax_output = npu_preparation::apply_tensor(query_layer, std::get<1>(output_sizes));
+  auto output_sizes =
+      fused_attention_score_infer_shape(query_layer, attention_mask);
+  at::Tensor attention_score =
+      npu_preparation::apply_tensor(query_layer, std::get<0>(output_sizes));
+  at::Tensor softmax_output =
+      npu_preparation::apply_tensor(query_layer, std::get<1>(output_sizes));
   at::Tensor drop_mask;
-  auto original_stream = c10_npu::getCurrentNPUStream();
+  auto original_stream = c10::npu::getCurrentNPUStream();
   drop_mask = dropout_gen_mask_nocheck(softmax_output, at::Scalar(keep_prob));
-  npu_fused_attention_score_nocheck(attention_score, softmax_output, query_layer, key_layer, value_layer,
-      attention_mask, drop_mask, scale, keep_prob, query_transpose, key_transpose,
-      bmm_score_transpose_a, bmm_score_transpose_b);
+  npu_fused_attention_score_nocheck(
+      attention_score,
+      softmax_output,
+      query_layer,
+      key_layer,
+      value_layer,
+      attention_mask,
+      drop_mask,
+      scale,
+      keep_prob,
+      query_transpose,
+      key_transpose,
+      bmm_score_transpose_a,
+      bmm_score_transpose_b);
   return std::tie(attention_score, softmax_output, drop_mask);
 }
 
@@ -193,31 +251,41 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_fused_attention_score_grad(
     bool key_transpose,
     bool value_transpose,
     bool dx_transpose) {
-    TORCH_CHECK(query_layer.dim() >= 4, "query_layer must be at least 4-dimensional"
-        + OPS_ERROR(ErrCode::PARAM));
-    at::Tensor query_dx = npu_preparation::apply_tensor_with_format(grad_output, ACL_FORMAT_FRACTAL_NZ);
-    at::Tensor key_dw = npu_preparation::apply_tensor_with_format(grad_output, ACL_FORMAT_FRACTAL_NZ);
-    at::Tensor value_dw = npu_preparation::apply_tensor_with_format(grad_output, ACL_FORMAT_FRACTAL_NZ);
-    at::Tensor grad_output_permute = acl_op::npu_confusion_transpose(grad_output, {0, 2, 1, 3},
-        {query_layer.size(0), query_layer.size(2), query_layer.size(1), query_layer.size(3)}, false);
-    at_npu::native::OpCommand cmd;
-    cmd.Name("AttentionScoreGrad")
-        .Input(softmax_output)
-        .Input(grad_output_permute)
-        .Input(value_layer)
-        .Input(key_layer)
-        .Input(query_layer)
-        .Input(scale, at::kHalf)
-        .Input(drop_mask)
-        .Output(value_dw)
-        .Output(query_dx)
-        .Output(key_dw)
-        .Attr("keep_prob", (float)keep_prob)
-        .Attr("query_transpose", query_transpose)
-        .Attr("key_transpose", key_transpose)
-        .Attr("value_transpose", value_transpose)
-        .Attr("dx_transpose", dx_transpose)
-        .Run();
-    return std::tie(query_dx, key_dw, value_dw);
+  TORCH_CHECK(
+      query_layer.dim() >= 4,
+      "query_layer must be at least 4-dimensional" + OPS_ERROR(ErrCode::PARAM));
+  at::Tensor query_dx = npu_preparation::apply_tensor_with_format(
+      grad_output, ACL_FORMAT_FRACTAL_NZ);
+  at::Tensor key_dw = npu_preparation::apply_tensor_with_format(
+      grad_output, ACL_FORMAT_FRACTAL_NZ);
+  at::Tensor value_dw = npu_preparation::apply_tensor_with_format(
+      grad_output, ACL_FORMAT_FRACTAL_NZ);
+  at::Tensor grad_output_permute = acl_op::npu_confusion_transpose(
+      grad_output,
+      {0, 2, 1, 3},
+      {query_layer.size(0),
+       query_layer.size(2),
+       query_layer.size(1),
+       query_layer.size(3)},
+      false);
+  at_npu::native::OpCommand cmd;
+  cmd.Name("AttentionScoreGrad")
+      .Input(softmax_output)
+      .Input(grad_output_permute)
+      .Input(value_layer)
+      .Input(key_layer)
+      .Input(query_layer)
+      .Input(scale, at::kHalf)
+      .Input(drop_mask)
+      .Output(value_dw)
+      .Output(query_dx)
+      .Output(key_dw)
+      .Attr("keep_prob", (float)keep_prob)
+      .Attr("query_transpose", query_transpose)
+      .Attr("key_transpose", key_transpose)
+      .Attr("value_transpose", value_transpose)
+      .Attr("dx_transpose", dx_transpose)
+      .Run();
+  return std::tie(query_dx, key_dw, value_dw);
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/IndexPutKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/IndexPutKernelNpu.cpp
@@ -17,10 +17,10 @@
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/TypeProperties.h>
 
-#include "npu/aten/AclOpsInterface.h"
-#include "npu/aten/utils/OpAdapter.h"
-#include "npu/aten/utils/AdvancedIndex.h"
 #include "npu/acl/include/op_proto/all_ops.h"
+#include "npu/aten/AclOpsInterface.h"
+#include "npu/aten/utils/AdvancedIndex.h"
+#include "npu/aten/utils/OpAdapter.h"
 #include "npu/framework/utils/UtilForOpAdapter.h"
 
 namespace acl_op {
@@ -31,10 +31,12 @@ using npu_compile_type = at_npu::native::CompileType;
 namespace {
 template <typename ge_op_type>
 at_npu::native::DynamicInputRegFunc indexput_func =
-    [](std::vector<std::pair<uint32_t, uint32_t>> num_and_index, std::string op_name) -> ge::OperatorPtr {
-    auto ge_op = std::make_shared<ge_op_type>(op_name.c_str());
-    ge_op->create_dynamic_input_byindex_indices(num_and_index.front().first, num_and_index.front().second);
-    return ge_op;
+    [](std::vector<std::pair<uint32_t, uint32_t>> num_and_index,
+       std::string op_name) -> ge::OperatorPtr {
+  auto ge_op = std::make_shared<ge_op_type>(op_name.c_str());
+  ge_op->create_dynamic_input_byindex_indices(
+      num_and_index.front().first, num_and_index.front().second);
+  return ge_op;
 };
 const std::string x_str = "x";
 const std::string value_str = "value";
@@ -42,253 +44,345 @@ const std::string indexed_sizes_str = "indexed_sizes";
 const std::string indexed_strides_str = "indexed_strides";
 const std::string aicore_str = "AiCore";
 
-bool is_aicpu_valid(const at::Tensor &self, const std::vector<at::Tensor> &all_defined_indices,
-                    const at::SmallVector<int64_t, N> masks)
-{
-    // using aicpu at non-binary scene
-    if (!at_npu::native::env::CheckJitDisable() &&
-        c10_npu::GetSocVersion() < c10_npu::SocVersion::Ascend910B1) {
-        return true;
+bool is_aicpu_valid(
+    const at::Tensor& self,
+    const std::vector<at::Tensor>& all_defined_indices,
+    const at::SmallVector<int64_t, N> masks) {
+  // using aicpu at non-binary scene
+  if (!at_npu::native::env::CheckJitDisable() &&
+      c10::npu::GetSocVersion() < c10::npu::SocVersion::Ascend910B1) {
+    return true;
+  }
+  // using aicore when index is continous, otherwise aicpu
+  bool is_zero_in_masks = false;
+  for (uint32_t i = 0; i < masks.size(); i++) {
+    if (is_zero_in_masks && masks[i] == 1) {
+      return true;
     }
-    // using aicore when index is continous, otherwise aicpu
-    bool is_zero_in_masks = false;
-    for (uint32_t i = 0; i < masks.size(); i++) {
-        if (is_zero_in_masks && masks[i] == 1) {
-            return true;
-        }
-        if (masks[i] == 0) {
-            is_zero_in_masks = true;
-        }
+    if (masks[i] == 0) {
+      is_zero_in_masks = true;
     }
-    // using aicpu when indices num is more than 20000 or the type of self tensor is double.
-    if (self.scalar_type() == at::kDouble || all_defined_indices[0].numel() > 20000) {
-        return true;
-    }
+  }
+  // using aicpu when indices num is more than 20000 or the type of self tensor
+  // is double.
+  if (self.scalar_type() == at::kDouble ||
+      all_defined_indices[0].numel() > 20000) {
+    return true;
+  }
 
-    // indices may need broadcast, in this case, indexput is implemented by aicpu
-    for (uint32_t i = 1; i < all_defined_indices.size(); i++) {
-        if (all_defined_indices[0].dim() != all_defined_indices[i].dim()) {
-            return true;
-        }
-        for (int32_t j = 0; j < all_defined_indices[0].dim(); j++) {
-            if (all_defined_indices[0].sizes()[j] != all_defined_indices[i].sizes()[j]) {
-                return true;
-            }
-        }
+  // indices may need broadcast, in this case, indexput is implemented by aicpu
+  for (uint32_t i = 1; i < all_defined_indices.size(); i++) {
+    if (all_defined_indices[0].dim() != all_defined_indices[i].dim()) {
+      return true;
     }
-
-    int tail_size = 1;
-    for (uint32_t i = all_defined_indices.size(); i < self.dim(); i++) {
-        tail_size = tail_size * self.sizes()[i];
-    }
-    if (self.scalar_type() != at::kHalf && self.scalar_type() != at::kFloat &&
-        self.scalar_type() != at::kBFloat16 && (all_defined_indices[0].numel() > 200 || tail_size > 128)) {
+    for (int32_t j = 0; j < all_defined_indices[0].dim(); j++) {
+      if (all_defined_indices[0].sizes()[j] !=
+          all_defined_indices[i].sizes()[j]) {
         return true;
+      }
     }
-    return false;
+  }
+
+  int tail_size = 1;
+  for (uint32_t i = all_defined_indices.size(); i < self.dim(); i++) {
+    tail_size = tail_size * self.sizes()[i];
+  }
+  if (self.scalar_type() != at::kHalf && self.scalar_type() != at::kFloat &&
+      self.scalar_type() != at::kBFloat16 &&
+      (all_defined_indices[0].numel() > 200 || tail_size > 128)) {
+    return true;
+  }
+  return false;
 }
 
-at::Tensor &index_put_aicore_nocheck(at::Tensor &self, const std::vector<at::Tensor> &all_defined_indices,
-                                     at::SmallVector<int64_t, N> masks, at::SmallVector<int64_t, N> expand_masks,
-                                     const at::Tensor &value, bool accumulate)
-{
-    if (value.numel() == 0) {
-        return self;
-    }
-    at::Tensor temp_self = self;
-    at::Tensor temp_value = value;
-    if (self.scalar_type() == at::ScalarType::Half) {
-        temp_self = at_npu::native::custom_ops::npu_dtype_cast(self, at::ScalarType::Float);
-        temp_value = at_npu::native::custom_ops::npu_dtype_cast(value, at::ScalarType::Float);
-    }
-    at::Tensor temp_value_broadcast = temp_value;
-    if (self.dim() == 1 && all_defined_indices.size() == 1 && all_defined_indices[0].scalar_type() == at::kLong &&
-        all_defined_indices[0].sizes()[0] != value.sizes()[0]) {
-        temp_value_broadcast = acl_op::npu_broadcast(temp_value, all_defined_indices[0].sizes());
-    }
-
-    at_npu::native::OpCommand cmd;
-    cmd.Name("IndexPutV2")
-        .Input(temp_self, x_str)
-        .Input(temp_value_broadcast, value_str)
-        .Input(masks, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT, "", indexed_sizes_str)
-        .Input(expand_masks, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT, "", indexed_strides_str);
-    for (uint i = 0; i < all_defined_indices.size(); i++) {
-        string input_name = "indices" + std::to_string(i);
-        cmd.Input(all_defined_indices[i], input_name);
-    }
-    cmd.DynamicInputReg(indexput_func<ge::op::IndexPutV2>, {{all_defined_indices.size(), 4}})
-        .Output(temp_self, x_str)
-        .Attr("accumulate", accumulate)
-        .Run();
-    if (self.scalar_type() == at::ScalarType::Half) {
-        temp_self = at_npu::native::custom_ops::npu_dtype_cast(temp_self, at::ScalarType::Half);
-        self.copy_(temp_self);
-    } else {
-        self = temp_self;
-    }
+at::Tensor& index_put_aicore_nocheck(
+    at::Tensor& self,
+    const std::vector<at::Tensor>& all_defined_indices,
+    at::SmallVector<int64_t, N> masks,
+    at::SmallVector<int64_t, N> expand_masks,
+    const at::Tensor& value,
+    bool accumulate) {
+  if (value.numel() == 0) {
     return self;
+  }
+  at::Tensor temp_self = self;
+  at::Tensor temp_value = value;
+  if (self.scalar_type() == at::ScalarType::Half) {
+    temp_self =
+        at_npu::native::custom_ops::npu_dtype_cast(self, at::ScalarType::Float);
+    temp_value = at_npu::native::custom_ops::npu_dtype_cast(
+        value, at::ScalarType::Float);
+  }
+  at::Tensor temp_value_broadcast = temp_value;
+  if (self.dim() == 1 && all_defined_indices.size() == 1 &&
+      all_defined_indices[0].scalar_type() == at::kLong &&
+      all_defined_indices[0].sizes()[0] != value.sizes()[0]) {
+    temp_value_broadcast =
+        acl_op::npu_broadcast(temp_value, all_defined_indices[0].sizes());
+  }
+
+  at_npu::native::OpCommand cmd;
+  cmd.Name("IndexPutV2")
+      .Input(temp_self, x_str)
+      .Input(temp_value_broadcast, value_str)
+      .Input(
+          masks,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT,
+          "",
+          indexed_sizes_str)
+      .Input(
+          expand_masks,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT,
+          "",
+          indexed_strides_str);
+  for (uint i = 0; i < all_defined_indices.size(); i++) {
+    string input_name = "indices" + std::to_string(i);
+    cmd.Input(all_defined_indices[i], input_name);
+  }
+  cmd.DynamicInputReg(
+         indexput_func<ge::op::IndexPutV2>, {{all_defined_indices.size(), 4}})
+      .Output(temp_self, x_str)
+      .Attr("accumulate", accumulate)
+      .Run();
+  if (self.scalar_type() == at::ScalarType::Half) {
+    temp_self = at_npu::native::custom_ops::npu_dtype_cast(
+        temp_self, at::ScalarType::Half);
+    self.copy_(temp_self);
+  } else {
+    self = temp_self;
+  }
+  return self;
 }
 
-at::SmallVector<int64_t, N> npu_expand_tensors_mask(const at::Tensor &self,
-                                                    const torch::List<c10::optional<at::Tensor>> &indices)
-{
-    at::SmallVector<int64_t, N> result;
-    for (c10::optional<at::Tensor> index_opt : indices) {
-        if (!index_opt.has_value()) {
-            result.emplace_back(0);
-        } else {
-            const auto &index = *index_opt;
-            if (index.scalar_type() != at::kByte && index.scalar_type() != at::kBool) {
-                result.emplace_back(0);
-                break;
-            }
-        }
+at::SmallVector<int64_t, N> npu_expand_tensors_mask(
+    const at::Tensor& self,
+    const torch::List<c10::optional<at::Tensor>>& indices) {
+  at::SmallVector<int64_t, N> result;
+  for (c10::optional<at::Tensor> index_opt : indices) {
+    if (!index_opt.has_value()) {
+      result.emplace_back(0);
+    } else {
+      const auto& index = *index_opt;
+      if (index.scalar_type() != at::kByte &&
+          index.scalar_type() != at::kBool) {
+        result.emplace_back(0);
+        break;
+      }
     }
-    if (result.empty()) {
-        result.emplace_back(1);
-    }
+  }
+  if (result.empty()) {
+    result.emplace_back(1);
+  }
+  return result;
+}
+
+at::Tensor& index_put_aicpu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    std::vector<at::Tensor> all_defined_indices,
+    at::SmallVector<int64_t, N> masks,
+    const at::Tensor& value,
+    bool accumulate) {
+  if (value.numel() == 0) {
     return result;
+  }
+
+  at::Tensor temp_self = self;
+  at::Tensor temp_value = value;
+  if (self.scalar_type() == at::ScalarType::Half) {
+    temp_self =
+        at_npu::native::custom_ops::npu_dtype_cast(self, at::ScalarType::Float);
+    temp_value = at_npu::native::custom_ops::npu_dtype_cast(
+        value, at::ScalarType::Float);
+    result = at_npu::native::custom_ops::npu_dtype_cast(
+        result, at::ScalarType::Float);
+  }
+
+  at_npu::native::OpCommand cmd;
+  cmd.Name("IndexPutV2")
+      .Input(temp_self, x_str)
+      .Input(temp_value, value_str)
+      .Input(
+          masks,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT,
+          "",
+          indexed_sizes_str)
+      .Input(
+          masks,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT,
+          "",
+          indexed_strides_str);
+  for (uint i = 0; i < all_defined_indices.size(); i++) {
+    string input_name = "indices" + std::to_string(i);
+    cmd.Input(all_defined_indices[i], input_name);
+  }
+  cmd.DynamicInputReg(
+         indexput_func<ge::op::IndexPutV2>, {{all_defined_indices.size(), 4}})
+      .Output(result, x_str)
+      .Attr("_exclude_engines", aicore_str)
+      .Attr("accumulate", accumulate)
+      .Run();
+
+  if (self.scalar_type() == at::ScalarType::Half) {
+    result = at_npu::native::custom_ops::npu_dtype_cast(
+        result, at::ScalarType::Half);
+  }
+  return result;
 }
 
-at::Tensor &index_put_aicpu_nocheck(at::Tensor &result, const at::Tensor &self,
-                                    std::vector<at::Tensor> all_defined_indices, at::SmallVector<int64_t, N> masks,
-                                    const at::Tensor &value, bool accumulate)
-{
-    if (value.numel() == 0) {
-        return result;
-    }
-
-    at::Tensor temp_self = self;
-    at::Tensor temp_value = value;
-    if (self.scalar_type() == at::ScalarType::Half) {
-        temp_self = at_npu::native::custom_ops::npu_dtype_cast(self, at::ScalarType::Float);
-        temp_value = at_npu::native::custom_ops::npu_dtype_cast(value, at::ScalarType::Float);
-        result = at_npu::native::custom_ops::npu_dtype_cast(result, at::ScalarType::Float);
-    }
-
-    at_npu::native::OpCommand cmd;
-    cmd.Name("IndexPutV2")
-        .Input(temp_self, x_str)
-        .Input(temp_value, value_str)
-        .Input(masks, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT, "", indexed_sizes_str)
-        .Input(masks, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT, "", indexed_strides_str);
-    for (uint i = 0; i < all_defined_indices.size(); i++) {
-        string input_name = "indices" + std::to_string(i);
-        cmd.Input(all_defined_indices[i], input_name);
-    }
-    cmd.DynamicInputReg(indexput_func<ge::op::IndexPutV2>, {{all_defined_indices.size(), 4}})
-        .Output(result, x_str)
-        .Attr("_exclude_engines", aicore_str)
-        .Attr("accumulate", accumulate)
-        .Run();
-
-    if (self.scalar_type() == at::ScalarType::Half) {
-        result = at_npu::native::custom_ops::npu_dtype_cast(result, at::ScalarType::Half);
-    }
-    return result;
+at::Tensor& index_put_aicpu(
+    at::Tensor& result,
+    at::Tensor& self,
+    std::vector<at::Tensor> all_defined_indices,
+    at::SmallVector<int64_t, N> masks,
+    const at::Tensor& value,
+    bool accumulate) {
+  if (!npu_utils::check_match(&self)) {
+    at::Tensor contiguous_self = npu_utils::format_contiguous(self);
+    index_put_aicpu_nocheck(
+        contiguous_self,
+        contiguous_self,
+        all_defined_indices,
+        masks,
+        value,
+        accumulate);
+    npu_utils::format_fresh_view(self, contiguous_self);
+  } else {
+    index_put_aicpu_nocheck(
+        self, self, all_defined_indices, masks, value, accumulate);
+  }
+  return self;
 }
 
-at::Tensor &index_put_aicpu(at::Tensor &result, at::Tensor &self, std::vector<at::Tensor> all_defined_indices,
-                            at::SmallVector<int64_t, N> masks, const at::Tensor &value, bool accumulate)
-{
-    if (!npu_utils::check_match(&self)) {
-        at::Tensor contiguous_self = npu_utils::format_contiguous(self);
-        index_put_aicpu_nocheck(contiguous_self, contiguous_self, all_defined_indices, masks, value, accumulate);
-        npu_utils::format_fresh_view(self, contiguous_self);
-    } else {
-        index_put_aicpu_nocheck(self, self, all_defined_indices, masks, value, accumulate);
-    }
-    return self;
-}
-
-at::Tensor &index_put_aicore(at::Tensor &self, std::vector<at::Tensor> indices_expand,
-                             at::SmallVector<int64_t, N> masks, at::SmallVector<int64_t, N> bool_masks,
-                             const at::Tensor &value_broadcast, bool accumulate)
-{
-    if (!npu_utils::check_match(&self)) {
-        at::Tensor contiguous_self = npu_utils::format_contiguous(self);
-        index_put_aicore_nocheck(contiguous_self, indices_expand, masks, bool_masks, value_broadcast, accumulate);
-        self.copy_(contiguous_self);
-    } else {
-        index_put_aicore_nocheck(self, indices_expand, masks, bool_masks, value_broadcast, accumulate);
-    }
-    return self;
+at::Tensor& index_put_aicore(
+    at::Tensor& self,
+    std::vector<at::Tensor> indices_expand,
+    at::SmallVector<int64_t, N> masks,
+    at::SmallVector<int64_t, N> bool_masks,
+    const at::Tensor& value_broadcast,
+    bool accumulate) {
+  if (!npu_utils::check_match(&self)) {
+    at::Tensor contiguous_self = npu_utils::format_contiguous(self);
+    index_put_aicore_nocheck(
+        contiguous_self,
+        indices_expand,
+        masks,
+        bool_masks,
+        value_broadcast,
+        accumulate);
+    self.copy_(contiguous_self);
+  } else {
+    index_put_aicore_nocheck(
+        self, indices_expand, masks, bool_masks, value_broadcast, accumulate);
+  }
+  return self;
 }
 } // namespace
 
-at::Tensor index_put(const at::Tensor &self, const c10::List<c10::optional<at::Tensor>> &indices,
-                     const at::Tensor &value, bool accumulate)
-{
-    return self.clone(at::MemoryFormat::Contiguous).index_put_(indices, value, accumulate);
+at::Tensor index_put(
+    const at::Tensor& self,
+    const c10::List<c10::optional<at::Tensor>>& indices,
+    const at::Tensor& value,
+    bool accumulate) {
+  return self.clone(at::MemoryFormat::Contiguous)
+      .index_put_(indices, value, accumulate);
 }
 
-at::Tensor &index_put_(at::Tensor &self, const c10::List<c10::optional<at::Tensor>> &indices, const at::Tensor &value,
-                       const bool accumulate)
-{
-    return at::_index_put_impl_(self, indices, value, accumulate, false);
+at::Tensor& index_put_(
+    at::Tensor& self,
+    const c10::List<c10::optional<at::Tensor>>& indices,
+    const at::Tensor& value,
+    const bool accumulate) {
+  return at::_index_put_impl_(self, indices, value, accumulate, false);
 }
 
-at::Tensor &_index_put_impl_(at::Tensor &self, const c10::List<c10::optional<at::Tensor>> &indices,
-                             const at::Tensor &value, const bool accumulate, const bool unsafe)
-{
-    if (self.device().type() == at::kCPU) {
-        return at::native::_index_put_impl_(self, indices, value, accumulate, unsafe);
-    }
-    bool needCast = op_plugin::AdvanceIndex::checkIndexTensorTypes(indices);
-    at::SmallVector<int64_t, N> masks;
-    std::vector<at::Tensor> all_defined_indices;
-    std::vector<at::Tensor> indices_expand;
-    c10::List<c10::optional<at::Tensor>> indices_expand_list;
-    indices_expand = op_plugin::AdvanceIndex::npu_expand_tensors(self, indices, needCast);
-    for (at::Tensor index_opt : indices_expand) {
-        indices_expand_list.push_back(index_opt);
-    }
-    auto info = op_plugin::AdvanceIndex::make_info(self, indices_expand_list);
-    TORCH_CHECK(op_plugin::AdvanceIndex::is_expandable_to(value.sizes(), info.src.sizes()),
-        "shape mismatch: value tensor of shape ", value.sizes(),
-        " cannot be broadcast to indexing result of shape ", info.src.sizes(),
-        OPS_ERROR(ErrCode::PARAM));
-    for (c10::optional<at::Tensor> index_opt : indices_expand) {
-        if (index_opt.has_value()) {
-            const auto &index = *index_opt;
-            if (index.defined()) {
-                all_defined_indices.emplace_back(index);
-                masks.emplace_back(1);
-            } else {
-                masks.emplace_back(0);
-            }
-        } else {
-            masks.emplace_back(0);
-        }
-    }
-    for (auto &all_defined_indice : all_defined_indices) {
-        if (all_defined_indice.device() != self.device()) {
-            all_defined_indice = all_defined_indice.to(self.device());
-        }
-    }
-
-    npu_preparation::CastBackToOriFormat(self);
-    at::Tensor value_copy = value;
-    at::Tensor self_copy = self;
-    npu_preparation::CastBackToOriFormat(value_copy);
-
-    bool aicpu_true = is_aicpu_valid(self, all_defined_indices, masks);
-    auto index_output_size = op_infer::index_npu_output_size(self, indices_expand);
-    if (index_output_size.size() > 8) {
-        aicpu_true = true;
-    }
-    if (aicpu_true) {
-        index_put_aicpu(self_copy, self_copy, all_defined_indices, masks, value_copy, accumulate);
+at::Tensor& _index_put_impl_(
+    at::Tensor& self,
+    const c10::List<c10::optional<at::Tensor>>& indices,
+    const at::Tensor& value,
+    const bool accumulate,
+    const bool unsafe) {
+  if (self.device().type() == at::kCPU) {
+    return at::native::_index_put_impl_(
+        self, indices, value, accumulate, unsafe);
+  }
+  bool needCast = op_plugin::AdvanceIndex::checkIndexTensorTypes(indices);
+  at::SmallVector<int64_t, N> masks;
+  std::vector<at::Tensor> all_defined_indices;
+  std::vector<at::Tensor> indices_expand;
+  c10::List<c10::optional<at::Tensor>> indices_expand_list;
+  indices_expand =
+      op_plugin::AdvanceIndex::npu_expand_tensors(self, indices, needCast);
+  for (at::Tensor index_opt : indices_expand) {
+    indices_expand_list.push_back(index_opt);
+  }
+  auto info = op_plugin::AdvanceIndex::make_info(self, indices_expand_list);
+  TORCH_CHECK(
+      op_plugin::AdvanceIndex::is_expandable_to(
+          value.sizes(), info.src.sizes()),
+      "shape mismatch: value tensor of shape ",
+      value.sizes(),
+      " cannot be broadcast to indexing result of shape ",
+      info.src.sizes(),
+      OPS_ERROR(ErrCode::PARAM));
+  for (c10::optional<at::Tensor> index_opt : indices_expand) {
+    if (index_opt.has_value()) {
+      const auto& index = *index_opt;
+      if (index.defined()) {
+        all_defined_indices.emplace_back(index);
+        masks.emplace_back(1);
+      } else {
+        masks.emplace_back(0);
+      }
     } else {
-        auto bool_mask = npu_expand_tensors_mask(self, indices);
-        // value broadcast
-        auto value_shape = op_infer::array_to_small_vector(value_copy.sizes());
-        at::Tensor value_broadcast =
-            (index_output_size != value_shape) ? acl_op::npu_broadcast(value_copy, index_output_size) : value_copy;
-        index_put_aicore(self_copy, indices_expand, masks, bool_mask, value_broadcast, accumulate);
+      masks.emplace_back(0);
     }
-    self.copy_(self_copy);
-    return self;
+  }
+  for (auto& all_defined_indice : all_defined_indices) {
+    if (all_defined_indice.device() != self.device()) {
+      all_defined_indice = all_defined_indice.to(self.device());
+    }
+  }
+
+  npu_preparation::CastBackToOriFormat(self);
+  at::Tensor value_copy = value;
+  at::Tensor self_copy = self;
+  npu_preparation::CastBackToOriFormat(value_copy);
+
+  bool aicpu_true = is_aicpu_valid(self, all_defined_indices, masks);
+  auto index_output_size =
+      op_infer::index_npu_output_size(self, indices_expand);
+  if (index_output_size.size() > 8) {
+    aicpu_true = true;
+  }
+  if (aicpu_true) {
+    index_put_aicpu(
+        self_copy,
+        self_copy,
+        all_defined_indices,
+        masks,
+        value_copy,
+        accumulate);
+  } else {
+    auto bool_mask = npu_expand_tensors_mask(self, indices);
+    // value broadcast
+    auto value_shape = op_infer::array_to_small_vector(value_copy.sizes());
+    at::Tensor value_broadcast = (index_output_size != value_shape)
+        ? acl_op::npu_broadcast(value_copy, index_output_size)
+        : value_copy;
+    index_put_aicore(
+        self_copy,
+        indices_expand,
+        masks,
+        bool_mask,
+        value_broadcast,
+        accumulate);
+  }
+  self.copy_(self_copy);
+  return self;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/LinearKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/LinearKernelNpu.cpp
@@ -26,90 +26,124 @@ using npu_format_helper = at_npu::native::FormatHelper;
 using npu_preparation = at_npu::native::OpPreparation;
 
 namespace {
-at::Tensor linear_npu_nocheck(const at::Tensor &input, const at::Tensor &weight,
-                              const c10::optional<at::Tensor> &bias_opt)
-{
-    const at::Tensor &bias = c10::value_or_else(bias_opt, [] { return at::Tensor(); });
-    c10::SmallVector<int64_t, SIZE> output_size = {input.size(0), weight.size(0)};
-    at::Tensor output = npu_preparation::apply_tensor(input, output_size);
+at::Tensor linear_npu_nocheck(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const c10::optional<at::Tensor>& bias_opt) {
+  const at::Tensor& bias =
+      c10::value_or_else(bias_opt, [] { return at::Tensor(); });
+  c10::SmallVector<int64_t, SIZE> output_size = {input.size(0), weight.size(0)};
+  at::Tensor output = npu_preparation::apply_tensor(input, output_size);
 
-    int64_t offset_x = 0;
-    at_npu::native::OpCommand cmd;
-    cmd.Name("MatMulV2").Input(input).Input(weight);
-    if (bias.defined()) {
-        cmd.Input(bias);
-    }
-    cmd.Output(output).Attr("transpose_x1", false).Attr("transpose_x2", true).Attr("offset_x", offset_x).Run();
+  int64_t offset_x = 0;
+  at_npu::native::OpCommand cmd;
+  cmd.Name("MatMulV2").Input(input).Input(weight);
+  if (bias.defined()) {
+    cmd.Input(bias);
+  }
+  cmd.Output(output)
+      .Attr("transpose_x1", false)
+      .Attr("transpose_x2", true)
+      .Attr("offset_x", offset_x)
+      .Run();
 
-    return output;
+  return output;
 }
 
-at::Tensor linear_backward_out_npu_nocheck(at::Tensor &result, const at::Tensor &input, const at::Tensor &weight,
-                                           bool transpose_x1, bool transpose_x2)
-{
-    int64_t offset_x = 0;
-    at_npu::native::OpCommand cmd;
-    cmd.Name("MatMulV2")
-        .Input(input)
-        .Input(weight)
-        .Output(result)
-        .Attr("transpose_x1", transpose_x1)
-        .Attr("transpose_x2", transpose_x2)
-        .Attr("offset_x", offset_x)
-        .Run();
-    return result;
+at::Tensor linear_backward_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    bool transpose_x1,
+    bool transpose_x2) {
+  int64_t offset_x = 0;
+  at_npu::native::OpCommand cmd;
+  cmd.Name("MatMulV2")
+      .Input(input)
+      .Input(weight)
+      .Output(result)
+      .Attr("transpose_x1", transpose_x1)
+      .Attr("transpose_x2", transpose_x2)
+      .Attr("offset_x", offset_x)
+      .Run();
+  return result;
 }
 } // namespace
 
-std::tuple<at::Tensor, at::Tensor> npu_linear_backward(const at::Tensor &grad, const at::Tensor &input,
-                                                       const at::Tensor &weight)
-{
-    TORCH_CHECK(grad.dim() >= 2, "torch.nn.functional.linear() grad must be at least two-dimensional."
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(input.dim() >= 2, "torch.nn.functional.linear() input must be at least two-dimensional."
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(weight.dim() >= 2, "torch.nn.functional.linear() weight must be at least two-dimensional."
-        + OPS_ERROR(ErrCode::PARAM));
-    c10::SmallVector<int64_t, SIZE> input_grad_output_size = {grad.size(0), weight.size(1)};
-    c10::SmallVector<int64_t, SIZE> weight_grad_output_size = {grad.size(1), input.size(1)};
-    at::Tensor input_grad = npu_preparation::apply_tensor(input, input_grad_output_size);
-    at::Tensor weight_grad = npu_preparation::apply_tensor(weight, weight_grad_output_size);
+std::tuple<at::Tensor, at::Tensor> npu_linear_backward(
+    const at::Tensor& grad,
+    const at::Tensor& input,
+    const at::Tensor& weight) {
+  TORCH_CHECK(
+      grad.dim() >= 2,
+      "torch.nn.functional.linear() grad must be at least two-dimensional." +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "torch.nn.functional.linear() input must be at least two-dimensional." +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      weight.dim() >= 2,
+      "torch.nn.functional.linear() weight must be at least two-dimensional." +
+          OPS_ERROR(ErrCode::PARAM));
+  c10::SmallVector<int64_t, SIZE> input_grad_output_size = {
+      grad.size(0), weight.size(1)};
+  c10::SmallVector<int64_t, SIZE> weight_grad_output_size = {
+      grad.size(1), input.size(1)};
+  at::Tensor input_grad =
+      npu_preparation::apply_tensor(input, input_grad_output_size);
+  at::Tensor weight_grad =
+      npu_preparation::apply_tensor(weight, weight_grad_output_size);
 
-    if (npu_preparation::get_tensor_npu_format(grad) == npu_preparation::get_tensor_npu_format(weight)) {
-        linear_backward_out_npu_nocheck(input_grad, grad, weight, false, false);
-        linear_backward_out_npu_nocheck(weight_grad, grad, input, true, false);
-    } else {
-        at::Tensor gradFormatcast = npu_preparation::apply_tensor(grad, grad.sizes());
-        gradFormatcast =
-            at_npu::native::custom_ops::npu_format_cast(grad, npu_preparation::get_tensor_npu_format(weight));
-        linear_backward_out_npu_nocheck(input_grad, gradFormatcast, weight, false, false);
-        linear_backward_out_npu_nocheck(weight_grad, gradFormatcast, input, true, false);
-    }
+  if (npu_preparation::get_tensor_npu_format(grad) ==
+      npu_preparation::get_tensor_npu_format(weight)) {
+    linear_backward_out_npu_nocheck(input_grad, grad, weight, false, false);
+    linear_backward_out_npu_nocheck(weight_grad, grad, input, true, false);
+  } else {
+    at::Tensor gradFormatcast =
+        npu_preparation::apply_tensor(grad, grad.sizes());
+    gradFormatcast = at_npu::native::custom_ops::npu_format_cast(
+        grad, npu_preparation::get_tensor_npu_format(weight));
+    linear_backward_out_npu_nocheck(
+        input_grad, gradFormatcast, weight, false, false);
+    linear_backward_out_npu_nocheck(
+        weight_grad, gradFormatcast, input, true, false);
+  }
 
-    return std::tie(input_grad, weight_grad);
+  return std::tie(input_grad, weight_grad);
 }
 
-at::Tensor npu_linear(const at::Tensor &input, const at::Tensor &weight, const c10::optional<at::Tensor> &bias_opt)
-{
-    TORCH_CHECK(input.dim() >= 2, "torch.nn.functional.linear() input must be at least two-dimensional."
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(weight.dim() >= 2, "torch.nn.functional.linear() weight must be at least two-dimensional."
-        + OPS_ERROR(ErrCode::PARAM));
+at::Tensor npu_linear(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const c10::optional<at::Tensor>& bias_opt) {
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "torch.nn.functional.linear() input must be at least two-dimensional." +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      weight.dim() >= 2,
+      "torch.nn.functional.linear() weight must be at least two-dimensional." +
+          OPS_ERROR(ErrCode::PARAM));
 
-    auto is_aligin = [&]() {
-        return (!(static_cast<uint64_t>(input.size(0)) & 0x0000000F)) &&
-               (!(static_cast<uint64_t>(input.size(1)) & 0x0000000F)) &&
-               (!(static_cast<uint64_t>(weight.size(0)) & 0x0000000F)) &&
-               (!(static_cast<uint64_t>(weight.size(1)) & 0x0000000F));
-    };
+  auto is_aligin = [&]() {
+    return (!(static_cast<uint64_t>(input.size(0)) & 0x0000000F)) &&
+        (!(static_cast<uint64_t>(input.size(1)) & 0x0000000F)) &&
+        (!(static_cast<uint64_t>(weight.size(0)) & 0x0000000F)) &&
+        (!(static_cast<uint64_t>(weight.size(1)) & 0x0000000F));
+  };
 
-    static auto mm_bmm_nd = !at_npu::native::env::CheckMmBmmNDDisable();
-    static bool is_support_nd_out = c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1;
-    at::Tensor input_cast = (npu_format_helper::IsBaseFormatType(input) && mm_bmm_nd &&
-                             ((is_support_nd_out && op_plugin::utils::is_nd_to_nz_on_fly(input, weight)) ||
-                              (!is_support_nd_out && is_aligin()))) ?
-                                input :
-                                at_npu::native::custom_ops::npu_format_cast(input, ACL_FORMAT_FRACTAL_NZ);
-    return linear_npu_nocheck(input_cast, weight, bias_opt);
+  static auto mm_bmm_nd = !at_npu::native::env::CheckMmBmmNDDisable();
+  static bool is_support_nd_out =
+      c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1;
+  at::Tensor input_cast =
+      (npu_format_helper::IsBaseFormatType(input) && mm_bmm_nd &&
+       ((is_support_nd_out &&
+         op_plugin::utils::is_nd_to_nz_on_fly(input, weight)) ||
+        (!is_support_nd_out && is_aligin())))
+      ? input
+      : at_npu::native::custom_ops::npu_format_cast(
+            input, ACL_FORMAT_FRACTAL_NZ);
+  return linear_npu_nocheck(input_cast, weight, bias_opt);
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/MmKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/MmKernelNpu.cpp
@@ -37,270 +37,328 @@ Return:
 Matmul: [1] 2-2-t(strict transpose); [2] 2-n-view+t(view transpose).
   False--Tensor is not transposed, proceed to format_contiguous.
 *****************************************/
-bool is_transpose_last_two_dims_flex(const at::Tensor &tensor)
-{
-    if (tensor.dim() != 2) {
-        return false;
-    }
+bool is_transpose_last_two_dims_flex(const at::Tensor& tensor) {
+  if (tensor.dim() != 2) {
+    return false;
+  }
 
-    int64_t dim1 = tensor.dim() - 1;
-    int64_t dim2 = tensor.dim() - 2;
-    if (tensor.stride(dim2) == 1 && tensor.stride(dim1) == tensor.size(dim2)) {
-        return true;
-    } else {
-        return false;
-    }
+  int64_t dim1 = tensor.dim() - 1;
+  int64_t dim2 = tensor.dim() - 2;
+  if (tensor.stride(dim2) == 1 && tensor.stride(dim1) == tensor.size(dim2)) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 // Pick out strict-transpose tensors from flex-transpose tensors.
-bool is_transpose_last_two_dims_strict(const at::Tensor &tensor, bool is_transpose_flex)
-{
-    auto base_sizes = torch_npu::NPUBridge::GetNpuStorageImpl(tensor)->get_npu_desc().base_sizes_;
-    if (is_transpose_flex && base_sizes.size() == static_cast<uint>(tensor.dim()) &&
-        tensor.size(-1) == base_sizes[tensor.dim() - 2] && tensor.size(-2) == base_sizes[tensor.dim() - 1]) {
-        return true;
-    }
-    return false;
+bool is_transpose_last_two_dims_strict(
+    const at::Tensor& tensor,
+    bool is_transpose_flex) {
+  auto base_sizes = torch_npu::NPUBridge::GetNpuStorageImpl(tensor)
+                        ->get_npu_desc()
+                        .base_sizes_;
+  if (is_transpose_flex &&
+      base_sizes.size() == static_cast<uint>(tensor.dim()) &&
+      tensor.size(-1) == base_sizes[tensor.dim() - 2] &&
+      tensor.size(-2) == base_sizes[tensor.dim() - 1]) {
+    return true;
+  }
+  return false;
 }
 
 // Refresh storage desc of view-transpose tensor.
-void set_transposed_npu_desc(at::Tensor &tensor)
-{
-    at::Tensor temp_transpose_Tensor = tensor.transpose(-1, -2);
-    at_npu::native::StorageDescHelper::SetDesc(tensor, temp_transpose_Tensor.sizes(), temp_transpose_Tensor.strides());
+void set_transposed_npu_desc(at::Tensor& tensor) {
+  at::Tensor temp_transpose_Tensor = tensor.transpose(-1, -2);
+  at_npu::native::StorageDescHelper::SetDesc(
+      tensor, temp_transpose_Tensor.sizes(), temp_transpose_Tensor.strides());
 }
 
-void mm_insert_input_transpose(at::Tensor &tensor, bool &is_tensor_trans_flex, bool &is_tensor_trans_strict)
-{
-    tensor = is_tensor_trans_flex ? tensor.clone() : tensor.transpose(-1, -2).clone();
-    is_tensor_trans_flex = !is_tensor_trans_flex;
-    is_tensor_trans_strict = !is_tensor_trans_strict;
+void mm_insert_input_transpose(
+    at::Tensor& tensor,
+    bool& is_tensor_trans_flex,
+    bool& is_tensor_trans_strict) {
+  tensor =
+      is_tensor_trans_flex ? tensor.clone() : tensor.transpose(-1, -2).clone();
+  is_tensor_trans_flex = !is_tensor_trans_flex;
+  is_tensor_trans_strict = !is_tensor_trans_strict;
 }
 
-void mm_set_format_contiguous(at::Tensor &tensor, bool &is_tensor_trans_flex, bool &is_tensor_trans_strict)
-{
-    if (is_tensor_trans_flex) {
-        if (!is_tensor_trans_strict) {
-            // Matmul cannot directly deal with view+transposed tensor with NZ format,
-            // so Transdata is necessary
-            tensor = npu_preparation::CastBackToOriFormat(tensor);
-            // Storage desc of view-transpose tensors should be refreshed to be
-            // matched.
-            set_transposed_npu_desc(tensor);
-        }
-    } else {
-        tensor = npu_utils::format_contiguous_add_copy_optimize(tensor);
+void mm_set_format_contiguous(
+    at::Tensor& tensor,
+    bool& is_tensor_trans_flex,
+    bool& is_tensor_trans_strict) {
+  if (is_tensor_trans_flex) {
+    if (!is_tensor_trans_strict) {
+      // Matmul cannot directly deal with view+transposed tensor with NZ format,
+      // so Transdata is necessary
+      tensor = npu_preparation::CastBackToOriFormat(tensor);
+      // Storage desc of view-transpose tensors should be refreshed to be
+      // matched.
+      set_transposed_npu_desc(tensor);
     }
+  } else {
+    tensor = npu_utils::format_contiguous_add_copy_optimize(tensor);
+  }
 }
 
-bool is_mm_transpose(const at::Tensor &tensor)
-{
-    if (tensor.dim() < 2 || tensor.dim() > 3) {
-        return false;
-    }
-    int64_t dim1 = tensor.dim() - 1;
-    int64_t dim2 = tensor.dim() - 2;
-    if (tensor.stride(dim2) == 1 && tensor.stride(dim1) == tensor.size(dim2)) {
-        return true;
-    } else {
-        return false;
-    }
+bool is_mm_transpose(const at::Tensor& tensor) {
+  if (tensor.dim() < 2 || tensor.dim() > 3) {
+    return false;
+  }
+  int64_t dim1 = tensor.dim() - 1;
+  int64_t dim2 = tensor.dim() - 2;
+  if (tensor.stride(dim2) == 1 && tensor.stride(dim1) == tensor.size(dim2)) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
-bool mm_check_nd_to_nz_on_the_fly(const at::Tensor &self, const at::Tensor &mat2)
-{
-    const static int64_t kInnerAxisMinBytes = 256;
-    const static int64_t kInnerAxisMaxLimit = 65535;
-    int64_t self_inner_axis = self.size(self.dim() - 1);
-    int64_t self_outer_axis = self.size(self.dim() - 2);
-    int64_t mat2_inner_axis = mat2.size(mat2.dim() - 1);
-    int64_t mat2_outer_axis = mat2.size(mat2.dim() - 2);
-    if (is_mm_transpose(self)) {
-        self_inner_axis = self.size(self.dim() - 2);
-        self_outer_axis = self.size(self.dim() - 1);
-    }
-    if (is_mm_transpose(mat2)) {
-        mat2_inner_axis = mat2.size(mat2.dim() - 2);
-        mat2_outer_axis = mat2.size(mat2.dim() - 1);
-    }
-    int64_t data_type = static_cast<int64_t>(elementSize(self.scalar_type()));
-    if (self_outer_axis > kInnerAxisMaxLimit && self_inner_axis * data_type < kInnerAxisMinBytes &&
-        bool((static_cast<uint64_t>(self_inner_axis) * static_cast<uint64_t>(data_type)) & 0x1F)) {
-        return false;
-    }
-    return !((self_inner_axis > kInnerAxisMaxLimit && self_outer_axis > kInnerAxisMaxLimit) ||
-             (mat2_inner_axis > kInnerAxisMaxLimit && mat2_outer_axis > kInnerAxisMaxLimit));
+bool mm_check_nd_to_nz_on_the_fly(
+    const at::Tensor& self,
+    const at::Tensor& mat2) {
+  const static int64_t kInnerAxisMinBytes = 256;
+  const static int64_t kInnerAxisMaxLimit = 65535;
+  int64_t self_inner_axis = self.size(self.dim() - 1);
+  int64_t self_outer_axis = self.size(self.dim() - 2);
+  int64_t mat2_inner_axis = mat2.size(mat2.dim() - 1);
+  int64_t mat2_outer_axis = mat2.size(mat2.dim() - 2);
+  if (is_mm_transpose(self)) {
+    self_inner_axis = self.size(self.dim() - 2);
+    self_outer_axis = self.size(self.dim() - 1);
+  }
+  if (is_mm_transpose(mat2)) {
+    mat2_inner_axis = mat2.size(mat2.dim() - 2);
+    mat2_outer_axis = mat2.size(mat2.dim() - 1);
+  }
+  int64_t data_type = static_cast<int64_t>(elementSize(self.scalar_type()));
+  if (self_outer_axis > kInnerAxisMaxLimit &&
+      self_inner_axis * data_type < kInnerAxisMinBytes &&
+      bool(
+          (static_cast<uint64_t>(self_inner_axis) *
+           static_cast<uint64_t>(data_type)) &
+          0x1F)) {
+    return false;
+  }
+  return !(
+      (self_inner_axis > kInnerAxisMaxLimit &&
+       self_outer_axis > kInnerAxisMaxLimit) ||
+      (mat2_inner_axis > kInnerAxisMaxLimit &&
+       mat2_outer_axis > kInnerAxisMaxLimit));
 }
 
-bool is_transpose_inner_axis(const at::Tensor &self)
-{
-    const static int64_t kInnerAxisMinBytes = 256;
-    const static int64_t kInnerAxisMaxLimit = 65535;
-    if (c10_npu::GetSocVersion() < c10_npu::SocVersion::Ascend910B1 || self.dim() < 2 ||
-        (self.scalar_type() != at::ScalarType::Half && self.scalar_type() != at::ScalarType::Float &&
-         self.scalar_type() != at::ScalarType::BFloat16)) {
-        return false;
-    }
-    int64_t data_type = static_cast<int64_t>(elementSize(self.scalar_type()));
-    int64_t self_inner_axis = self.size(self.dim() - 1);
-    int64_t self_outer_axis = self.size(self.dim() - 2);
-    if (is_mm_transpose(self)) {
-        self_inner_axis = self.size(self.dim() - 2);
-        self_outer_axis = self.size(self.dim() - 1);
-    }
-    if (self_inner_axis == 1 && self_outer_axis > kInnerAxisMaxLimit) {
-        return true;
-    }
-    if (self_inner_axis * self_outer_axis <= kInnerAxisMaxLimit) {
-        // too small tensor size
-        return false;
-    }
-    return ((self_inner_axis > kInnerAxisMaxLimit) ||
-            (self_inner_axis * data_type < kInnerAxisMinBytes &&
-             bool((static_cast<uint64_t>(self_inner_axis) * static_cast<uint64_t>(data_type)) & 0x1F))) &&
-           ((self_outer_axis * data_type >= kInnerAxisMinBytes && self_outer_axis <= kInnerAxisMaxLimit) ||
-            (self_outer_axis * data_type < kInnerAxisMinBytes &&
-             !((static_cast<uint64_t>(self_outer_axis) * static_cast<uint64_t>(data_type)) & 0x1F)));
+bool is_transpose_inner_axis(const at::Tensor& self) {
+  const static int64_t kInnerAxisMinBytes = 256;
+  const static int64_t kInnerAxisMaxLimit = 65535;
+  if (c10::npu::GetSocVersion() < c10::npu::SocVersion::Ascend910B1 ||
+      self.dim() < 2 ||
+      (self.scalar_type() != at::ScalarType::Half &&
+       self.scalar_type() != at::ScalarType::Float &&
+       self.scalar_type() != at::ScalarType::BFloat16)) {
+    return false;
+  }
+  int64_t data_type = static_cast<int64_t>(elementSize(self.scalar_type()));
+  int64_t self_inner_axis = self.size(self.dim() - 1);
+  int64_t self_outer_axis = self.size(self.dim() - 2);
+  if (is_mm_transpose(self)) {
+    self_inner_axis = self.size(self.dim() - 2);
+    self_outer_axis = self.size(self.dim() - 1);
+  }
+  if (self_inner_axis == 1 && self_outer_axis > kInnerAxisMaxLimit) {
+    return true;
+  }
+  if (self_inner_axis * self_outer_axis <= kInnerAxisMaxLimit) {
+    // too small tensor size
+    return false;
+  }
+  return ((self_inner_axis > kInnerAxisMaxLimit) ||
+          (self_inner_axis * data_type < kInnerAxisMinBytes &&
+           bool(
+               (static_cast<uint64_t>(self_inner_axis) *
+                static_cast<uint64_t>(data_type)) &
+               0x1F))) &&
+      ((self_outer_axis * data_type >= kInnerAxisMinBytes &&
+        self_outer_axis <= kInnerAxisMaxLimit) ||
+       (self_outer_axis * data_type < kInnerAxisMinBytes &&
+        !((static_cast<uint64_t>(self_outer_axis) *
+           static_cast<uint64_t>(data_type)) &
+          0x1F)));
 }
 
-bool is_transpose_both_inner_axis(const at::Tensor &self, const at::Tensor &mat2)
-{
-    const static int64_t kInnerAxisMaxLimit = 65535;
-    int64_t self_inner_axis = self.size(self.dim() - 1);
-    int64_t self_outer_axis = self.size(self.dim() - 2);
-    int64_t mat2_inner_axis = mat2.size(mat2.dim() - 1);
-    int64_t mat2_outer_axis = mat2.size(mat2.dim() - 2);
-    if (op_plugin::utils::is_transpose_last_two_dims(self)) {
-        self_inner_axis = self.size(self.dim() - 2);
-        self_outer_axis = self.size(self.dim() - 1);
-    }
-    if (op_plugin::utils::is_transpose_last_two_dims(mat2)) {
-        mat2_inner_axis = mat2.size(mat2.dim() - 2);
-        mat2_outer_axis = mat2.size(mat2.dim() - 1);
-    }
-    return self_inner_axis > kInnerAxisMaxLimit && self_outer_axis <= kInnerAxisMaxLimit &&
-           mat2_inner_axis > kInnerAxisMaxLimit && mat2_outer_axis <= kInnerAxisMaxLimit;
+bool is_transpose_both_inner_axis(
+    const at::Tensor& self,
+    const at::Tensor& mat2) {
+  const static int64_t kInnerAxisMaxLimit = 65535;
+  int64_t self_inner_axis = self.size(self.dim() - 1);
+  int64_t self_outer_axis = self.size(self.dim() - 2);
+  int64_t mat2_inner_axis = mat2.size(mat2.dim() - 1);
+  int64_t mat2_outer_axis = mat2.size(mat2.dim() - 2);
+  if (op_plugin::utils::is_transpose_last_two_dims(self)) {
+    self_inner_axis = self.size(self.dim() - 2);
+    self_outer_axis = self.size(self.dim() - 1);
+  }
+  if (op_plugin::utils::is_transpose_last_two_dims(mat2)) {
+    mat2_inner_axis = mat2.size(mat2.dim() - 2);
+    mat2_outer_axis = mat2.size(mat2.dim() - 1);
+  }
+  return self_inner_axis > kInnerAxisMaxLimit &&
+      self_outer_axis <= kInnerAxisMaxLimit &&
+      mat2_inner_axis > kInnerAxisMaxLimit &&
+      mat2_outer_axis <= kInnerAxisMaxLimit;
 }
 
-int64_t ceil(int64_t x, int64_t y)
-{
-    TORCH_CHECK(y != 0, "Error, zero division." + OPS_ERROR(ErrCode::VALUE));
-    return ((x + y - 1) / y) * y;
+int64_t ceil(int64_t x, int64_t y) {
+  TORCH_CHECK(y != 0, "Error, zero division." + OPS_ERROR(ErrCode::VALUE));
+  return ((x + y - 1) / y) * y;
 }
 
-int64_t ceil_div(int64_t x, int64_t y)
-{
-    TORCH_CHECK(y != 0, "Error, zero division." + OPS_ERROR(ErrCode::VALUE));
-    return (x + y - 1) / y;
+int64_t ceil_div(int64_t x, int64_t y) {
+  TORCH_CHECK(y != 0, "Error, zero division." + OPS_ERROR(ErrCode::VALUE));
+  return (x + y - 1) / y;
 }
 
+at::Tensor& mm_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Tensor& mat2) {
+  const auto self_desc =
+      torch_npu::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
+  const auto mat2_desc =
+      torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
+  bool is_self_t_flex = is_transpose_last_two_dims_flex(self);
+  bool is_mat2_t_flex = is_transpose_last_two_dims_flex(mat2);
+  bool is_self_t_strict =
+      is_transpose_last_two_dims_strict(self, is_self_t_flex);
+  bool is_mat2_t_strict =
+      is_transpose_last_two_dims_strict(mat2, is_mat2_t_flex);
+  at::Tensor contiguous_self = self;
+  at::Tensor contiguous_mat2 = mat2;
 
-at::Tensor &mm_out_npu_nocheck(at::Tensor &result, const at::Tensor &self, const at::Tensor &mat2)
-{
-    const auto self_desc = torch_npu::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
-    const auto mat2_desc = torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
-    bool is_self_t_flex = is_transpose_last_two_dims_flex(self);
-    bool is_mat2_t_flex = is_transpose_last_two_dims_flex(mat2);
-    bool is_self_t_strict = is_transpose_last_two_dims_strict(self, is_self_t_flex);
-    bool is_mat2_t_strict = is_transpose_last_two_dims_strict(mat2, is_mat2_t_flex);
-    at::Tensor contiguous_self = self;
-    at::Tensor contiguous_mat2 = mat2;
+  bool is_transpose_self = is_transpose_inner_axis(contiguous_self);
+  bool is_transpose_mat2 = is_transpose_inner_axis(contiguous_mat2);
+  if (is_transpose_self && is_transpose_mat2 &&
+      !is_transpose_both_inner_axis(contiguous_self, contiguous_mat2)) {
+    is_transpose_self = !is_transpose_self;
+    is_transpose_mat2 = !is_transpose_mat2;
+  }
 
-    bool is_transpose_self = is_transpose_inner_axis(contiguous_self);
-    bool is_transpose_mat2 = is_transpose_inner_axis(contiguous_mat2);
-    if (is_transpose_self && is_transpose_mat2 && !is_transpose_both_inner_axis(contiguous_self, contiguous_mat2)) {
-        is_transpose_self = !is_transpose_self;
-        is_transpose_mat2 = !is_transpose_mat2;
-    }
+  if (is_transpose_self) {
+    mm_insert_input_transpose(
+        contiguous_self, is_self_t_flex, is_self_t_strict);
+  }
+  if (is_transpose_mat2) {
+    mm_insert_input_transpose(
+        contiguous_mat2, is_mat2_t_flex, is_mat2_t_strict);
+  }
 
-    if (is_transpose_self) {
-        mm_insert_input_transpose(contiguous_self, is_self_t_flex, is_self_t_strict);
-    }
-    if (is_transpose_mat2) {
-        mm_insert_input_transpose(contiguous_mat2, is_mat2_t_flex, is_mat2_t_strict);
-    }
+  mm_set_format_contiguous(contiguous_self, is_self_t_flex, is_self_t_strict);
+  mm_set_format_contiguous(contiguous_mat2, is_mat2_t_flex, is_mat2_t_strict);
 
-    mm_set_format_contiguous(contiguous_self, is_self_t_flex, is_self_t_strict);
-    mm_set_format_contiguous(contiguous_mat2, is_mat2_t_flex, is_mat2_t_strict);
+  at_npu::native::OpCommand cmd;
+  cmd.Name("MatMul")
+      .InputWithoutContiguous(contiguous_self)
+      .InputWithoutContiguous(contiguous_mat2)
+      .Output(result)
+      .Attr("transpose_x1", is_self_t_flex)
+      .Attr("transpose_x2", is_mat2_t_flex)
+      .Run();
 
-    at_npu::native::OpCommand cmd;
-    cmd.Name("MatMul")
-        .InputWithoutContiguous(contiguous_self)
-        .InputWithoutContiguous(contiguous_mat2)
-        .Output(result)
-        .Attr("transpose_x1", is_self_t_flex)
-        .Attr("transpose_x2", is_mat2_t_flex)
-        .Run();
+  // Recover storage desc of view-transpose tensors, i.e. the inverse process of
+  // set_transposed_npu_desc
+  if (is_self_t_flex && (!is_self_t_strict)) {
+    torch_npu::NPUBridge::GetNpuStorageImpl(self)->npu_desc_ = self_desc;
+  }
+  if (is_mat2_t_flex && (!is_mat2_t_strict)) {
+    torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
+  }
 
-    // Recover storage desc of view-transpose tensors, i.e. the inverse process of
-    // set_transposed_npu_desc
-    if (is_self_t_flex && (!is_self_t_strict)) {
-        torch_npu::NPUBridge::GetNpuStorageImpl(self)->npu_desc_ = self_desc;
-    }
-    if (is_mat2_t_flex && (!is_mat2_t_strict)) {
-        torch_npu::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
-    }
-
-    return result;
+  return result;
 }
 } // namespace
 
-at::Tensor &mm_out(const at::Tensor &self, const at::Tensor &mat2, at::Tensor &result)
-{
-    TORCH_CHECK(self.dim() == 2 && mat2.dim() == 2, "both arguments to matmul need to be 2D, but they are ",
-                self.dim(), "D and ", mat2.dim(), "D", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(self.scalar_type() != at::ScalarType::Char && mat2.scalar_type() != at::ScalarType::Char,
-                "mm_out is not support int8 dtype", OPS_ERROR(ErrCode::PARAM))
-    if (!result.is_contiguous()) {
-        at::Tensor contiguous_result = npu_utils::format_contiguous(result);
-        mm_out_npu_nocheck(contiguous_result, self, mat2);
-        npu_utils::format_fresh_view(result, contiguous_result);
-    } else {
-        mm_out_npu_nocheck(result, self, mat2);
-    }
-    return result;
+at::Tensor& mm_out(
+    const at::Tensor& self,
+    const at::Tensor& mat2,
+    at::Tensor& result) {
+  TORCH_CHECK(
+      self.dim() == 2 && mat2.dim() == 2,
+      "both arguments to matmul need to be 2D, but they are ",
+      self.dim(),
+      "D and ",
+      mat2.dim(),
+      "D",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      self.scalar_type() != at::ScalarType::Char &&
+          mat2.scalar_type() != at::ScalarType::Char,
+      "mm_out is not support int8 dtype",
+      OPS_ERROR(ErrCode::PARAM))
+  if (!result.is_contiguous()) {
+    at::Tensor contiguous_result = npu_utils::format_contiguous(result);
+    mm_out_npu_nocheck(contiguous_result, self, mat2);
+    npu_utils::format_fresh_view(result, contiguous_result);
+  } else {
+    mm_out_npu_nocheck(result, self, mat2);
+  }
+  return result;
 }
 
-at::Tensor mm(const at::Tensor &self, const at::Tensor &mat2)
-{
-    TORCH_CHECK(self.dim() == 2 && mat2.dim() == 2, "both arguments to matmul need to be 2D, but they are ",
-                self.dim(), "D and ", mat2.dim(), "D", OPS_ERROR(ErrCode::PARAM));
+at::Tensor mm(const at::Tensor& self, const at::Tensor& mat2) {
+  TORCH_CHECK(
+      self.dim() == 2 && mat2.dim() == 2,
+      "both arguments to matmul need to be 2D, but they are ",
+      self.dim(),
+      "D and ",
+      mat2.dim(),
+      "D",
+      OPS_ERROR(ErrCode::PARAM));
 
-    // 1、cann bmm support int8(input)->int32(out)
-    // 2、onnx can support because of change y dtype to be int32.
-    // 3、torch need int8(input)->int8(out), cann can not support.
-    TORCH_CHECK(self.scalar_type() != at::ScalarType::Char && mat2.scalar_type() != at::ScalarType::Char,
-                "mm is not support int8 dtype", OPS_ERROR(ErrCode::PARAM))
-    auto output_size = {self.size(0), mat2.size(1)};
+  // 1、cann bmm support int8(input)->int32(out)
+  // 2、onnx can support because of change y dtype to be int32.
+  // 3、torch need int8(input)->int8(out), cann can not support.
+  TORCH_CHECK(
+      self.scalar_type() != at::ScalarType::Char &&
+          mat2.scalar_type() != at::ScalarType::Char,
+      "mm is not support int8 dtype",
+      OPS_ERROR(ErrCode::PARAM))
+  auto output_size = {self.size(0), mat2.size(1)};
 
-    at::Tensor result = npu_preparation::apply_tensor_with_format(output_size, self.options(), ACL_FORMAT_ND);
-    bool need_nd_out = false;
-    static bool is_support_nd_out = c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1;
-    // check format_out of mm is NCHW. Delate after definite NLP model.
-    if ((self.scalar_type() == at::ScalarType::Half)) {
-        // check is 16-algined with high-performance
-        auto is_aligin = [&]() {
-            return (!(static_cast<uint64_t>(self.size(0)) & 0xF)) && (!(static_cast<uint64_t>(self.size(1)) & 0xF)) &&
-                   (!(static_cast<uint64_t>(mat2.size(0)) & 0xF)) && (!(static_cast<uint64_t>(mat2.size(1)) & 0xF));
-        };
-        // There is a data trampling problem in non-aligned scenes. For the time
-        // being, only aligned scenes are supported.
-        static auto mm_bmm_nd = !at_npu::native::env::CheckMmBmmNDDisable();
-        if (format_helper::IsBaseFormatType(self) && format_helper::IsBaseFormatType(mat2) && mm_bmm_nd &&
-            ((is_support_nd_out && mm_check_nd_to_nz_on_the_fly(self, mat2)) || (!is_support_nd_out && is_aligin()))) {
-            result = npu_preparation::apply_tensor_with_format(output_size, self.options(), ACL_FORMAT_ND);
-        } else {
-            need_nd_out = mm_bmm_nd;
-            result =
-                npu_preparation::apply_tensor_with_format(output_size, self.options(), ACL_FORMAT_FRACTAL_NZ, true);
-        }
+  at::Tensor result = npu_preparation::apply_tensor_with_format(
+      output_size, self.options(), ACL_FORMAT_ND);
+  bool need_nd_out = false;
+  static bool is_support_nd_out =
+      c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1;
+  // check format_out of mm is NCHW. Delate after definite NLP model.
+  if ((self.scalar_type() == at::ScalarType::Half)) {
+    // check is 16-algined with high-performance
+    auto is_aligin = [&]() {
+      return (!(static_cast<uint64_t>(self.size(0)) & 0xF)) &&
+          (!(static_cast<uint64_t>(self.size(1)) & 0xF)) &&
+          (!(static_cast<uint64_t>(mat2.size(0)) & 0xF)) &&
+          (!(static_cast<uint64_t>(mat2.size(1)) & 0xF));
+    };
+    // There is a data trampling problem in non-aligned scenes. For the time
+    // being, only aligned scenes are supported.
+    static auto mm_bmm_nd = !at_npu::native::env::CheckMmBmmNDDisable();
+    if (format_helper::IsBaseFormatType(self) &&
+        format_helper::IsBaseFormatType(mat2) && mm_bmm_nd &&
+        ((is_support_nd_out && mm_check_nd_to_nz_on_the_fly(self, mat2)) ||
+         (!is_support_nd_out && is_aligin()))) {
+      result = npu_preparation::apply_tensor_with_format(
+          output_size, self.options(), ACL_FORMAT_ND);
+    } else {
+      need_nd_out = mm_bmm_nd;
+      result = npu_preparation::apply_tensor_with_format(
+          output_size, self.options(), ACL_FORMAT_FRACTAL_NZ, true);
     }
+  }
 
-    mm_out_npu_nocheck(result, self, mat2);
+  mm_out_npu_nocheck(result, self, mat2);
 
-    if (need_nd_out) {
-        result = at_npu::native::custom_ops::npu_format_cast(result, ACL_FORMAT_ND);
-    }
-    return result;
+  if (need_nd_out) {
+    result = at_npu::native::custom_ops::npu_format_cast(result, ACL_FORMAT_ND);
+  }
+  return result;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/MulKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/MulKernelNpu.cpp
@@ -24,7 +24,10 @@ using npu_preparation = at_npu::native::OpPreparation;
 using npu_utils = at_npu::native::NpuUtils;
 
 namespace {
-at::Tensor& mul_out_npu_nocheck(at::Tensor& result, const at::Tensor& self, const at::Scalar& other) {
+at::Tensor& mul_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Scalar& other) {
   at_npu::native::OpCommand cmd;
   cmd.Name("Mul")
       .Input(self)
@@ -34,81 +37,88 @@ at::Tensor& mul_out_npu_nocheck(at::Tensor& result, const at::Tensor& self, cons
   return result;
 }
 
-at::Tensor& mul_out_npu_nocheck(at::Tensor& result, const at::Tensor& self, const at::Tensor& other) {
+at::Tensor& mul_out_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    const at::Tensor& other) {
   if (npu_preparation::IsCPUScalar(other)) {
     mul_out_npu_nocheck(result, self, other.item());
   } else if (npu_preparation::IsCPUScalar(self)) {
     mul_out_npu_nocheck(result, other, self.item());
   } else {
     at_npu::native::OpCommand cmd;
-    cmd.Name("Mul")
-        .Input(self)
-        .Input(other)
-        .Output(result)
-        .Run();
+    cmd.Name("Mul").Input(self).Input(other).Output(result).Run();
   }
   return result;
 }
 } // namespace
 
-bool check_mul_out_result(const at::Tensor *result)
-{
-    if (!result->is_contiguous()) {
-        return false;
+bool check_mul_out_result(const at::Tensor* result) {
+  if (!result->is_contiguous()) {
+    return false;
+  }
+  if (at_npu::native::FormatHelper::IsBaseFormatType(*result)) {
+    if (c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+      return true;
+    } else if ((result->numel() * result->element_size()) % 32 == 0) {
+      return true;
     }
-    if (at_npu::native::FormatHelper::IsBaseFormatType(*result)) {
-        if (c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-            return true;
-        } else if ((result->numel() * result->element_size()) % 32 == 0) {
-            return true;
-        }
-    }
-    if (!at_npu::native::StorageDescHelper::MetaDataAreMatch(result)) {
-        return false;
-    }
-    bool isPadding = at_npu::native::FormatHelper::IsPadded(result);
-    if (isPadding && (!at_npu::native::StorageDescHelper::OffsetAreMatch(result))) {
-        return false;
-    }
-    return true;
+  }
+  if (!at_npu::native::StorageDescHelper::MetaDataAreMatch(result)) {
+    return false;
+  }
+  bool isPadding = at_npu::native::FormatHelper::IsPadded(result);
+  if (isPadding &&
+      (!at_npu::native::StorageDescHelper::OffsetAreMatch(result))) {
+    return false;
+  }
+  return true;
 }
 
-at::Tensor& mul_out(const at::Tensor& self, const at::Tensor& other, at::Tensor& result) {
-    auto output_size = op_infer::broadcast_ops_npu_output_size(self, other);
-    npu_preparation::CheckOut(
-        {self, other},
-        result,
-        result,
-        output_size);
+at::Tensor& mul_out(
+    const at::Tensor& self,
+    const at::Tensor& other,
+    at::Tensor& result) {
+  auto output_size = op_infer::broadcast_ops_npu_output_size(self, other);
+  npu_preparation::CheckOut({self, other}, result, result, output_size);
 
-    auto result_type = result.scalar_type();
-    auto calculate_type = at::native::result_type(self, other);
-    TORCH_CHECK(canCast(calculate_type, result_type),
-        "result type ", calculate_type, " can't be cast to the desired output type ", result_type,
-        OPS_ERROR(ErrCode::TYPE));
+  auto result_type = result.scalar_type();
+  auto calculate_type = at::native::result_type(self, other);
+  TORCH_CHECK(
+      canCast(calculate_type, result_type),
+      "result type ",
+      calculate_type,
+      " can't be cast to the desired output type ",
+      result_type,
+      OPS_ERROR(ErrCode::TYPE));
 
-    if (calculate_type == at::kBool) {
-        calculate_type = at::kFloat;
-    }
-    at::Tensor self_cast = (self.scalar_type() == calculate_type) ? self : self.to(calculate_type);
-    at::Tensor other_cast = (other.scalar_type() == calculate_type ||
-                             other.dim() == 0) ? other : other.to(calculate_type);
+  if (calculate_type == at::kBool) {
+    calculate_type = at::kFloat;
+  }
+  at::Tensor self_cast =
+      (self.scalar_type() == calculate_type) ? self : self.to(calculate_type);
+  at::Tensor other_cast =
+      (other.scalar_type() == calculate_type || other.dim() == 0)
+      ? other
+      : other.to(calculate_type);
 
-    at::Tensor result_cast = (result_type == calculate_type) ? result :
-        at_npu::native::custom_ops::npu_dtype_cast(result, calculate_type);
-    if (!check_mul_out_result(&result_cast)) {
-        at::Tensor contiguous_result = npu_utils::format_contiguous(result_cast);
-        mul_out_npu_nocheck(contiguous_result, self_cast, other_cast);
-        npu_utils::format_fresh_view(result_cast, contiguous_result);
-    } else {
-        mul_out_npu_nocheck(result_cast, self_cast, other_cast);
-    }
+  at::Tensor result_cast = (result_type == calculate_type)
+      ? result
+      : at_npu::native::custom_ops::npu_dtype_cast(result, calculate_type);
+  if (!check_mul_out_result(&result_cast)) {
+    at::Tensor contiguous_result = npu_utils::format_contiguous(result_cast);
+    mul_out_npu_nocheck(contiguous_result, self_cast, other_cast);
+    npu_utils::format_fresh_view(result_cast, contiguous_result);
+  } else {
+    mul_out_npu_nocheck(result_cast, self_cast, other_cast);
+  }
 
-    if (result_type != calculate_type) {
-        result_cast = at_npu::native::custom_ops::npu_dtype_cast(result_cast, result_type);
-        result.copy_(result_cast);
-    }
-    return result;
+  if (result_type != calculate_type) {
+    result_cast =
+        at_npu::native::custom_ops::npu_dtype_cast(result_cast, result_type);
+    result.copy_(result_cast);
+  }
+  return result;
 }
 
 at::Tensor mul(const at::Tensor& self, const at::Tensor& other) {
@@ -118,22 +128,25 @@ at::Tensor mul(const at::Tensor& self, const at::Tensor& other) {
     calculate_type = at::kFloat;
   }
 
-    at::Tensor self_cast = self;
-    at::Tensor other_cast = other;
-    if (self.scalar_type() != calculate_type) {
-        self_cast = npu_preparation::IsCPUScalar(self) ?
-                        self.to(calculate_type) :
-                        at_npu::native::custom_ops::npu_dtype_cast(self, calculate_type);
-    }
-    if (other.scalar_type() != calculate_type) {
-        other_cast = npu_preparation::IsCPUScalar(other) ?
-                         other.to(calculate_type) :
-                         at_npu::native::custom_ops::npu_dtype_cast(other, calculate_type);
-    }
+  at::Tensor self_cast = self;
+  at::Tensor other_cast = other;
+  if (self.scalar_type() != calculate_type) {
+    self_cast = npu_preparation::IsCPUScalar(self)
+        ? self.to(calculate_type)
+        : at_npu::native::custom_ops::npu_dtype_cast(self, calculate_type);
+  }
+  if (other.scalar_type() != calculate_type) {
+    other_cast = npu_preparation::IsCPUScalar(other)
+        ? other.to(calculate_type)
+        : at_npu::native::custom_ops::npu_dtype_cast(other, calculate_type);
+  }
 
-  bool is_self_wrapped = npu_preparation::is_scalar_wrapped_to_tensor(self_cast) || npu_preparation::IsCPUScalar(self_cast);
+  bool is_self_wrapped =
+      npu_preparation::is_scalar_wrapped_to_tensor(self_cast) ||
+      npu_preparation::IsCPUScalar(self_cast);
   at::Tensor output_tensor = is_self_wrapped ? other_cast : self_cast;
-  auto output_size = op_infer::broadcast_ops_npu_output_size(self_cast, other_cast);
+  auto output_size =
+      op_infer::broadcast_ops_npu_output_size(self_cast, other_cast);
   at::Tensor result = npu_preparation::apply_tensor(output_tensor, output_size);
 
   mul_out_npu_nocheck(result, self_cast, other_cast);

--- a/npu/aten/ops/base/opapi/AmpForeachNonFiniteCheckAndUnscaleKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/AmpForeachNonFiniteCheckAndUnscaleKernelNpuOpApi.cpp
@@ -13,137 +13,178 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "npu/acl/include/acl/acl_rt.h"
 #include "npu/aten/AclOpsInterface.h"
 #include "npu/aten/OpApiInterface.h"
 #include "npu/aten/utils/op_api_common.h"
 #include "npu/framework/utils/UtilForOpAdapter.h"
-#include "npu/acl/include/acl/acl_rt.h"
 
 namespace op_api {
 using npu_preparation = at_npu::native::OpPreparation;
 
-#define NON_FINITE_CHECK_RESULT_ESTIMATE(result, host_mem_out, device_mem_out, log_str)                                \
-    do {                                                                                                               \
-        if ((result) != ACL_ERROR_NONE) {                                                                              \
-            TORCH_NPU_WARN_ONCE(log_str);                                                                              \
-            if ((host_mem_out) != nullptr) {                                                                           \
-                aclrtFreeHost(host_mem_out);                                                                           \
-                host_mem_out = nullptr;                                                                                \
-            }                                                                                                          \
-            if ((device_mem_out) != nullptr) {                                                                         \
-                aclrtFree(device_mem_out);                                                                             \
-                device_mem_out = nullptr;                                                                              \
-            }                                                                                                          \
-            return acl_op::_amp_foreach_non_finite_check(scaled_grads);                                                \
-        }                                                                                                              \
-    } while (0);
+#define NON_FINITE_CHECK_RESULT_ESTIMATE(                         \
+    result, host_mem_out, device_mem_out, log_str)                \
+  do {                                                            \
+    if ((result) != ACL_ERROR_NONE) {                             \
+      TORCH_NPU_WARN_ONCE(log_str);                               \
+      if ((host_mem_out) != nullptr) {                            \
+        aclrtFreeHost(host_mem_out);                              \
+        host_mem_out = nullptr;                                   \
+      }                                                           \
+      if ((device_mem_out) != nullptr) {                          \
+        aclrtFree(device_mem_out);                                \
+        device_mem_out = nullptr;                                 \
+      }                                                           \
+      return acl_op::_amp_foreach_non_finite_check(scaled_grads); \
+    }                                                             \
+  } while (0);
 
 const int FLOAT_STATUS_OP_DIMS_SIZE = 8;
 constexpr size_t MAX_TENSOR_COUNT = 250;
 
-static bool amp_foreach_non_finite_check(at::TensorList &scaled_grads)
-{
-    // apply for output host memory
-    uint64_t buff_size = 64;
-    void *host_mem_out = nullptr;
-    void *device_mem_out = nullptr;
-    aclrtStream aclStream = c10_npu::getCurrentNPUStream().stream();
+static bool amp_foreach_non_finite_check(at::TensorList& scaled_grads) {
+  // apply for output host memory
+  uint64_t buff_size = 64;
+  void* host_mem_out = nullptr;
+  void* device_mem_out = nullptr;
+  aclrtStream aclStream = c10::npu::getCurrentNPUStream().stream();
 
-    aclError err = aclrtMallocHost((void **)&host_mem_out, buff_size);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "malloc host memory failed!");
+  aclError err = aclrtMallocHost((void**)&host_mem_out, buff_size);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "malloc host memory failed!");
 
-    err = aclrtMemset(host_mem_out, buff_size, 0, buff_size);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "set host memory failed!");
+  err = aclrtMemset(host_mem_out, buff_size, 0, buff_size);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "set host memory failed!");
 
-    // apply for input parameter device memory(size is 64)
-    err = aclrtMalloc(&device_mem_out, buff_size, aclrtMemMallocPolicy::ACL_MEM_MALLOC_HUGE_FIRST);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "malloc host memory failed!");
+  // apply for input parameter device memory(size is 64)
+  err = aclrtMalloc(
+      &device_mem_out,
+      buff_size,
+      aclrtMemMallocPolicy::ACL_MEM_MALLOC_HUGE_FIRST);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "malloc host memory failed!");
 
-    err = aclrtGetOverflowStatus(device_mem_out, buff_size, aclStream);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "get overflow status failed!");
+  err = aclrtGetOverflowStatus(device_mem_out, buff_size, aclStream);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "get overflow status failed!");
 
-    err = aclrtSynchronizeStream(aclStream);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "synchronize stream failed!");
+  err = aclrtSynchronizeStream(aclStream);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "synchronize stream failed!");
 
-    err = aclrtMemcpy(host_mem_out, buff_size, device_mem_out, buff_size, aclrtMemcpyKind::ACL_MEMCPY_DEVICE_TO_HOST);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "memory copy failed!");
+  err = aclrtMemcpy(
+      host_mem_out,
+      buff_size,
+      device_mem_out,
+      buff_size,
+      aclrtMemcpyKind::ACL_MEMCPY_DEVICE_TO_HOST);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "memory copy failed!");
 
-    err = aclrtResetOverflowStatus(aclStream);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "reset overflow status failed!");
+  err = aclrtResetOverflowStatus(aclStream);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "reset overflow status failed!");
 
-    err = aclrtSynchronizeStream(aclStream);
-    NON_FINITE_CHECK_RESULT_ESTIMATE(err, host_mem_out, device_mem_out, "synchronize stream failed!");
+  err = aclrtSynchronizeStream(aclStream);
+  NON_FINITE_CHECK_RESULT_ESTIMATE(
+      err, host_mem_out, device_mem_out, "synchronize stream failed!");
 
-    uint64_t over_flow_flag = *(uint64_t *)host_mem_out;
-    aclrtFreeHost(host_mem_out);
-    host_mem_out = nullptr;
-    aclrtFree(device_mem_out);
-    device_mem_out = nullptr;
-    return over_flow_flag != 0;
+  uint64_t over_flow_flag = *(uint64_t*)host_mem_out;
+  aclrtFreeHost(host_mem_out);
+  host_mem_out = nullptr;
+  aclrtFree(device_mem_out);
+  device_mem_out = nullptr;
+  return over_flow_flag != 0;
 }
 
-void _split_and_exec_npu_cmd_(at::TensorList &scaled_grads, at::Tensor &found_inf, const at::Tensor &inv_scale)
-{
-    size_t tensor_count = scaled_grads.size();
-    size_t loop_time = tensor_count / MAX_TENSOR_COUNT; // Upward division
-    for (size_t i = 0; i < loop_time; i++) {
-        at::TensorList temp_scaled_grads(scaled_grads.data() + i * MAX_TENSOR_COUNT, MAX_TENSOR_COUNT);
-        EXEC_NPU_CMD(aclnnForeachNonFiniteCheckAndUnscale, temp_scaled_grads, found_inf, inv_scale);
-    }
-    size_t remaining_count = tensor_count % MAX_TENSOR_COUNT;
-    if (remaining_count) {
-        at::TensorList temp_scaled_grads(scaled_grads.data() + loop_time * MAX_TENSOR_COUNT, remaining_count);
-        EXEC_NPU_CMD(aclnnForeachNonFiniteCheckAndUnscale, temp_scaled_grads, found_inf, inv_scale);
-    }
+void _split_and_exec_npu_cmd_(
+    at::TensorList& scaled_grads,
+    at::Tensor& found_inf,
+    const at::Tensor& inv_scale) {
+  size_t tensor_count = scaled_grads.size();
+  size_t loop_time = tensor_count / MAX_TENSOR_COUNT; // Upward division
+  for (size_t i = 0; i < loop_time; i++) {
+    at::TensorList temp_scaled_grads(
+        scaled_grads.data() + i * MAX_TENSOR_COUNT, MAX_TENSOR_COUNT);
+    EXEC_NPU_CMD(
+        aclnnForeachNonFiniteCheckAndUnscale,
+        temp_scaled_grads,
+        found_inf,
+        inv_scale);
+  }
+  size_t remaining_count = tensor_count % MAX_TENSOR_COUNT;
+  if (remaining_count) {
+    at::TensorList temp_scaled_grads(
+        scaled_grads.data() + loop_time * MAX_TENSOR_COUNT, remaining_count);
+    EXEC_NPU_CMD(
+        aclnnForeachNonFiniteCheckAndUnscale,
+        temp_scaled_grads,
+        found_inf,
+        inv_scale);
+  }
 }
 
-void _amp_foreach_non_finite_check_and_unscale_(at::TensorList scaled_grads, at::Tensor &found_inf,
-                                                const at::Tensor &inv_scale)
-{
-    TORCH_NPU_WARN_ONCE("Non finite check and unscale on NPU device!");
-    TORCH_CHECK(torch_npu::utils::is_npu(inv_scale), "inv_scale must be NPU-Tensor"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(inv_scale.numel() == 1, "inv_scale must be a 1-element tensor"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(found_inf.numel() == 1, "found_inf must be a 1-element tensor"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(inv_scale.scalar_type() == at::ScalarType::Float, "inv_scale must be a float tensor"
-        + OPS_ERROR(ErrCode::TYPE));
-    TORCH_CHECK(found_inf.scalar_type() == at::ScalarType::Float, "found_inf must be a float tensor"
-        + OPS_ERROR(ErrCode::TYPE));
+void _amp_foreach_non_finite_check_and_unscale_(
+    at::TensorList scaled_grads,
+    at::Tensor& found_inf,
+    const at::Tensor& inv_scale) {
+  TORCH_NPU_WARN_ONCE("Non finite check and unscale on NPU device!");
+  TORCH_CHECK(
+      torch_npu::utils::is_npu(inv_scale),
+      "inv_scale must be NPU-Tensor" + OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      inv_scale.numel() == 1,
+      "inv_scale must be a 1-element tensor" + OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      found_inf.numel() == 1,
+      "found_inf must be a 1-element tensor" + OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      inv_scale.scalar_type() == at::ScalarType::Float,
+      "inv_scale must be a float tensor" + OPS_ERROR(ErrCode::TYPE));
+  TORCH_CHECK(
+      found_inf.scalar_type() == at::ScalarType::Float,
+      "found_inf must be a float tensor" + OPS_ERROR(ErrCode::TYPE));
 
-    if (scaled_grads.empty()) {
-        return;
-    }
+  if (scaled_grads.empty()) {
+    return;
+  }
 
-    // inf/nan mode
-    if (c10_npu::IsSupportInfNan()) {
-        _split_and_exec_npu_cmd_(scaled_grads, found_inf, inv_scale);
-        return;
-    }
+  // inf/nan mode
+  if (c10::npu::IsSupportInfNan()) {
+    _split_and_exec_npu_cmd_(scaled_grads, found_inf, inv_scale);
+    return;
+  }
 
-    // saturation mode
-    // Due to the high false positive rate of rts interface, we fallback to path 3 interface to determinw finite.
-    bool is_finite = !acl_op::_amp_foreach_non_finite_check(scaled_grads);
-    if (!is_finite) {
-        op_api::ones_out(1, found_inf);
-        return;
-    }
+  // saturation mode
+  // Due to the high false positive rate of rts interface, we fallback to path 3
+  // interface to determinw finite.
+  bool is_finite = !acl_op::_amp_foreach_non_finite_check(scaled_grads);
+  if (!is_finite) {
+    op_api::ones_out(1, found_inf);
+    return;
+  }
 
-    auto expected_device = scaled_grads[0].device();
-    auto expected_dtype = scaled_grads[0].dtype();
-    for (auto &t : scaled_grads) {
-        TORCH_CHECK(torch_npu::utils::is_npu(t), "one of scaled_grads was not a NPU tensor."
-            + OPS_ERROR(ErrCode::PARAM));
-        TORCH_CHECK(t.device() == expected_device, "scaled_grads must be on the same device."
-            + OPS_ERROR(ErrCode::PARAM));
-        TORCH_CHECK(t.dtype() == expected_dtype, "scaled_grads must have the same dtype."
-            + OPS_ERROR(ErrCode::TYPE));
-        TORCH_CHECK(t.layout() == at::kStrided, "one of scaled_grads was not a strided tensor."
-            + OPS_ERROR(ErrCode::PARAM));
+  auto expected_device = scaled_grads[0].device();
+  auto expected_dtype = scaled_grads[0].dtype();
+  for (auto& t : scaled_grads) {
+    TORCH_CHECK(
+        torch_npu::utils::is_npu(t),
+        "one of scaled_grads was not a NPU tensor." +
+            OPS_ERROR(ErrCode::PARAM));
+    TORCH_CHECK(
+        t.device() == expected_device,
+        "scaled_grads must be on the same device." + OPS_ERROR(ErrCode::PARAM));
+    TORCH_CHECK(
+        t.dtype() == expected_dtype,
+        "scaled_grads must have the same dtype." + OPS_ERROR(ErrCode::TYPE));
+    TORCH_CHECK(
+        t.layout() == at::kStrided,
+        "one of scaled_grads was not a strided tensor." +
+            OPS_ERROR(ErrCode::PARAM));
 
-        op_api::mul_out(t, inv_scale, const_cast<at::Tensor &>(t));
-    }
+    op_api::mul_out(t, inv_scale, const_cast<at::Tensor&>(t));
+  }
 }
 
 } // namespace op_api

--- a/npu/aten/ops/base/opapi/Im2colKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/Im2colKernelNpuOpApi.cpp
@@ -21,30 +21,48 @@
 namespace op_api {
 using npu_preparation = at_npu::native::OpPreparation;
 
-at::Tensor &im2col_out(const at::Tensor &self, at::IntArrayRef kernel_size, at::IntArrayRef dilation,
-                       at::IntArrayRef padding, at::IntArrayRef stride, at::Tensor &result)
-{
-    DO_COMPATIBILITY(aclnnIm2col, acl_op::im2col_out(self, kernel_size, dilation, padding, stride, result));
-    if (c10_npu::GetSocVersion() < c10_npu::SocVersion::Ascend910B1) {
-        return acl_op::im2col_out(self, kernel_size, dilation, padding, stride, result);
-    }
-    auto output_size = op_infer::image_to_col_npu_output_size(self, kernel_size, stride, dilation, padding);
-    npu_preparation::check_tensor({self}, result, result.scalar_type(), output_size);
-    EXEC_NPU_CMD(aclnnIm2col, self, kernel_size, dilation, padding, stride, result);
-    return result;
+at::Tensor& im2col_out(
+    const at::Tensor& self,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef dilation,
+    at::IntArrayRef padding,
+    at::IntArrayRef stride,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(
+      aclnnIm2col,
+      acl_op::im2col_out(self, kernel_size, dilation, padding, stride, result));
+  if (c10::npu::GetSocVersion() < c10::npu::SocVersion::Ascend910B1) {
+    return acl_op::im2col_out(
+        self, kernel_size, dilation, padding, stride, result);
+  }
+  auto output_size = op_infer::image_to_col_npu_output_size(
+      self, kernel_size, stride, dilation, padding);
+  npu_preparation::check_tensor(
+      {self}, result, result.scalar_type(), output_size);
+  EXEC_NPU_CMD(
+      aclnnIm2col, self, kernel_size, dilation, padding, stride, result);
+  return result;
 }
 
-at::Tensor im2col(const at::Tensor &self, at::IntArrayRef kernel_size, at::IntArrayRef dilation,
-                  at::IntArrayRef padding, at::IntArrayRef stride)
-{
-    DO_COMPATIBILITY(aclnnIm2col, acl_op::im2col(self, kernel_size, dilation, padding, stride));
-    if (c10_npu::GetSocVersion() < c10_npu::SocVersion::Ascend910B1) {
-        return acl_op::im2col(self, kernel_size, dilation, padding, stride);
-    }
-    auto output_size = op_infer::image_to_col_npu_output_size(self, kernel_size, stride, dilation, padding);
-    at::Tensor result = npu_preparation::apply_tensor_without_format(self, output_size);
-    EXEC_NPU_CMD(aclnnIm2col, self, kernel_size, dilation, padding, stride, result);
-    return result;
+at::Tensor im2col(
+    const at::Tensor& self,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef dilation,
+    at::IntArrayRef padding,
+    at::IntArrayRef stride) {
+  DO_COMPATIBILITY(
+      aclnnIm2col,
+      acl_op::im2col(self, kernel_size, dilation, padding, stride));
+  if (c10::npu::GetSocVersion() < c10::npu::SocVersion::Ascend910B1) {
+    return acl_op::im2col(self, kernel_size, dilation, padding, stride);
+  }
+  auto output_size = op_infer::image_to_col_npu_output_size(
+      self, kernel_size, stride, dilation, padding);
+  at::Tensor result =
+      npu_preparation::apply_tensor_without_format(self, output_size);
+  EXEC_NPU_CMD(
+      aclnnIm2col, self, kernel_size, dilation, padding, stride, result);
+  return result;
 }
 
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/base/opapi/NativeDropoutKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/NativeDropoutKernelNpuOpApi.cpp
@@ -14,26 +14,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "npu/framework/utils/RandomOpAdapter.h"
 #include "npu/aten/AclOpsInterface.h"
 #include "npu/aten/OpApiInterface.h"
 #include "npu/aten/utils/op_api_common.h"
+#include "npu/framework/utils/RandomOpAdapter.h"
 
 namespace op_api {
 
 static const int64_t BIT_NUMBER = 128;
 static const int64_t UINT8_BIT_NUMBER = 8;
 
-std::tuple<at::Tensor, at::Tensor> _npu_dropout(const at::Tensor& self, double p) {
+std::tuple<at::Tensor, at::Tensor> _npu_dropout(
+    const at::Tensor& self,
+    double p) {
   DO_COMPATIBILITY(aclnnDropoutGenMaskV2, acl_op::_npu_dropout(self, p));
   DO_COMPATIBILITY(aclnnDropoutDoMask, acl_op::_npu_dropout(self, p));
 
-  int64_t length = (self.numel() + BIT_NUMBER - 1) / BIT_NUMBER * BIT_NUMBER / UINT8_BIT_NUMBER;
-  at::Tensor result = at_npu::native::OpPreparation::apply_tensor_without_format(self);
+  int64_t length = (self.numel() + BIT_NUMBER - 1) / BIT_NUMBER * BIT_NUMBER /
+      UINT8_BIT_NUMBER;
+  at::Tensor result =
+      at_npu::native::OpPreparation::apply_tensor_without_format(self);
   at::Tensor mask;
 
-  auto original_stream = c10_npu::getCurrentNPUStream();
-  mask = at_npu::native::OpPreparation::apply_tensor_without_format({length}, self.options().dtype(at::kByte));
+  auto original_stream = c10::npu::getCurrentNPUStream();
+  mask = at_npu::native::OpPreparation::apply_tensor_without_format(
+      {length}, self.options().dtype(at::kByte));
   at::IntArrayRef shapeArray(self.sizes());
 
   // DropOutGenMask use seed and seed1 to generator a seed, like this:
@@ -42,28 +47,43 @@ std::tuple<at::Tensor, at::Tensor> _npu_dropout(const at::Tensor& self, double p
   // so, we set seed1 = 0 to ensure the seed which user set is equal to the seed
   // used by the operator DropOutGenMask
   const auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto pair = at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(10);
+  auto pair =
+      at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(
+          10);
   // At present, the default value of random number may be very large,
   // which will cause overflow in graph mode, so we set seed = 0 to avoid it.
   const uint64_t seed = pair.first;
   const uint64_t offset = pair.second;
-  aclDataType dataType = at_npu::native::OpPreparation::convert_to_acl_data_type(self.scalar_type());
-  EXEC_NPU_CMD(aclnnDropoutGenMaskV2, shapeArray, p, seed, offset, dataType, mask);
+  aclDataType dataType =
+      at_npu::native::OpPreparation::convert_to_acl_data_type(
+          self.scalar_type());
+  EXEC_NPU_CMD(
+      aclnnDropoutGenMaskV2, shapeArray, p, seed, offset, dataType, mask);
 
   EXEC_NPU_CMD(aclnnDropoutDoMask, self, mask, p, result);
   return std::tie(result, mask);
 }
 
-at::Tensor npu_dropout_backward(const at::Tensor& grad_output, const at::Tensor& mask, double scale) {
-  DO_COMPATIBILITY(aclnnDropoutDoMask, acl_op::npu_dropout_backward(grad_output, mask, scale));
+at::Tensor npu_dropout_backward(
+    const at::Tensor& grad_output,
+    const at::Tensor& mask,
+    double scale) {
+  DO_COMPATIBILITY(
+      aclnnDropoutDoMask,
+      acl_op::npu_dropout_backward(grad_output, mask, scale));
 
-  at::Tensor result = at_npu::native::OpPreparation::apply_tensor_without_format(grad_output);
+  at::Tensor result =
+      at_npu::native::OpPreparation::apply_tensor_without_format(grad_output);
   EXEC_NPU_CMD(aclnnDropoutDoMask, grad_output, mask, scale, result);
   return result;
 }
 
-std::tuple<at::Tensor, at::Tensor> native_dropout(const at::Tensor& input, double p, c10::optional<bool> train) {
-  DO_COMPATIBILITY(aclnnDropoutGenMaskV2, acl_op::native_dropout(input, p, train));
+std::tuple<at::Tensor, at::Tensor> native_dropout(
+    const at::Tensor& input,
+    double p,
+    c10::optional<bool> train) {
+  DO_COMPATIBILITY(
+      aclnnDropoutGenMaskV2, acl_op::native_dropout(input, p, train));
   DO_COMPATIBILITY(aclnnDropoutDoMask, acl_op::native_dropout(input, p, train));
 
   bool dropout_train = !train.has_value() ? true : train.value();
@@ -80,8 +100,13 @@ std::tuple<at::Tensor, at::Tensor> native_dropout(const at::Tensor& input, doubl
   return op_api::_npu_dropout(input, p);
 }
 
-at::Tensor native_dropout_backward(const at::Tensor& grad_output, const at::Tensor& mask, double scale) {
-  DO_COMPATIBILITY(aclnnDropoutDoMask, acl_op::native_dropout_backward(grad_output, mask, scale));
+at::Tensor native_dropout_backward(
+    const at::Tensor& grad_output,
+    const at::Tensor& mask,
+    double scale) {
+  DO_COMPATIBILITY(
+      aclnnDropoutDoMask,
+      acl_op::native_dropout_backward(grad_output, mask, scale));
 
   double p = (scale == 0.0) ? 1 : (1 - 1 / scale);
   if (p == 0) {
@@ -94,4 +119,4 @@ at::Tensor native_dropout_backward(const at::Tensor& grad_output, const at::Tens
   return op_api::npu_dropout_backward(grad_output, mask, p);
 }
 
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/latest/op_api/CopyKernelOpApi.cpp
+++ b/npu/aten/ops/latest/op_api/CopyKernelOpApi.cpp
@@ -18,10 +18,10 @@
 #include "csrc/aten/generated/NPUOpApiNativeFunctions.h"
 #include "csrc/npu/NPUCachingHostAllocator.h"
 #include "npu/aten/common/InnerNpuNativeFunction.h"
+#include "npu/aten/utils/op_api_common.h"
 #include "npu/core/NPUPeerToPeerAccess.h"
 #include "npu/framework/contiguous/ContiguousOpt.h"
 #include "npu/framework/utils/CalcuOpUtil.h"
-#include "npu/aten/utils/op_api_common.h"
 
 namespace at_npu {
 namespace native {
@@ -35,7 +35,7 @@ void copy_between_host_and_device_opapi(
     aclrtMemcpyKind kind,
     bool non_blocking) {
   int64_t nbytes = dst.numel() * dst.element_size();
-  c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
+  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
 
   if (non_blocking) {
     auto ret = CalcuOpUtil::LaunchAsyncCopyTaskWithModeSwitch(
@@ -61,7 +61,7 @@ void copy_between_host_and_device_opapi(
     NPU_CHECK_ERROR(ret, "aclrtMemcpy");
     if (error != ACL_ERROR_NONE) {
       C10_NPU_SHOW_ERR_MSG();
-      if (c10_npu::option::OptionsManager::IsResumeModeEnable()) {
+      if (c10::npu::option::OptionsManager::IsResumeModeEnable()) {
         TORCH_NPU_WARN(
             "ACL stream synchronize failed, error code:",
             error,
@@ -185,8 +185,8 @@ void copy_d2d_baseformat_opapi(
           dst.device().index());
     }
     guard.reset_device(dst.device());
-    c10_npu::NPUStream dst_stream =
-        c10_npu::getCurrentNPUStream(dst.device().index());
+    c10::npu::NPUStream dst_stream =
+        c10::npu::getCurrentNPUStream(dst.device().index());
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(dst_stream, -1));
     guard.reset_device(src.device());
   } else {
@@ -196,7 +196,7 @@ void copy_d2d_baseformat_opapi(
   }
   EXEC_NPU_CMD(aclnnInplaceCopy, dst, src);
   if (dst.device().index() != src.device().index()) {
-    c10_npu::NPUStream copy_stream = c10_npu::getCurrentNPUStream();
+    c10::npu::NPUStream copy_stream = c10::npu::getCurrentNPUStream();
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(copy_stream, -1));
   }
 }

--- a/npu/aten/ops/latest/op_api/ScaledDotProductAttentionKernelNpuOpApi.cpp
+++ b/npu/aten/ops/latest/op_api/ScaledDotProductAttentionKernelNpuOpApi.cpp
@@ -28,127 +28,175 @@ const static int64_t TOKEN_MAX = 2147483647;
 const static int64_t LEFT_UP_CAUSAL = 2;
 
 inline void validate_sdpa_input(
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const c10::optional<at::Tensor> &attn_mask,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const c10::optional<at::Tensor>& attn_mask,
     double dropout_p,
     bool is_causal,
-    c10::optional<double> scale)
-{
-    TORCH_CHECK(query.dtype() == key.dtype() && query.dtype() == value.dtype(),
-        "Expected query, key, and value to have the same dtype, but got query.dtype: ",
-        query.dtype(), " key.dtype: ", key.dtype(), " and value.dtype: ", value.dtype(), " instead." +
-        OPS_ERROR(ErrCode::NOT_SUPPORT));
-    TORCH_CHECK(query.device() == key.device() && query.device() == value.device(),
-        "Expected query, key, and value to have the same device type, but got query.device: ",
-        query.device(), " key.device: ", key.device(), " and value.device: ", value.device(), " instead." +
-        OPS_ERROR(ErrCode::NOT_SUPPORT));
-    TORCH_CHECK(query.dim() >= 2 && key.dim() >= 2 && value.dim() >= 2,
-        "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
-        query.dim(), " key.dim: ", key.dim(), " and value.dim: ", value.dim(), " instead." +
-        OPS_ERROR(ErrCode::NOT_SUPPORT));
-    if (attn_mask.has_value()) {
-        auto mask_dtype = attn_mask->dtype();
-        TORCH_CHECK(mask_dtype == at::kBool || mask_dtype == query.dtype(),
-            "Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: ",
-            mask_dtype, " and  query.dtype: ", query.dtype(), " instead." + OPS_ERROR(ErrCode::NOT_SUPPORT));
-        TORCH_CHECK(!query.is_nested() && !key.is_nested(),
-            "Scaled_dot_product_attention: Nested tensors for query / key are not supported "
-            "when an explicit attn_mask is set" + OPS_ERROR(ErrCode::NOT_SUPPORT));
-    }
-    return;
+    c10::optional<double> scale) {
+  TORCH_CHECK(
+      query.dtype() == key.dtype() && query.dtype() == value.dtype(),
+      "Expected query, key, and value to have the same dtype, but got query.dtype: ",
+      query.dtype(),
+      " key.dtype: ",
+      key.dtype(),
+      " and value.dtype: ",
+      value.dtype(),
+      " instead." + OPS_ERROR(ErrCode::NOT_SUPPORT));
+  TORCH_CHECK(
+      query.device() == key.device() && query.device() == value.device(),
+      "Expected query, key, and value to have the same device type, but got query.device: ",
+      query.device(),
+      " key.device: ",
+      key.device(),
+      " and value.device: ",
+      value.device(),
+      " instead." + OPS_ERROR(ErrCode::NOT_SUPPORT));
+  TORCH_CHECK(
+      query.dim() >= 2 && key.dim() >= 2 && value.dim() >= 2,
+      "Expected query, key, and value to all be  at least 2 dimensional, but got query.dim: ",
+      query.dim(),
+      " key.dim: ",
+      key.dim(),
+      " and value.dim: ",
+      value.dim(),
+      " instead." + OPS_ERROR(ErrCode::NOT_SUPPORT));
+  if (attn_mask.has_value()) {
+    auto mask_dtype = attn_mask->dtype();
+    TORCH_CHECK(
+        mask_dtype == at::kBool || mask_dtype == query.dtype(),
+        "Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: ",
+        mask_dtype,
+        " and  query.dtype: ",
+        query.dtype(),
+        " instead." + OPS_ERROR(ErrCode::NOT_SUPPORT));
+    TORCH_CHECK(
+        !query.is_nested() && !key.is_nested(),
+        "Scaled_dot_product_attention: Nested tensors for query / key are not supported "
+        "when an explicit attn_mask is set" +
+            OPS_ERROR(ErrCode::NOT_SUPPORT));
+  }
+  return;
 }
 
 c10::optional<at::Tensor> convert_boolean_attn_mask_math(
-    const c10::optional<at::Tensor> &attn_mask,
-    caffe2::TypeMeta dtype)
-{
-    if (!attn_mask.has_value()) {
-        return c10::nullopt;
-    }
-    if (attn_mask->dtype() == at::kBool) {
-        auto new_attn_mask = at::zeros_like(attn_mask.value(), dtype);
-        new_attn_mask.masked_fill_(attn_mask->logical_not(), -std::numeric_limits<double>::infinity());
-        return new_attn_mask;
-    }
-    return attn_mask;
+    const c10::optional<at::Tensor>& attn_mask,
+    caffe2::TypeMeta dtype) {
+  if (!attn_mask.has_value()) {
+    return c10::nullopt;
+  }
+  if (attn_mask->dtype() == at::kBool) {
+    auto new_attn_mask = at::zeros_like(attn_mask.value(), dtype);
+    new_attn_mask.masked_fill_(
+        attn_mask->logical_not(), -std::numeric_limits<double>::infinity());
+    return new_attn_mask;
+  }
+  return attn_mask;
 }
 
 c10::optional<at::Tensor> convert_boolean_attn_mask(
-    const at::Tensor &query,
-    const c10::optional<at::Tensor> &attn_mask,
-    bool is_causal)
-{
-    if (!attn_mask.has_value() && !is_causal) {
-        return c10::nullopt;
-    }
-    if (is_causal) {
-        TORCH_CHECK(!attn_mask.has_value(),
-            "The attn_mask should be none when is_causal is true, but got ",
-            attn_mask.has_value(), "-value");
-        at::Tensor atten_mask_shape = at::ones({ATTENMASK_LIMIT, ATTENMASK_LIMIT}, query.options().dtype(at::kBool));
-        auto new_attn_mask = op_api::triu(atten_mask_shape, 1);
-        return new_attn_mask;
-    }
-    const at::Tensor &atten_mask_in = attn_mask.value_or(at::Tensor());
-    at::Tensor atten_mask = op_api::logical_not(atten_mask_in);
-    return atten_mask;
+    const at::Tensor& query,
+    const c10::optional<at::Tensor>& attn_mask,
+    bool is_causal) {
+  if (!attn_mask.has_value() && !is_causal) {
+    return c10::nullopt;
+  }
+  if (is_causal) {
+    TORCH_CHECK(
+        !attn_mask.has_value(),
+        "The attn_mask should be none when is_causal is true, but got ",
+        attn_mask.has_value(),
+        "-value");
+    at::Tensor atten_mask_shape = at::ones(
+        {ATTENMASK_LIMIT, ATTENMASK_LIMIT}, query.options().dtype(at::kBool));
+    auto new_attn_mask = op_api::triu(atten_mask_shape, 1);
+    return new_attn_mask;
+  }
+  const at::Tensor& atten_mask_in = attn_mask.value_or(at::Tensor());
+  at::Tensor atten_mask = op_api::logical_not(atten_mask_in);
+  return atten_mask;
 }
 
 inline c10::SymFloat calculate_scale(
-    const at::Tensor &query,
-    c10::optional<double> scale)
-{
-    const auto softmax_scale = scale.has_value()
-        ? scale.value()
-        : (c10::SymFloat(1.0) / (c10::SymFloat(query.sym_size(-1)).sqrt()));
-    return c10::SymFloat(softmax_scale);
+    const at::Tensor& query,
+    c10::optional<double> scale) {
+  const auto softmax_scale = scale.has_value()
+      ? scale.value()
+      : (c10::SymFloat(1.0) / (c10::SymFloat(query.sym_size(-1)).sqrt()));
+  return c10::SymFloat(softmax_scale);
 }
 
 at::Tensor scaled_dot_product_attention(
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const c10::optional<at::Tensor> &attn_mask,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const c10::optional<at::Tensor>& attn_mask,
     double dropout_p,
     bool is_causal,
-    c10::optional<double> scale)
-{
-    validate_sdpa_input(query, key, value, attn_mask, dropout_p, is_causal, scale);
-    if (query.requires_grad() && key.requires_grad() && value.requires_grad() &&
-        (query.scalar_type() == at::kHalf || query.scalar_type() == at::kBFloat16) &&
-        ((attn_mask.has_value() && attn_mask->dtype() == at::kBool) || !attn_mask.has_value()) &&
-        query.dim() == BNSD_DIM && key.dim() == BNSD_DIM && value.dim() == BNSD_DIM &&
-        query.size(1) <= N_LIMIT && query.size(3) <= D_LIMIT && key.size(1) <= N_LIMIT &&
-        query.size(1) % key.size(1) == 0 && query.size(1) / key.size(1) > 0 &&
-        c10_npu::GetSocVersion() >= c10_npu::SocVersion::Ascend910B1) {
-        /* The implementation of the NPU FlashAttention fusion operator constraints:
-           1. The attn_mask supports only the bool data type.
-           2. The shape [B, N1, S1, D] of the query is suppported, where N1 <= N_LIMIT,
-              D <= D_LIMIT and dim == BNSD_DIM.
-           3. For GQA, the key shape is [B, N2, S2, D], where N2 <= N_LIMIT, and N1 is a positive integer
-              multiple of N2.
-           4. It only supports SocVersion after Ascend910B1. */
-        c10::optional<at::Tensor> atten_mask = convert_boolean_attn_mask(query, attn_mask, is_causal);
-        int64_t head_num = query.size(1);
-        c10::string_view input_layout = "BNSD";
-        auto input_scale = calculate_scale(query, scale);
-        double keep_prob = 1 - dropout_p;
-        int64_t next_tockens = is_causal ? 0 : TOKEN_MAX;
-        int64_t sparse_mode = is_causal ? LEFT_UP_CAUSAL : 0;
-        c10::optional<at::Tensor> nulltensor = c10::nullopt;
-        c10::OptionalIntArrayRef nulllen = c10::nullopt;
-        auto output =
-            at_npu::native::custom_ops::npu_fusion_attention(query, key, value, head_num, input_layout, nulltensor,
-                                                             nulltensor, atten_mask, input_scale.as_float_unchecked(),
-                                                             keep_prob, TOKEN_MAX, next_tockens, 0, nulllen,
-                                                             nulllen, nulllen, sparse_mode, true, false);
-        return std::get<0>(output);
-    }
-    c10::optional<at::Tensor> atten_mask_math = convert_boolean_attn_mask_math(attn_mask, query.dtype());
-    auto output = at::_scaled_dot_product_attention_math(query, key, value, atten_mask_math, dropout_p, is_causal,
-                                                         c10::nullopt, scale);
+    c10::optional<double> scale) {
+  validate_sdpa_input(
+      query, key, value, attn_mask, dropout_p, is_causal, scale);
+  if (query.requires_grad() && key.requires_grad() && value.requires_grad() &&
+      (query.scalar_type() == at::kHalf ||
+       query.scalar_type() == at::kBFloat16) &&
+      ((attn_mask.has_value() && attn_mask->dtype() == at::kBool) ||
+       !attn_mask.has_value()) &&
+      query.dim() == BNSD_DIM && key.dim() == BNSD_DIM &&
+      value.dim() == BNSD_DIM && query.size(1) <= N_LIMIT &&
+      query.size(3) <= D_LIMIT && key.size(1) <= N_LIMIT &&
+      query.size(1) % key.size(1) == 0 && query.size(1) / key.size(1) > 0 &&
+      c10::npu::GetSocVersion() >= c10::npu::SocVersion::Ascend910B1) {
+    /* The implementation of the NPU FlashAttention fusion operator constraints:
+       1. The attn_mask supports only the bool data type.
+       2. The shape [B, N1, S1, D] of the query is suppported, where N1 <=
+       N_LIMIT, D <= D_LIMIT and dim == BNSD_DIM.
+       3. For GQA, the key shape is [B, N2, S2, D], where N2 <= N_LIMIT, and N1
+       is a positive integer multiple of N2.
+       4. It only supports SocVersion after Ascend910B1. */
+    c10::optional<at::Tensor> atten_mask =
+        convert_boolean_attn_mask(query, attn_mask, is_causal);
+    int64_t head_num = query.size(1);
+    c10::string_view input_layout = "BNSD";
+    auto input_scale = calculate_scale(query, scale);
+    double keep_prob = 1 - dropout_p;
+    int64_t next_tockens = is_causal ? 0 : TOKEN_MAX;
+    int64_t sparse_mode = is_causal ? LEFT_UP_CAUSAL : 0;
+    c10::optional<at::Tensor> nulltensor = c10::nullopt;
+    c10::OptionalIntArrayRef nulllen = c10::nullopt;
+    auto output = at_npu::native::custom_ops::npu_fusion_attention(
+        query,
+        key,
+        value,
+        head_num,
+        input_layout,
+        nulltensor,
+        nulltensor,
+        atten_mask,
+        input_scale.as_float_unchecked(),
+        keep_prob,
+        TOKEN_MAX,
+        next_tockens,
+        0,
+        nulllen,
+        nulllen,
+        nulllen,
+        sparse_mode,
+        true,
+        false);
     return std::get<0>(output);
+  }
+  c10::optional<at::Tensor> atten_mask_math =
+      convert_boolean_attn_mask_math(attn_mask, query.dtype());
+  auto output = at::_scaled_dot_product_attention_math(
+      query,
+      key,
+      value,
+      atten_mask_math,
+      dropout_p,
+      is_causal,
+      c10::nullopt,
+      scale);
+  return std::get<0>(output);
 }
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/utils/op_api_common.h
+++ b/npu/aten/utils/op_api_common.h
@@ -16,22 +16,22 @@
 #ifndef TORCHNPU_TORCH_NPU_CSRC_ATEN_OPS_OP_API_PTA_COMMON_H_
 #define TORCHNPU_TORCH_NPU_CSRC_ATEN_OPS_OP_API_PTA_COMMON_H_
 
-#include <fstream>
-#include <sys/stat.h>
-#include <dlfcn.h>
-#include <vector>
-#include <functional>
-#include <type_traits>
 #include <ATen/Tensor.h>
 #include <acl/acl_base.h>
+#include <dlfcn.h>
+#include <sys/stat.h>
+#include <fstream>
+#include <functional>
+#include <type_traits>
+#include <vector>
+#include "csrc/aten/generated/NPUNativeFunctions.h"
+#include "csrc/npu/NPUStream.h"
 #include "npu/aten/utils/KernelNpuOutputSize.h"
 #include "npu/aten/utils/OpConstants.h"
 #include "npu/aten/utils/OpUtils.h"
-#include "csrc/npu/NPUStream.h"
 #include "npu/framework/OpCommand.h"
-#include "npu/framework/utils/OpPreparation.h"
 #include "npu/framework/interface/EnvVariables.h"
-#include "csrc/aten/generated/NPUNativeFunctions.h"
+#include "npu/framework/utils/OpPreparation.h"
 
 typedef struct aclOpExecutor aclOpExecutor;
 typedef struct aclTensor aclTensor;
@@ -42,25 +42,35 @@ typedef struct aclBoolArray aclBoolArray;
 typedef struct aclTensorList aclTensorList;
 typedef struct aclScalarList aclScalarList;
 
-typedef aclTensor *(*_aclCreateTensor)(const int64_t *view_dims, uint64_t view_dims_num, aclDataType data_type,
-                                       const int64_t *stride, int64_t offset, aclFormat format,
-                                       const int64_t *storage_dims, uint64_t storage_dims_num, void *tensor_data);
-typedef aclScalar *(*_aclCreateScalar)(void *value, aclDataType data_type);
-typedef aclIntArray *(*_aclCreateIntArray)(const int64_t *value, uint64_t size);
-typedef aclFloatArray *(*_aclCreateFloatArray)(const float *value, uint64_t size);
-typedef aclBoolArray *(*_aclCreateBoolArray)(const bool *value, uint64_t size);
-typedef aclTensorList *(*_aclCreateTensorList)(const aclTensor *const *value, uint64_t size);
-typedef aclScalarList *(*_aclCreateScalarList)(const aclScalar *const *value, uint64_t size);
+typedef aclTensor* (*_aclCreateTensor)(
+    const int64_t* view_dims,
+    uint64_t view_dims_num,
+    aclDataType data_type,
+    const int64_t* stride,
+    int64_t offset,
+    aclFormat format,
+    const int64_t* storage_dims,
+    uint64_t storage_dims_num,
+    void* tensor_data);
+typedef aclScalar* (*_aclCreateScalar)(void* value, aclDataType data_type);
+typedef aclIntArray* (*_aclCreateIntArray)(const int64_t* value, uint64_t size);
+typedef aclFloatArray* (
+    *_aclCreateFloatArray)(const float* value, uint64_t size);
+typedef aclBoolArray* (*_aclCreateBoolArray)(const bool* value, uint64_t size);
+typedef aclTensorList* (
+    *_aclCreateTensorList)(const aclTensor* const* value, uint64_t size);
+typedef aclScalarList* (
+    *_aclCreateScalarList)(const aclScalar* const* value, uint64_t size);
 
-typedef int (*_aclDestroyTensor)(const aclTensor *tensor);
-typedef int (*_aclDestroyScalar)(const aclScalar *scalar);
-typedef int (*_aclDestroyIntArray)(const aclIntArray *array);
-typedef int (*_aclDestroyFloatArray)(const aclFloatArray *array);
-typedef int (*_aclDestroyBoolArray)(const aclBoolArray *array);
-typedef int (*_aclDestroyTensorList)(const aclTensorList *array);
-typedef int (*_aclDestroyScalarList)(const aclScalarList *array);
+typedef int (*_aclDestroyTensor)(const aclTensor* tensor);
+typedef int (*_aclDestroyScalar)(const aclScalar* scalar);
+typedef int (*_aclDestroyIntArray)(const aclIntArray* array);
+typedef int (*_aclDestroyFloatArray)(const aclFloatArray* array);
+typedef int (*_aclDestroyBoolArray)(const aclBoolArray* array);
+typedef int (*_aclDestroyTensorList)(const aclTensorList* array);
+typedef int (*_aclDestroyScalarList)(const aclScalarList* array);
 
-using OpApiFunc = int (*)(void *, uint64_t, aclOpExecutor *, const aclrtStream);
+using OpApiFunc = int (*)(void*, uint64_t, aclOpExecutor*, const aclrtStream);
 
 constexpr int g_hash_buf_size = 8192;
 constexpr int g_hash_buf_max_size = g_hash_buf_size + 1024;
@@ -69,861 +79,1030 @@ extern thread_local int g_hash_offset;
 extern const std::vector<std::string> g_custom_lib_path;
 extern const std::vector<std::string> g_default_custom_lib_path;
 
-std::string real_path(const std::string &path);
+std::string real_path(const std::string& path);
 
-#define GET_OP_API_FUNC(apiName) reinterpret_cast<_##apiName>(GetOpApiFuncAddr(#apiName))
+#define GET_OP_API_FUNC(apiName) \
+  reinterpret_cast<_##apiName>(GetOpApiFuncAddr(#apiName))
 
-#define MEMCPY_TO_BUF(data_expression, size_expression)                                                                \
-    if (g_hash_offset + (size_expression) > g_hash_buf_size) {                                                         \
-        g_hash_offset = g_hash_buf_max_size;                                                                           \
-        return;                                                                                                        \
-    }                                                                                                                  \
-    memcpy(g_hash_buf + g_hash_offset, data_expression, size_expression);                                              \
-    g_hash_offset += size_expression;
+#define MEMCPY_TO_BUF(data_expression, size_expression)                 \
+  if (g_hash_offset + (size_expression) > g_hash_buf_size) {            \
+    g_hash_offset = g_hash_buf_max_size;                                \
+    return;                                                             \
+  }                                                                     \
+  memcpy(g_hash_buf + g_hash_offset, data_expression, size_expression); \
+  g_hash_offset += size_expression;
 
-inline const char *GetOpApiLibName(void)
-{
-    return "libopapi.so";
+inline const char* GetOpApiLibName(void) {
+  return "libopapi.so";
 }
 
-inline const char *GetCustOpApiLibName(void)
-{
-    return "libcust_opapi.so";
+inline const char* GetCustOpApiLibName(void) {
+  return "libcust_opapi.so";
 }
 
-inline void *GetOpApiFuncAddrInLib(void *handler, const char *libName, const char *apiName)
-{
-    auto funcAddr = dlsym(handler, apiName);
-    if (funcAddr == nullptr) {
-        ASCEND_LOGW("dlsym %s from %s failed, error:%s.", apiName, libName, dlerror());
-    }
-    return funcAddr;
+inline void* GetOpApiFuncAddrInLib(
+    void* handler,
+    const char* libName,
+    const char* apiName) {
+  auto funcAddr = dlsym(handler, apiName);
+  if (funcAddr == nullptr) {
+    ASCEND_LOGW(
+        "dlsym %s from %s failed, error:%s.", apiName, libName, dlerror());
+  }
+  return funcAddr;
 }
 
-inline void *GetOpApiLibHandler(const char *libName)
-{
-    auto handler = dlopen(libName, RTLD_LAZY);
-    if (handler == nullptr) {
-        ASCEND_LOGW("dlopen %s failed, error:%s.", libName, dlerror());
-    }
-    return handler;
+inline void* GetOpApiLibHandler(const char* libName) {
+  auto handler = dlopen(libName, RTLD_LAZY);
+  if (handler == nullptr) {
+    ASCEND_LOGW("dlopen %s failed, error:%s.", libName, dlerror());
+  }
+  return handler;
 }
 
-#define GET_OP_API_FUNC_FROM_FEATURE_LIB(lib_handler, lib_name)                                                        \
-    static auto lib_handler = GetOpApiLibHandler(lib_name);                                                            \
-    if ((lib_handler) != nullptr) {                                                                                      \
-        auto funcAddr = GetOpApiFuncAddrInLib(lib_handler, lib_name, api_name);                                        \
-        if (funcAddr != nullptr) {                                                                                     \
-            return funcAddr;                                                                                           \
-        }                                                                                                              \
-    }
+#define GET_OP_API_FUNC_FROM_FEATURE_LIB(lib_handler, lib_name)             \
+  static auto lib_handler = GetOpApiLibHandler(lib_name);                   \
+  if ((lib_handler) != nullptr) {                                           \
+    auto funcAddr = GetOpApiFuncAddrInLib(lib_handler, lib_name, api_name); \
+    if (funcAddr != nullptr) {                                              \
+      return funcAddr;                                                      \
+    }                                                                       \
+  }
 
-void *GetOpApiFuncAddrFromFeatureLib(const char *api_name);
+void* GetOpApiFuncAddrFromFeatureLib(const char* api_name);
 
-inline void *GetOpApiFuncAddr(const char *apiName)
-{
-    if (!g_custom_lib_path.empty()) {
-        for (auto &it : g_custom_lib_path) {
-            auto cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
-            if (cust_opapi_lib.empty()) {
-                break;
-            }
-            auto custOpApiHandler = GetOpApiLibHandler(cust_opapi_lib.c_str());
-            if (custOpApiHandler != nullptr) {
-                auto funcAddr =
-                    GetOpApiFuncAddrInLib(custOpApiHandler, GetCustOpApiLibName(), apiName);
-                if (funcAddr != nullptr) {
-                    ASCEND_LOGI("%s is found in %s.", apiName, cust_opapi_lib.c_str());
-                    return funcAddr;
-                }
-            }
-        }
-        ASCEND_LOGI("%s is not in custom lib.", apiName);
-    }
-
-    if (!g_default_custom_lib_path.empty()) {
-        for (auto &it : g_default_custom_lib_path) {
-            auto default_cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
-            if (default_cust_opapi_lib.empty()) {
-                break;
-            }
-            auto custOpApiHandler = GetOpApiLibHandler(default_cust_opapi_lib.c_str());
-            if (custOpApiHandler != nullptr) {
-                auto funcAddr =
-                    GetOpApiFuncAddrInLib(custOpApiHandler, GetCustOpApiLibName(), apiName);
-                if (funcAddr != nullptr) {
-                    ASCEND_LOGI("%s is found in %s.", apiName, default_cust_opapi_lib.c_str());
-                    return funcAddr;
-                }
-            }
-        }
-        ASCEND_LOGI("%s is not in default custom lib.", apiName);
-    }
-
-    static auto opApiHandler = GetOpApiLibHandler(GetOpApiLibName());
-    if (opApiHandler != nullptr) {
-        auto funcAddr = GetOpApiFuncAddrInLib(opApiHandler, GetOpApiLibName(), apiName);
+inline void* GetOpApiFuncAddr(const char* apiName) {
+  if (!g_custom_lib_path.empty()) {
+    for (auto& it : g_custom_lib_path) {
+      auto cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
+      if (cust_opapi_lib.empty()) {
+        break;
+      }
+      auto custOpApiHandler = GetOpApiLibHandler(cust_opapi_lib.c_str());
+      if (custOpApiHandler != nullptr) {
+        auto funcAddr = GetOpApiFuncAddrInLib(
+            custOpApiHandler, GetCustOpApiLibName(), apiName);
         if (funcAddr != nullptr) {
-            return funcAddr;
+          ASCEND_LOGI("%s is found in %s.", apiName, cust_opapi_lib.c_str());
+          return funcAddr;
         }
+      }
     }
-    return GetOpApiFuncAddrFromFeatureLib(apiName);
+    ASCEND_LOGI("%s is not in custom lib.", apiName);
+  }
+
+  if (!g_default_custom_lib_path.empty()) {
+    for (auto& it : g_default_custom_lib_path) {
+      auto default_cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
+      if (default_cust_opapi_lib.empty()) {
+        break;
+      }
+      auto custOpApiHandler =
+          GetOpApiLibHandler(default_cust_opapi_lib.c_str());
+      if (custOpApiHandler != nullptr) {
+        auto funcAddr = GetOpApiFuncAddrInLib(
+            custOpApiHandler, GetCustOpApiLibName(), apiName);
+        if (funcAddr != nullptr) {
+          ASCEND_LOGI(
+              "%s is found in %s.", apiName, default_cust_opapi_lib.c_str());
+          return funcAddr;
+        }
+      }
+    }
+    ASCEND_LOGI("%s is not in default custom lib.", apiName);
+  }
+
+  static auto opApiHandler = GetOpApiLibHandler(GetOpApiLibName());
+  if (opApiHandler != nullptr) {
+    auto funcAddr =
+        GetOpApiFuncAddrInLib(opApiHandler, GetOpApiLibName(), apiName);
+    if (funcAddr != nullptr) {
+      return funcAddr;
+    }
+  }
+  return GetOpApiFuncAddrFromFeatureLib(apiName);
 }
 
-inline aclTensor *ConvertType(const at::Tensor &at_tensor)
-{
-    static const auto aclCreateTensor = GET_OP_API_FUNC(aclCreateTensor);
-    if (aclCreateTensor == nullptr) {
-        return nullptr;
-    }
-
-    if (!at_tensor.defined()) {
-        return nullptr;
-    }
-    TORCH_CHECK(torch_npu::utils::is_npu(at_tensor), "only npu tensor is supported", OPS_ERROR(ErrCode::PARAM));
-    at::ScalarType scalar_data_type = at_tensor.scalar_type();
-    aclDataType acl_data_type = at_npu::native::OpPreparation::convert_to_acl_data_type(scalar_data_type);
-    c10::SmallVector<int64_t, 5> storageDims;
-    // if acl_data_type is ACL_STRING, storageDims is empty.
-    if (acl_data_type != ACL_STRING) {
-        TORCH_CHECK(at_tensor.itemsize() > 0, "the itemsize of tensor must be greater than 0.",
-            OPS_ERROR(ErrCode::VALUE));
-        storageDims.push_back(at_tensor.storage().nbytes() / at_tensor.itemsize());
-    }
-
-    const auto dimNum = at_tensor.sizes().size();
-    aclFormat format = ACL_FORMAT_ND;
-    switch (dimNum) {
-        case 3:
-            format = ACL_FORMAT_NCL;
-            break;
-        case 4:
-            format = ACL_FORMAT_NCHW;
-            break;
-        case 5:
-            format = ACL_FORMAT_NCDHW;
-            break;
-        default:
-            format = ACL_FORMAT_ND;
-    }
-
-    if (at_npu::native::OpPreparation::is_scalar_wrapped_to_tensor(at_tensor)) {
-        c10::Scalar expScalar = at_tensor.item();
-        at::Tensor aclInput = at_npu::native::OpPreparation::copy_scalar_to_device(expScalar, scalar_data_type);
-        return aclCreateTensor(aclInput.sizes().data(), aclInput.sizes().size(), acl_data_type,
-                               aclInput.strides().data(), aclInput.storage_offset(), format, storageDims.data(),
-                               storageDims.size(), const_cast<void *>(aclInput.storage().data()));
-    }
-
-    auto acl_tensor =
-        aclCreateTensor(at_tensor.sizes().data(), at_tensor.sizes().size(), acl_data_type, at_tensor.strides().data(),
-                        at_tensor.storage_offset(), format, storageDims.data(), storageDims.size(),
-                        const_cast<void *>(at_tensor.storage().data()));
-    return acl_tensor;
-}
-
-inline aclScalar *ConvertType(const at::Scalar &at_scalar)
-{
-    static const auto aclCreateScalar = GET_OP_API_FUNC(aclCreateScalar);
-    if (aclCreateScalar == nullptr) {
-        return nullptr;
-    }
-
-    at::ScalarType scalar_data_type = at_scalar.type();
-    aclDataType acl_data_type = at_npu::native::OpPreparation::convert_to_acl_data_type(scalar_data_type);
-    aclScalar *acl_scalar = nullptr;
-    switch (scalar_data_type) {
-        case at::ScalarType::Double:
-            {
-                double value = at_scalar.toDouble();
-                acl_scalar = aclCreateScalar(&value, acl_data_type);
-                break;
-            }
-        case at::ScalarType::Long:
-            {
-                int64_t value = at_scalar.toLong();
-                acl_scalar = aclCreateScalar(&value, acl_data_type);
-                break;
-            }
-        case at::ScalarType::Bool:
-            {
-                bool value = at_scalar.toBool();
-                acl_scalar = aclCreateScalar(&value, acl_data_type);
-                break;
-            }
-        case at::ScalarType::ComplexDouble:
-            {
-                auto value = at_scalar.toComplexDouble();
-                acl_scalar = aclCreateScalar(&value, acl_data_type);
-                break;
-            }
-        default:
-            acl_scalar = nullptr;
-            break;
-    }
-
-    return acl_scalar;
-}
-
-inline aclIntArray *ConvertType(const at::IntArrayRef &at_array)
-{
-    static const auto aclCreateIntArray = GET_OP_API_FUNC(aclCreateIntArray);
-    if (aclCreateIntArray == nullptr) {
-        return nullptr;
-    }
-    auto array = aclCreateIntArray(at_array.data(), at_array.size());
-    return array;
-}
-
-template <std::size_t N> inline aclBoolArray *ConvertType(const std::array<bool, N> &value)
-{
-    static const auto aclCreateBoolArray = GET_OP_API_FUNC(aclCreateBoolArray);
-    if (aclCreateBoolArray == nullptr) {
-        return nullptr;
-    }
-
-    auto array = aclCreateBoolArray(value.data(), value.size());
-    return array;
-}
-
-inline aclBoolArray *ConvertType(const at::ArrayRef<bool> &value)
-{
-    static const auto aclCreateBoolArray = GET_OP_API_FUNC(aclCreateBoolArray);
-    if (aclCreateBoolArray == nullptr) {
-        return nullptr;
-    }
-
-    auto array = aclCreateBoolArray(value.data(), value.size());
-    return array;
-}
-
-inline aclTensorList *ConvertType(const at::TensorList &at_tensor_list)
-{
-    static const auto aclCreateTensorList = GET_OP_API_FUNC(aclCreateTensorList);
-    if (aclCreateTensorList == nullptr) {
-        return nullptr;
-    }
-
-    std::vector<const aclTensor *> tensor_list(at_tensor_list.size());
-    for (size_t i = 0; i < at_tensor_list.size(); i++) {
-        tensor_list[i] = ConvertType(at_tensor_list[i]);
-    }
-    auto acl_tensor_list = aclCreateTensorList(tensor_list.data(), tensor_list.size());
-    return acl_tensor_list;
-}
-
-inline aclScalarList *ConvertType(const at::ArrayRef<at::Scalar> &at_scalar_list)
-{
-    static const auto aclCreateScalarList = GET_OP_API_FUNC(aclCreateScalarList);
-    if (aclCreateScalarList == nullptr) {
-        return nullptr;
-    }
-
-    std::vector<const aclScalar *> scalar_list(at_scalar_list.size());
-    for (size_t i = 0; i < at_scalar_list.size(); i++) {
-        scalar_list[i] = ConvertType(at_scalar_list[i]);
-    }
-    auto acl_scalar_list = aclCreateScalarList(scalar_list.data(), scalar_list.size());
-    return acl_scalar_list;
-}
-
-inline aclTensor *ConvertType(const c10::optional<at::Tensor> &opt_tensor)
-{
-    if (opt_tensor.has_value() && opt_tensor.value().defined()) {
-        return ConvertType(opt_tensor.value());
-    }
-
+inline aclTensor* ConvertType(const at::Tensor& at_tensor) {
+  static const auto aclCreateTensor = GET_OP_API_FUNC(aclCreateTensor);
+  if (aclCreateTensor == nullptr) {
     return nullptr;
-}
+  }
 
-inline aclIntArray *ConvertType(const c10::optional<at::IntArrayRef> &opt_array)
-{
-    if (opt_array.has_value()) {
-        return ConvertType(opt_array.value());
-    }
-
+  if (!at_tensor.defined()) {
     return nullptr;
+  }
+  TORCH_CHECK(
+      torch_npu::utils::is_npu(at_tensor),
+      "only npu tensor is supported",
+      OPS_ERROR(ErrCode::PARAM));
+  at::ScalarType scalar_data_type = at_tensor.scalar_type();
+  aclDataType acl_data_type =
+      at_npu::native::OpPreparation::convert_to_acl_data_type(scalar_data_type);
+  c10::SmallVector<int64_t, 5> storageDims;
+  // if acl_data_type is ACL_STRING, storageDims is empty.
+  if (acl_data_type != ACL_STRING) {
+    TORCH_CHECK(
+        at_tensor.itemsize() > 0,
+        "the itemsize of tensor must be greater than 0.",
+        OPS_ERROR(ErrCode::VALUE));
+    storageDims.push_back(at_tensor.storage().nbytes() / at_tensor.itemsize());
+  }
+
+  const auto dimNum = at_tensor.sizes().size();
+  aclFormat format = ACL_FORMAT_ND;
+  switch (dimNum) {
+    case 3:
+      format = ACL_FORMAT_NCL;
+      break;
+    case 4:
+      format = ACL_FORMAT_NCHW;
+      break;
+    case 5:
+      format = ACL_FORMAT_NCDHW;
+      break;
+    default:
+      format = ACL_FORMAT_ND;
+  }
+
+  if (at_npu::native::OpPreparation::is_scalar_wrapped_to_tensor(at_tensor)) {
+    c10::Scalar expScalar = at_tensor.item();
+    at::Tensor aclInput = at_npu::native::OpPreparation::copy_scalar_to_device(
+        expScalar, scalar_data_type);
+    return aclCreateTensor(
+        aclInput.sizes().data(),
+        aclInput.sizes().size(),
+        acl_data_type,
+        aclInput.strides().data(),
+        aclInput.storage_offset(),
+        format,
+        storageDims.data(),
+        storageDims.size(),
+        const_cast<void*>(aclInput.storage().data()));
+  }
+
+  auto acl_tensor = aclCreateTensor(
+      at_tensor.sizes().data(),
+      at_tensor.sizes().size(),
+      acl_data_type,
+      at_tensor.strides().data(),
+      at_tensor.storage_offset(),
+      format,
+      storageDims.data(),
+      storageDims.size(),
+      const_cast<void*>(at_tensor.storage().data()));
+  return acl_tensor;
 }
 
-inline aclScalar *ConvertType(const c10::optional<at::Scalar> &opt_scalar)
-{
-    if (opt_scalar.has_value()) {
-        return ConvertType(opt_scalar.value());
-    }
-
+inline aclScalar* ConvertType(const at::Scalar& at_scalar) {
+  static const auto aclCreateScalar = GET_OP_API_FUNC(aclCreateScalar);
+  if (aclCreateScalar == nullptr) {
     return nullptr;
-}
+  }
 
-inline aclDataType ConvertType(const at::ScalarType scalarType)
-{
-    return at_npu::native::OpPreparation::convert_to_acl_data_type(scalarType);
-}
-
-template <typename T> T ConvertType(T value)
-{
-    return value;
-}
-
-inline void Release(aclTensor *p)
-{
-    static const auto aclDestroyTensor = GET_OP_API_FUNC(aclDestroyTensor);
-    if (aclDestroyTensor == nullptr) {
-        return;
+  at::ScalarType scalar_data_type = at_scalar.type();
+  aclDataType acl_data_type =
+      at_npu::native::OpPreparation::convert_to_acl_data_type(scalar_data_type);
+  aclScalar* acl_scalar = nullptr;
+  switch (scalar_data_type) {
+    case at::ScalarType::Double: {
+      double value = at_scalar.toDouble();
+      acl_scalar = aclCreateScalar(&value, acl_data_type);
+      break;
     }
-    aclDestroyTensor(p);
-}
-
-inline void Release(aclScalar *p)
-{
-    static const auto aclDestroyScalar = GET_OP_API_FUNC(aclDestroyScalar);
-    if (aclDestroyScalar == nullptr) {
-        return;
+    case at::ScalarType::Long: {
+      int64_t value = at_scalar.toLong();
+      acl_scalar = aclCreateScalar(&value, acl_data_type);
+      break;
     }
-    aclDestroyScalar(p);
-}
-
-inline void Release(aclIntArray *p)
-{
-    static const auto aclDestroyIntArray = GET_OP_API_FUNC(aclDestroyIntArray);
-    if (aclDestroyIntArray == nullptr) {
-        return;
+    case at::ScalarType::Bool: {
+      bool value = at_scalar.toBool();
+      acl_scalar = aclCreateScalar(&value, acl_data_type);
+      break;
     }
-
-    aclDestroyIntArray(p);
-}
-
-inline void Release(aclBoolArray *p)
-{
-    static const auto aclDestroyBoolArray = GET_OP_API_FUNC(aclDestroyBoolArray);
-    if (aclDestroyBoolArray == nullptr) {
-        return;
+    case at::ScalarType::ComplexDouble: {
+      auto value = at_scalar.toComplexDouble();
+      acl_scalar = aclCreateScalar(&value, acl_data_type);
+      break;
     }
+    default:
+      acl_scalar = nullptr;
+      break;
+  }
 
-    aclDestroyBoolArray(p);
+  return acl_scalar;
 }
 
-inline void Release(aclTensorList *p)
-{
-    static const auto aclDestroyTensorList = GET_OP_API_FUNC(aclDestroyTensorList);
-    if (aclDestroyTensorList == nullptr) {
-        return;
-    }
-
-    aclDestroyTensorList(p);
+inline aclIntArray* ConvertType(const at::IntArrayRef& at_array) {
+  static const auto aclCreateIntArray = GET_OP_API_FUNC(aclCreateIntArray);
+  if (aclCreateIntArray == nullptr) {
+    return nullptr;
+  }
+  auto array = aclCreateIntArray(at_array.data(), at_array.size());
+  return array;
 }
 
-inline void Release(aclScalarList *p)
-{
-    static const auto aclDestroyScalarList = GET_OP_API_FUNC(aclDestroyScalarList);
-    if (aclDestroyScalarList == nullptr) {
-        return;
-    }
+template <std::size_t N>
+inline aclBoolArray* ConvertType(const std::array<bool, N>& value) {
+  static const auto aclCreateBoolArray = GET_OP_API_FUNC(aclCreateBoolArray);
+  if (aclCreateBoolArray == nullptr) {
+    return nullptr;
+  }
 
-    aclDestroyScalarList(p);
+  auto array = aclCreateBoolArray(value.data(), value.size());
+  return array;
 }
 
-template <typename T> void Release(T value)
-{
-    (void)value;
+inline aclBoolArray* ConvertType(const at::ArrayRef<bool>& value) {
+  static const auto aclCreateBoolArray = GET_OP_API_FUNC(aclCreateBoolArray);
+  if (aclCreateBoolArray == nullptr) {
+    return nullptr;
+  }
+
+  auto array = aclCreateBoolArray(value.data(), value.size());
+  return array;
 }
 
-template <typename Tuple, size_t... I> void CallRelease(Tuple t, std::index_sequence<I...>)
-{
-    (void)std::initializer_list<int>{(Release(std::get<I>(t)), 0)...};
+inline aclTensorList* ConvertType(const at::TensorList& at_tensor_list) {
+  static const auto aclCreateTensorList = GET_OP_API_FUNC(aclCreateTensorList);
+  if (aclCreateTensorList == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<const aclTensor*> tensor_list(at_tensor_list.size());
+  for (size_t i = 0; i < at_tensor_list.size(); i++) {
+    tensor_list[i] = ConvertType(at_tensor_list[i]);
+  }
+  auto acl_tensor_list =
+      aclCreateTensorList(tensor_list.data(), tensor_list.size());
+  return acl_tensor_list;
 }
 
-template <typename Tuple> void ReleaseConvertTypes(Tuple &t)
-{
-    static constexpr auto size = std::tuple_size<Tuple>::value;
-    CallRelease(t, std::make_index_sequence<size>{});
+inline aclScalarList* ConvertType(
+    const at::ArrayRef<at::Scalar>& at_scalar_list) {
+  static const auto aclCreateScalarList = GET_OP_API_FUNC(aclCreateScalarList);
+  if (aclCreateScalarList == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<const aclScalar*> scalar_list(at_scalar_list.size());
+  for (size_t i = 0; i < at_scalar_list.size(); i++) {
+    scalar_list[i] = ConvertType(at_scalar_list[i]);
+  }
+  auto acl_scalar_list =
+      aclCreateScalarList(scalar_list.data(), scalar_list.size());
+  return acl_scalar_list;
 }
 
-template <typename... Ts> constexpr auto ConvertTypes(Ts &...args)
-{
-    return std::make_tuple(ConvertType(args)...);
+inline aclTensor* ConvertType(const c10::optional<at::Tensor>& opt_tensor) {
+  if (opt_tensor.has_value() && opt_tensor.value().defined()) {
+    return ConvertType(opt_tensor.value());
+  }
+
+  return nullptr;
 }
 
-template <typename Function, typename Tuple, size_t... I> auto call(Function f, Tuple t, std::index_sequence<I...>)
-{
-    return f(std::get<I>(t)...);
+inline aclIntArray* ConvertType(
+    const c10::optional<at::IntArrayRef>& opt_array) {
+  if (opt_array.has_value()) {
+    return ConvertType(opt_array.value());
+  }
+
+  return nullptr;
 }
 
-template <typename Function, typename Tuple> auto call(Function f, Tuple t)
-{
-    static constexpr auto size = std::tuple_size<Tuple>::value;
-    return call(f, t, std::make_index_sequence<size>{});
+inline aclScalar* ConvertType(const c10::optional<at::Scalar>& opt_scalar) {
+  if (opt_scalar.has_value()) {
+    return ConvertType(opt_scalar.value());
+  }
+
+  return nullptr;
+}
+
+inline aclDataType ConvertType(const at::ScalarType scalarType) {
+  return at_npu::native::OpPreparation::convert_to_acl_data_type(scalarType);
+}
+
+template <typename T>
+T ConvertType(T value) {
+  return value;
+}
+
+inline void Release(aclTensor* p) {
+  static const auto aclDestroyTensor = GET_OP_API_FUNC(aclDestroyTensor);
+  if (aclDestroyTensor == nullptr) {
+    return;
+  }
+  aclDestroyTensor(p);
+}
+
+inline void Release(aclScalar* p) {
+  static const auto aclDestroyScalar = GET_OP_API_FUNC(aclDestroyScalar);
+  if (aclDestroyScalar == nullptr) {
+    return;
+  }
+  aclDestroyScalar(p);
+}
+
+inline void Release(aclIntArray* p) {
+  static const auto aclDestroyIntArray = GET_OP_API_FUNC(aclDestroyIntArray);
+  if (aclDestroyIntArray == nullptr) {
+    return;
+  }
+
+  aclDestroyIntArray(p);
+}
+
+inline void Release(aclBoolArray* p) {
+  static const auto aclDestroyBoolArray = GET_OP_API_FUNC(aclDestroyBoolArray);
+  if (aclDestroyBoolArray == nullptr) {
+    return;
+  }
+
+  aclDestroyBoolArray(p);
+}
+
+inline void Release(aclTensorList* p) {
+  static const auto aclDestroyTensorList =
+      GET_OP_API_FUNC(aclDestroyTensorList);
+  if (aclDestroyTensorList == nullptr) {
+    return;
+  }
+
+  aclDestroyTensorList(p);
+}
+
+inline void Release(aclScalarList* p) {
+  static const auto aclDestroyScalarList =
+      GET_OP_API_FUNC(aclDestroyScalarList);
+  if (aclDestroyScalarList == nullptr) {
+    return;
+  }
+
+  aclDestroyScalarList(p);
+}
+
+template <typename T>
+void Release(T value) {
+  (void)value;
 }
 
 template <typename Tuple, size_t... I>
-auto ConvertToOpApiFunc(const Tuple &params, void *opApiAddr, std::index_sequence<I...>)
-{
-    typedef int (*OpApiFunc)(typename std::decay<decltype(std::get<I>(params))>::type...);
-    auto func = reinterpret_cast<OpApiFunc>(opApiAddr);
-    return func;
+void CallRelease(Tuple t, std::index_sequence<I...>) {
+  (void)std::initializer_list<int>{(Release(std::get<I>(t)), 0)...};
 }
 
-template <typename Tuple> auto ConvertToOpApiFunc(const Tuple &params, void *opApiAddr)
-{
-    static constexpr auto size = std::tuple_size<Tuple>::value;
-    return ConvertToOpApiFunc(params, opApiAddr, std::make_index_sequence<size>{});
+template <typename Tuple>
+void ReleaseConvertTypes(Tuple& t) {
+  static constexpr auto size = std::tuple_size<Tuple>::value;
+  CallRelease(t, std::make_index_sequence<size>{});
 }
 
-template <std::size_t N> void add_param_to_buf(const std::array<bool, N> &value)
-{
-    MEMCPY_TO_BUF(value.data(), static_cast<int64_t>(value.size() * sizeof(bool)));
+template <typename... Ts>
+constexpr auto ConvertTypes(Ts&... args) {
+  return std::make_tuple(ConvertType(args)...);
 }
 
-template <typename T> void add_param_to_buf(const T &value)
-{
-    MEMCPY_TO_BUF(&value, sizeof(T));
+template <typename Function, typename Tuple, size_t... I>
+auto call(Function f, Tuple t, std::index_sequence<I...>) {
+  return f(std::get<I>(t)...);
 }
 
-void add_param_to_buf(const at::Tensor &);
-void add_param_to_buf(const at::Scalar &);
-void add_param_to_buf(const at::IntArrayRef &);
-void add_param_to_buf(const at::ArrayRef<bool> &);
-void add_param_to_buf(const at::TensorList &);
-void add_param_to_buf(const at::ArrayRef<at::Scalar> &);
-void add_param_to_buf(const c10::optional<at::Tensor> &);
-void add_param_to_buf(const c10::optional<at::IntArrayRef> &);
-void add_param_to_buf(const c10::optional<at::Scalar> &);
+template <typename Function, typename Tuple>
+auto call(Function f, Tuple t) {
+  static constexpr auto size = std::tuple_size<Tuple>::value;
+  return call(f, t, std::make_index_sequence<size>{});
+}
+
+template <typename Tuple, size_t... I>
+auto ConvertToOpApiFunc(
+    const Tuple& params,
+    void* opApiAddr,
+    std::index_sequence<I...>) {
+  typedef int (*OpApiFunc)(
+      typename std::decay<decltype(std::get<I>(params))>::type...);
+  auto func = reinterpret_cast<OpApiFunc>(opApiAddr);
+  return func;
+}
+
+template <typename Tuple>
+auto ConvertToOpApiFunc(const Tuple& params, void* opApiAddr) {
+  static constexpr auto size = std::tuple_size<Tuple>::value;
+  return ConvertToOpApiFunc(
+      params, opApiAddr, std::make_index_sequence<size>{});
+}
+
+template <std::size_t N>
+void add_param_to_buf(const std::array<bool, N>& value) {
+  MEMCPY_TO_BUF(
+      value.data(), static_cast<int64_t>(value.size() * sizeof(bool)));
+}
+
+template <typename T>
+void add_param_to_buf(const T& value) {
+  MEMCPY_TO_BUF(&value, sizeof(T));
+}
+
+void add_param_to_buf(const at::Tensor&);
+void add_param_to_buf(const at::Scalar&);
+void add_param_to_buf(const at::IntArrayRef&);
+void add_param_to_buf(const at::ArrayRef<bool>&);
+void add_param_to_buf(const at::TensorList&);
+void add_param_to_buf(const at::ArrayRef<at::Scalar>&);
+void add_param_to_buf(const c10::optional<at::Tensor>&);
+void add_param_to_buf(const c10::optional<at::IntArrayRef>&);
+void add_param_to_buf(const c10::optional<at::Scalar>&);
 void add_param_to_buf(const at::ScalarType);
-void add_param_to_buf(const string &);
-void add_param_to_buf(char *);
-void add_param_to_buf(const char *);
+void add_param_to_buf(const string&);
+void add_param_to_buf(char*);
+void add_param_to_buf(const char*);
 void add_param_to_buf();
 
-template <typename T, typename... Args> void add_param_to_buf(const T &arg, Args &...args)
-{
-    add_param_to_buf(arg);
-    add_param_to_buf(args...);
+template <typename T, typename... Args>
+void add_param_to_buf(const T& arg, Args&... args) {
+  add_param_to_buf(arg);
+  add_param_to_buf(args...);
 }
 
 uint64_t calc_hash_id();
 
-#define DO_COMPATIBILITY(aclnn_api, originCallExpression)                                                              \
-    do {                                                                                                               \
-        static const auto getWorkspaceSizeFuncAddr = GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                  \
-        static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);                                                \
-        if (getWorkspaceSizeFuncAddr == nullptr || opApiFuncAddr == nullptr) {                                         \
-            ASCEND_LOGW("%s or %sGetWorkspaceSize not in %s, or %s not found. Will call %s", #aclnn_api, #aclnn_api,   \
-                        GetOpApiLibName(), GetOpApiLibName(), #originCallExpression);                                  \
-            return originCallExpression;                                                                               \
-        }                                                                                                              \
-    } while (0)
+#define DO_COMPATIBILITY(aclnn_api, originCallExpression)                      \
+  do {                                                                         \
+    static const auto getWorkspaceSizeFuncAddr =                               \
+        GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                       \
+    static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);            \
+    if (getWorkspaceSizeFuncAddr == nullptr || opApiFuncAddr == nullptr) {     \
+      ASCEND_LOGW(                                                             \
+          "%s or %sGetWorkspaceSize not in %s, or %s not found. Will call %s", \
+          #aclnn_api,                                                          \
+          #aclnn_api,                                                          \
+          GetOpApiLibName(),                                                   \
+          GetOpApiLibName(),                                                   \
+          #originCallExpression);                                              \
+      return originCallExpression;                                             \
+    }                                                                          \
+  } while (0)
 
-typedef int (*InitHugeMemThreadLocal)(void *, bool);
-typedef void (*UnInitHugeMemThreadLocal)(void *, bool);
-typedef void (*ReleaseHugeMem)(void *, bool);
-typedef aclOpExecutor *(*PTAGetExecCache)(uint64_t, uint64_t *);
+typedef int (*InitHugeMemThreadLocal)(void*, bool);
+typedef void (*UnInitHugeMemThreadLocal)(void*, bool);
+typedef void (*ReleaseHugeMem)(void*, bool);
+typedef aclOpExecutor* (*PTAGetExecCache)(uint64_t, uint64_t*);
 typedef void (*InitPTACacheThreadLocal)();
 typedef void (*SetPTAHashKey)(uint64_t);
-typedef bool (*CanUsePTACache)(const char *);
+typedef bool (*CanUsePTACache)(const char*);
 typedef void (*UnInitPTACacheThreadLocal)();
 
-inline void UnInitCacheThreadLocal()
-{
-    static const auto unInitPTACacheThreadLocalAddr = GetOpApiFuncAddr("UnInitPTACacheThreadLocal");
-    UnInitPTACacheThreadLocal unInitPTACacheThreadLocalFunc =
-        reinterpret_cast<UnInitPTACacheThreadLocal>(unInitPTACacheThreadLocalAddr);
-    if (unInitPTACacheThreadLocalFunc) {
-        unInitPTACacheThreadLocalFunc();
-    }
+inline void UnInitCacheThreadLocal() {
+  static const auto unInitPTACacheThreadLocalAddr =
+      GetOpApiFuncAddr("UnInitPTACacheThreadLocal");
+  UnInitPTACacheThreadLocal unInitPTACacheThreadLocalFunc =
+      reinterpret_cast<UnInitPTACacheThreadLocal>(
+          unInitPTACacheThreadLocalAddr);
+  if (unInitPTACacheThreadLocalFunc) {
+    unInitPTACacheThreadLocalFunc();
+  }
 }
 
-template <typename... Args> bool hit_cache(aclrtStream acl_stream, const char *aclnn_api, void *phrase2, Args &&...args)
-{
-    static const auto ptaGetExecCacheAddr = GetOpApiFuncAddr("PTAGetExecCache");
-    static const auto initPTACacheThreadLocalAddr = GetOpApiFuncAddr("InitPTACacheThreadLocal");
-    static const auto setPTAHashKeyAddr = GetOpApiFuncAddr("SetPTAHashKey");
-    static const auto canUsePTACacheAddr = GetOpApiFuncAddr("CanUsePTACache");
-    PTAGetExecCache ptaGetExecCacheFunc = reinterpret_cast<PTAGetExecCache>(ptaGetExecCacheAddr);
-    InitPTACacheThreadLocal initPTACacheThreadLocalFunc =
-        reinterpret_cast<InitPTACacheThreadLocal>(initPTACacheThreadLocalAddr);
-    SetPTAHashKey setPTAHashKeyFunc = reinterpret_cast<SetPTAHashKey>(setPTAHashKeyAddr);
-    CanUsePTACache canUsePTACacheFunc = reinterpret_cast<CanUsePTACache>(canUsePTACacheAddr);
-    bool has_func = ptaGetExecCacheFunc && initPTACacheThreadLocalFunc && setPTAHashKeyFunc;
-    bool can_use = canUsePTACacheFunc && canUsePTACacheFunc(aclnn_api);
-    if (!has_func || !can_use) {
-        return false;
-    }
-    uint64_t workspace_size = 0;
-    uint64_t *workspace_size_addr = &workspace_size;
-    initPTACacheThreadLocalFunc();
-    g_hash_offset = 0;
-    add_param_to_buf(std::string(aclnn_api), args...);
-    uint64_t hashId = calc_hash_id();
-    setPTAHashKeyFunc(hashId);
-    aclOpExecutor *executor = ptaGetExecCacheFunc(hashId, workspace_size_addr);
-    if (executor == nullptr) {
-        return false;
-    }
-    void *workspace_addr = nullptr;
-    at::Tensor workspace_tensor;
-    if (workspace_size != 0) {
-        workspace_tensor = at_npu::native::OpPreparation::unsafe_empty_workspace(workspace_size);
-        workspace_addr = const_cast<void *>(workspace_tensor.storage().data());
-    }
-    auto acl_call = [workspace_addr, workspace_size, acl_stream, executor, phrase2]() -> int {
-        OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(phrase2);
-        auto api_ret = opApiFunc(workspace_addr, workspace_size, executor, acl_stream);
-        TORCH_CHECK(api_ret == 0, "call failed, detail:", aclGetRecentErrMsg(), OPS_ERROR(ErrCode::INTERNAL));
-        return api_ret;
-    };
-    at_npu::native::OpCommand cmd;
-    cmd.Name(aclnn_api);
-    cmd.SetCustomHandler(acl_call);
-    cmd.Run();
-    UnInitCacheThreadLocal();
-    return true;
+template <typename... Args>
+bool hit_cache(
+    aclrtStream acl_stream,
+    const char* aclnn_api,
+    void* phrase2,
+    Args&&... args) {
+  static const auto ptaGetExecCacheAddr = GetOpApiFuncAddr("PTAGetExecCache");
+  static const auto initPTACacheThreadLocalAddr =
+      GetOpApiFuncAddr("InitPTACacheThreadLocal");
+  static const auto setPTAHashKeyAddr = GetOpApiFuncAddr("SetPTAHashKey");
+  static const auto canUsePTACacheAddr = GetOpApiFuncAddr("CanUsePTACache");
+  PTAGetExecCache ptaGetExecCacheFunc =
+      reinterpret_cast<PTAGetExecCache>(ptaGetExecCacheAddr);
+  InitPTACacheThreadLocal initPTACacheThreadLocalFunc =
+      reinterpret_cast<InitPTACacheThreadLocal>(initPTACacheThreadLocalAddr);
+  SetPTAHashKey setPTAHashKeyFunc =
+      reinterpret_cast<SetPTAHashKey>(setPTAHashKeyAddr);
+  CanUsePTACache canUsePTACacheFunc =
+      reinterpret_cast<CanUsePTACache>(canUsePTACacheAddr);
+  bool has_func =
+      ptaGetExecCacheFunc && initPTACacheThreadLocalFunc && setPTAHashKeyFunc;
+  bool can_use = canUsePTACacheFunc && canUsePTACacheFunc(aclnn_api);
+  if (!has_func || !can_use) {
+    return false;
+  }
+  uint64_t workspace_size = 0;
+  uint64_t* workspace_size_addr = &workspace_size;
+  initPTACacheThreadLocalFunc();
+  g_hash_offset = 0;
+  add_param_to_buf(std::string(aclnn_api), args...);
+  uint64_t hashId = calc_hash_id();
+  setPTAHashKeyFunc(hashId);
+  aclOpExecutor* executor = ptaGetExecCacheFunc(hashId, workspace_size_addr);
+  if (executor == nullptr) {
+    return false;
+  }
+  void* workspace_addr = nullptr;
+  at::Tensor workspace_tensor;
+  if (workspace_size != 0) {
+    workspace_tensor =
+        at_npu::native::OpPreparation::unsafe_empty_workspace(workspace_size);
+    workspace_addr = const_cast<void*>(workspace_tensor.storage().data());
+  }
+  auto acl_call =
+      [workspace_addr, workspace_size, acl_stream, executor, phrase2]() -> int {
+    OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(phrase2);
+    auto api_ret =
+        opApiFunc(workspace_addr, workspace_size, executor, acl_stream);
+    TORCH_CHECK(
+        api_ret == 0,
+        "call failed, detail:",
+        aclGetRecentErrMsg(),
+        OPS_ERROR(ErrCode::INTERNAL));
+    return api_ret;
+  };
+  at_npu::native::OpCommand cmd;
+  cmd.Name(aclnn_api);
+  cmd.SetCustomHandler(acl_call);
+  cmd.Run();
+  UnInitCacheThreadLocal();
+  return true;
 }
 
 /**
  * check arg is at::Tensor ?
  */
-template<typename T>
+template <typename T>
 struct is_at_tensor : std::false_type {};
 
-template<>
+template <>
 struct is_at_tensor<at::Tensor> : std::true_type {};
 
 /**
  * check arg is at::TensorList ?
  */
-template<typename T>
+template <typename T>
 struct is_at_tensor_list : std::false_type {};
 
-template<>
+template <>
 struct is_at_tensor_list<at::TensorList> : std::true_type {};
 
 /**
  * find first at::Tensor
  */
-template <std::size_t I = 0, typename...Ts>
-typename std::enable_if<I == sizeof...(Ts), void>::type GetFirstTensor(const std::tuple<Ts...>& t, at::Tensor& res) {}
+template <std::size_t I = 0, typename... Ts>
+typename std::enable_if<I == sizeof...(Ts), void>::type GetFirstTensor(
+    const std::tuple<Ts...>& t,
+    at::Tensor& res) {}
 
 template <std::size_t I = 0, typename... Ts>
-typename std::enable_if < I<sizeof...(Ts), void>::type GetFirstTensor(const std::tuple<Ts...> &t, at::Tensor &res)
-{
-    if constexpr (is_at_tensor<typename std::tuple_element<I, std::tuple<Ts...>>::type>::value) {
-        res = std::get<I>(t);
-        return;
-    } else if constexpr (is_at_tensor_list<typename std::tuple_element<I, std::tuple<Ts...>>::type>::value) {
-        res = std::get<I>(t)[0];
-        return;
-    }
-    return GetFirstTensor<I + 1, Ts...>(t, res);
+    typename std::enable_if < I<sizeof...(Ts), void>::type GetFirstTensor(
+                                  const std::tuple<Ts...>& t,
+                                  at::Tensor& res) {
+  if constexpr (is_at_tensor<typename std::tuple_element<I, std::tuple<Ts...>>::
+                                 type>::value) {
+    res = std::get<I>(t);
+    return;
+  } else if constexpr (is_at_tensor_list<typename std::tuple_element<
+                           I,
+                           std::tuple<Ts...>>::type>::value) {
+    res = std::get<I>(t)[0];
+    return;
+  }
+  return GetFirstTensor<I + 1, Ts...>(t, res);
 }
 
 /**
  * get the device
  */
 template <typename... Ts>
-auto DecodeDevice(Ts&... args) -> at::Device
-{
-    auto tp = std::make_tuple(args...);
-    at::Tensor ft;
-    GetFirstTensor(tp, ft);
-    return ft.device();
+auto DecodeDevice(Ts&... args) -> at::Device {
+  auto tp = std::make_tuple(args...);
+  at::Tensor ft;
+  GetFirstTensor(tp, ft);
+  return ft.device();
 }
 
 /**
  * 异步调用npu执行, 无返回值.
  */
-#define EXEC_NPU_CMD(aclnn_api, ...)                                                                                   \
-    do {                                                                                                               \
-        static const auto getWorkspaceSizeFuncAddr = GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                  \
-        static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);                                                \
-        static const auto initMemAddr = GetOpApiFuncAddr("InitHugeMemThreadLocal");                                    \
-        static const auto unInitMemAddr = GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                                \
-        static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");                                         \
-        TORCH_CHECK(getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr, #aclnn_api, " or ",               \
-                    #aclnn_api "GetWorkspaceSize", " not in ", GetOpApiLibName(), ", or ", GetOpApiLibName(),          \
-                    "not found.", OPS_ERROR(ErrCode::PTR));                                                            \
-        auto acl_stream = c10_npu::getCurrentNPUStream().stream();                                                     \
-        uint64_t workspace_size = 0;                                                                                   \
-        uint64_t *workspace_size_addr = &workspace_size;                                                               \
-        aclOpExecutor *executor = nullptr;                                                                             \
-        aclOpExecutor **executor_addr = &executor;                                                                     \
-        InitHugeMemThreadLocal initMemFunc = reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);                    \
-        UnInitHugeMemThreadLocal unInitMemFunc = reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);            \
-        if (hit_cache(acl_stream, #aclnn_api, opApiFuncAddr, __VA_ARGS__)) {                                           \
-            break;                                                                                                     \
-        }                                                                                                              \
-        at_npu::native::SetDeterministic();                                                                            \
-        if (initMemFunc) {                                                                                             \
-            initMemFunc(nullptr, false);                                                                               \
-        }                                                                                                              \
-        auto converted_params = ConvertTypes(__VA_ARGS__, workspace_size_addr, executor_addr);                         \
-        static auto getWorkspaceSizeFunc = ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);             \
-        auto workspace_status = call(getWorkspaceSizeFunc, converted_params);                                          \
-        TORCH_CHECK(workspace_status == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg(),                \
-            OPS_ERROR(ErrCode::INTERNAL));                                                                             \
-        void *workspace_addr = nullptr;                                                                                \
-        at::Tensor workspace_tensor;                                                                                   \
-        if (workspace_size != 0) {                                                                                     \
-            workspace_tensor = at_npu::native::OpPreparation::unsafe_empty_workspace(workspace_size);                  \
-            workspace_addr = const_cast<void *>(workspace_tensor.storage().data());                                    \
-        }                                                                                                              \
-        auto acl_call = [converted_params, workspace_addr, workspace_size, acl_stream, executor]()-> int {             \
-            OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);                                          \
-            auto api_ret = opApiFunc(workspace_addr, workspace_size, executor, acl_stream);                            \
-            TORCH_CHECK(api_ret == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg(),                     \
-                OPS_ERROR(ErrCode::INTERNAL));                                                                         \
-            ReleaseConvertTypes(converted_params);                                                                     \
-            ReleaseHugeMem releaseMemFunc = reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                          \
-            if (releaseMemFunc) {                                                                                      \
-                releaseMemFunc(nullptr, false);                                                                        \
-            }                                                                                                          \
-            return api_ret;                                                                                            \
-        };                                                                                                             \
-        at_npu::native::OpCommand cmd;                                                                                 \
-        cmd.Name(#aclnn_api);                                                                                          \
-        cmd.SetCustomHandler(acl_call);                                                                                \
-        cmd.Run();                                                                                                     \
-        if (unInitMemFunc) {                                                                                           \
-            unInitMemFunc(nullptr, false);                                                                             \
-        }                                                                                                              \
-        UnInitCacheThreadLocal();                                                                                      \
-    } while (false)
+#define EXEC_NPU_CMD(aclnn_api, ...)                                         \
+  do {                                                                       \
+    static const auto getWorkspaceSizeFuncAddr =                             \
+        GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                     \
+    static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);          \
+    static const auto initMemAddr =                                          \
+        GetOpApiFuncAddr("InitHugeMemThreadLocal");                          \
+    static const auto unInitMemAddr =                                        \
+        GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                        \
+    static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");   \
+    TORCH_CHECK(                                                             \
+        getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr,     \
+        #aclnn_api,                                                          \
+        " or ",                                                              \
+        #aclnn_api "GetWorkspaceSize",                                       \
+        " not in ",                                                          \
+        GetOpApiLibName(),                                                   \
+        ", or ",                                                             \
+        GetOpApiLibName(),                                                   \
+        "not found.",                                                        \
+        OPS_ERROR(ErrCode::PTR));                                            \
+    auto acl_stream = c10::npu::getCurrentNPUStream().stream();              \
+    uint64_t workspace_size = 0;                                             \
+    uint64_t* workspace_size_addr = &workspace_size;                         \
+    aclOpExecutor* executor = nullptr;                                       \
+    aclOpExecutor** executor_addr = &executor;                               \
+    InitHugeMemThreadLocal initMemFunc =                                     \
+        reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);               \
+    UnInitHugeMemThreadLocal unInitMemFunc =                                 \
+        reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);           \
+    if (hit_cache(acl_stream, #aclnn_api, opApiFuncAddr, __VA_ARGS__)) {     \
+      break;                                                                 \
+    }                                                                        \
+    at_npu::native::SetDeterministic();                                      \
+    if (initMemFunc) {                                                       \
+      initMemFunc(nullptr, false);                                           \
+    }                                                                        \
+    auto converted_params =                                                  \
+        ConvertTypes(__VA_ARGS__, workspace_size_addr, executor_addr);       \
+    static auto getWorkspaceSizeFunc =                                       \
+        ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);      \
+    auto workspace_status = call(getWorkspaceSizeFunc, converted_params);    \
+    TORCH_CHECK(                                                             \
+        workspace_status == 0,                                               \
+        "call " #aclnn_api " failed, detail:",                               \
+        aclGetRecentErrMsg(),                                                \
+        OPS_ERROR(ErrCode::INTERNAL));                                       \
+    void* workspace_addr = nullptr;                                          \
+    at::Tensor workspace_tensor;                                             \
+    if (workspace_size != 0) {                                               \
+      workspace_tensor =                                                     \
+          at_npu::native::OpPreparation::unsafe_empty_workspace(             \
+              workspace_size);                                               \
+      workspace_addr = const_cast<void*>(workspace_tensor.storage().data()); \
+    }                                                                        \
+    auto acl_call = [converted_params,                                       \
+                     workspace_addr,                                         \
+                     workspace_size,                                         \
+                     acl_stream,                                             \
+                     executor]() -> int {                                    \
+      OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);      \
+      auto api_ret =                                                         \
+          opApiFunc(workspace_addr, workspace_size, executor, acl_stream);   \
+      TORCH_CHECK(                                                           \
+          api_ret == 0,                                                      \
+          "call " #aclnn_api " failed, detail:",                             \
+          aclGetRecentErrMsg(),                                              \
+          OPS_ERROR(ErrCode::INTERNAL));                                     \
+      ReleaseConvertTypes(converted_params);                                 \
+      ReleaseHugeMem releaseMemFunc =                                        \
+          reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                  \
+      if (releaseMemFunc) {                                                  \
+        releaseMemFunc(nullptr, false);                                      \
+      }                                                                      \
+      return api_ret;                                                        \
+    };                                                                       \
+    at_npu::native::OpCommand cmd;                                           \
+    cmd.Name(#aclnn_api);                                                    \
+    cmd.SetCustomHandler(acl_call);                                          \
+    cmd.Run();                                                               \
+    if (unInitMemFunc) {                                                     \
+      unInitMemFunc(nullptr, false);                                         \
+    }                                                                        \
+    UnInitCacheThreadLocal();                                                \
+  } while (false)
 
 /**
  * 针对aclnnInplaceCopy重载EXEC_NPU_CMD, 获取第二个tensor(src)的device
  */
-#define EXEC_NPU_COPY_CMD(aclnn_api, ...)                                                                              \
-    do {                                                                                                               \
-        static const auto getWorkspaceSizeFuncAddr = GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                  \
-        static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);                                                \
-        static const auto initMemAddr = GetOpApiFuncAddr("InitHugeMemThreadLocal");                                    \
-        static const auto unInitMemAddr = GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                                \
-        static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");                                         \
-        TORCH_CHECK(getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr, #aclnn_api, " or ",               \
-                    #aclnn_api "GetWorkspaceSize", " not in ", GetOpApiLibName(), ", or ", GetOpApiLibName(),          \
-                    "not found.");                                                                                     \
-        auto acl_stream = c10_npu::getCurrentNPUStream().stream(false);                                                \
-        uint64_t workspace_size = 0;                                                                                   \
-        uint64_t *workspace_size_addr = &workspace_size;                                                               \
-        aclOpExecutor *executor = nullptr;                                                                             \
-        aclOpExecutor **executor_addr = &executor;                                                                     \
-        InitHugeMemThreadLocal initMemFunc = reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);                    \
-        UnInitHugeMemThreadLocal unInitMemFunc = reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);            \
-        if (hit_cache(acl_stream, #aclnn_api, opApiFuncAddr, __VA_ARGS__)) {                                           \
-            break;                                                                                                     \
-        }                                                                                                              \
-        at_npu::native::SetDeterministic();                                                                            \
-        if (initMemFunc) {                                                                                             \
-            initMemFunc(nullptr, false);                                                                               \
-        }                                                                                                              \
-        auto converted_params = ConvertTypes(__VA_ARGS__, workspace_size_addr, executor_addr);                         \
-        static auto getWorkspaceSizeFunc = ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);             \
-        auto workspace_status = call(getWorkspaceSizeFunc, converted_params);                                          \
-        TORCH_CHECK(workspace_status == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg());               \
-        void *workspace_addr = nullptr;                                                                                \
-        at::Tensor workspace_tensor;                                                                                   \
-        if (workspace_size != 0) {                                                                                     \
-            workspace_tensor = at_npu::native::OpPreparation::unsafe_empty_workspace(workspace_size);                  \
-            workspace_addr = const_cast<void *>(workspace_tensor.storage().data());                                    \
-        }                                                                                                              \
-        auto acl_call = [converted_params, workspace_addr, workspace_size, acl_stream, executor]()->int {              \
-            OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);                                          \
-            auto api_ret = opApiFunc(workspace_addr, workspace_size, executor, acl_stream);                            \
-            TORCH_CHECK(api_ret == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg());                    \
-            ReleaseConvertTypes(converted_params);                                                                     \
-            ReleaseHugeMem releaseMemFunc = reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                          \
-            if (releaseMemFunc) {                                                                                      \
-                releaseMemFunc(nullptr, false);                                                                        \
-            }                                                                                                          \
-            return api_ret;                                                                                            \
-        };                                                                                                             \
-        at_npu::native::OpCommand cmd;                                                                                 \
-        cmd.Name(#aclnn_api);                                                                                          \
-        cmd.SetCustomHandler(acl_call);                                                                                \
-        cmd.Run();                                                                                                     \
-        if (unInitMemFunc) {                                                                                           \
-            unInitMemFunc(nullptr, false);                                                                             \
-        }                                                                                                              \
-        UnInitCacheThreadLocal();                                                                                      \
-    } while (false)
+#define EXEC_NPU_COPY_CMD(aclnn_api, ...)                                    \
+  do {                                                                       \
+    static const auto getWorkspaceSizeFuncAddr =                             \
+        GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                     \
+    static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);          \
+    static const auto initMemAddr =                                          \
+        GetOpApiFuncAddr("InitHugeMemThreadLocal");                          \
+    static const auto unInitMemAddr =                                        \
+        GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                        \
+    static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");   \
+    TORCH_CHECK(                                                             \
+        getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr,     \
+        #aclnn_api,                                                          \
+        " or ",                                                              \
+        #aclnn_api "GetWorkspaceSize",                                       \
+        " not in ",                                                          \
+        GetOpApiLibName(),                                                   \
+        ", or ",                                                             \
+        GetOpApiLibName(),                                                   \
+        "not found.");                                                       \
+    auto acl_stream = c10::npu::getCurrentNPUStream().stream(false);         \
+    uint64_t workspace_size = 0;                                             \
+    uint64_t* workspace_size_addr = &workspace_size;                         \
+    aclOpExecutor* executor = nullptr;                                       \
+    aclOpExecutor** executor_addr = &executor;                               \
+    InitHugeMemThreadLocal initMemFunc =                                     \
+        reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);               \
+    UnInitHugeMemThreadLocal unInitMemFunc =                                 \
+        reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);           \
+    if (hit_cache(acl_stream, #aclnn_api, opApiFuncAddr, __VA_ARGS__)) {     \
+      break;                                                                 \
+    }                                                                        \
+    at_npu::native::SetDeterministic();                                      \
+    if (initMemFunc) {                                                       \
+      initMemFunc(nullptr, false);                                           \
+    }                                                                        \
+    auto converted_params =                                                  \
+        ConvertTypes(__VA_ARGS__, workspace_size_addr, executor_addr);       \
+    static auto getWorkspaceSizeFunc =                                       \
+        ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);      \
+    auto workspace_status = call(getWorkspaceSizeFunc, converted_params);    \
+    TORCH_CHECK(                                                             \
+        workspace_status == 0,                                               \
+        "call " #aclnn_api " failed, detail:",                               \
+        aclGetRecentErrMsg());                                               \
+    void* workspace_addr = nullptr;                                          \
+    at::Tensor workspace_tensor;                                             \
+    if (workspace_size != 0) {                                               \
+      workspace_tensor =                                                     \
+          at_npu::native::OpPreparation::unsafe_empty_workspace(             \
+              workspace_size);                                               \
+      workspace_addr = const_cast<void*>(workspace_tensor.storage().data()); \
+    }                                                                        \
+    auto acl_call = [converted_params,                                       \
+                     workspace_addr,                                         \
+                     workspace_size,                                         \
+                     acl_stream,                                             \
+                     executor]() -> int {                                    \
+      OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);      \
+      auto api_ret =                                                         \
+          opApiFunc(workspace_addr, workspace_size, executor, acl_stream);   \
+      TORCH_CHECK(                                                           \
+          api_ret == 0,                                                      \
+          "call " #aclnn_api " failed, detail:",                             \
+          aclGetRecentErrMsg());                                             \
+      ReleaseConvertTypes(converted_params);                                 \
+      ReleaseHugeMem releaseMemFunc =                                        \
+          reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                  \
+      if (releaseMemFunc) {                                                  \
+        releaseMemFunc(nullptr, false);                                      \
+      }                                                                      \
+      return api_ret;                                                        \
+    };                                                                       \
+    at_npu::native::OpCommand cmd;                                           \
+    cmd.Name(#aclnn_api);                                                    \
+    cmd.SetCustomHandler(acl_call);                                          \
+    cmd.Run();                                                               \
+    if (unInitMemFunc) {                                                     \
+      unInitMemFunc(nullptr, false);                                         \
+    }                                                                        \
+    UnInitCacheThreadLocal();                                                \
+  } while (false)
 
-#define EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnn_api, ...)                                                                   \
-    do {                                                                                                               \
-        static const auto getWorkspaceSizeFuncAddr = GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                  \
-        static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);                                                \
-        static const auto initMemAddr = GetOpApiFuncAddr("InitHugeMemThreadLocal");                                    \
-        static const auto unInitMemAddr = GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                                \
-        static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");                                         \
-        static const auto initPTACacheThreadLocalAddr = GetOpApiFuncAddr("InitPTACacheThreadLocal");                   \
-        static const auto setPTAHashKeyAddr = GetOpApiFuncAddr("SetPTAHashKey");                                       \
-        TORCH_CHECK(getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr, #aclnn_api, " or ",               \
-                    #aclnn_api "GetWorkspaceSize", " not in ", GetOpApiLibName(), ", or ", GetOpApiLibName(),          \
-                    "not found.", OPS_ERROR(ErrCode::PTR));                                                            \
-        auto acl_stream = c10_npu::getCurrentNPUStream().stream();                                                     \
-        uint64_t workspace_size = 0;                                                                                   \
-        uint64_t *workspace_size_addr = &workspace_size;                                                               \
-        aclOpExecutor *executor = nullptr;                                                                             \
-        aclOpExecutor **executor_addr = &executor;                                                                     \
-        InitHugeMemThreadLocal initMemFunc = reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);                    \
-        UnInitHugeMemThreadLocal unInitMemFunc = reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);            \
-        InitPTACacheThreadLocal initPTACacheThreadLocalFunc =                                                          \
-            reinterpret_cast<InitPTACacheThreadLocal>(initPTACacheThreadLocalAddr);                                    \
-        SetPTAHashKey setPTAHashKeyFunc = reinterpret_cast<SetPTAHashKey>(setPTAHashKeyAddr);                          \
-        if (initPTACacheThreadLocalFunc && setPTAHashKeyFunc) {                                                        \
-            initPTACacheThreadLocalFunc();                                                                             \
-            setPTAHashKeyFunc(0);                                                                                      \
-        }                                                                                                              \
-        at_npu::native::SetDeterministic();                                                                            \
-        if (initMemFunc) {                                                                                             \
-            initMemFunc(nullptr, false);                                                                               \
-        }                                                                                                              \
-        auto converted_params = ConvertTypes(__VA_ARGS__, workspace_size_addr, executor_addr);                         \
-        static auto getWorkspaceSizeFunc = ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);             \
-        auto workspace_status = call(getWorkspaceSizeFunc, converted_params);                                          \
-        TORCH_CHECK(workspace_status == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg(),                \
-            OPS_ERROR(ErrCode::INTERNAL));                                                                             \
-        void *workspace_addr = nullptr;                                                                                \
-        at::Tensor workspace_tensor;                                                                                   \
-        if (workspace_size != 0) {                                                                                     \
-            workspace_tensor = at_npu::native::OpPreparation::unsafe_empty_workspace(workspace_size);                  \
-            workspace_addr = const_cast<void *>(workspace_tensor.storage().data());                                    \
-        }                                                                                                              \
-        auto acl_call = [converted_params, workspace_addr, workspace_size, acl_stream, executor]()-> int {             \
-            OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);                                          \
-            auto api_ret = opApiFunc(workspace_addr, workspace_size, executor, acl_stream);                            \
-            TORCH_CHECK(api_ret == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg(),                     \
-                OPS_ERROR(ErrCode::INTERNAL));                                                                         \
-            ReleaseConvertTypes(converted_params);                                                                     \
-            ReleaseHugeMem releaseMemFunc = reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                          \
-            if (releaseMemFunc) {                                                                                      \
-                releaseMemFunc(nullptr, false);                                                                        \
-            }                                                                                                          \
-            return api_ret;                                                                                            \
-        };                                                                                                             \
-        at_npu::native::OpCommand cmd;                                                                                 \
-        cmd.Name(#aclnn_api);                                                                                          \
-        cmd.SetCustomHandler(acl_call);                                                                                \
-        cmd.Run();                                                                                                     \
-        if (unInitMemFunc) {                                                                                           \
-            unInitMemFunc(nullptr, false);                                                                             \
-        }                                                                                                              \
-        UnInitCacheThreadLocal();                                                                                      \
-    } while (false)
+#define EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnn_api, ...)                         \
+  do {                                                                       \
+    static const auto getWorkspaceSizeFuncAddr =                             \
+        GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                     \
+    static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);          \
+    static const auto initMemAddr =                                          \
+        GetOpApiFuncAddr("InitHugeMemThreadLocal");                          \
+    static const auto unInitMemAddr =                                        \
+        GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                        \
+    static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");   \
+    static const auto initPTACacheThreadLocalAddr =                          \
+        GetOpApiFuncAddr("InitPTACacheThreadLocal");                         \
+    static const auto setPTAHashKeyAddr = GetOpApiFuncAddr("SetPTAHashKey"); \
+    TORCH_CHECK(                                                             \
+        getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr,     \
+        #aclnn_api,                                                          \
+        " or ",                                                              \
+        #aclnn_api "GetWorkspaceSize",                                       \
+        " not in ",                                                          \
+        GetOpApiLibName(),                                                   \
+        ", or ",                                                             \
+        GetOpApiLibName(),                                                   \
+        "not found.",                                                        \
+        OPS_ERROR(ErrCode::PTR));                                            \
+    auto acl_stream = c10::npu::getCurrentNPUStream().stream();              \
+    uint64_t workspace_size = 0;                                             \
+    uint64_t* workspace_size_addr = &workspace_size;                         \
+    aclOpExecutor* executor = nullptr;                                       \
+    aclOpExecutor** executor_addr = &executor;                               \
+    InitHugeMemThreadLocal initMemFunc =                                     \
+        reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);               \
+    UnInitHugeMemThreadLocal unInitMemFunc =                                 \
+        reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);           \
+    InitPTACacheThreadLocal initPTACacheThreadLocalFunc =                    \
+        reinterpret_cast<InitPTACacheThreadLocal>(                           \
+            initPTACacheThreadLocalAddr);                                    \
+    SetPTAHashKey setPTAHashKeyFunc =                                        \
+        reinterpret_cast<SetPTAHashKey>(setPTAHashKeyAddr);                  \
+    if (initPTACacheThreadLocalFunc && setPTAHashKeyFunc) {                  \
+      initPTACacheThreadLocalFunc();                                         \
+      setPTAHashKeyFunc(0);                                                  \
+    }                                                                        \
+    at_npu::native::SetDeterministic();                                      \
+    if (initMemFunc) {                                                       \
+      initMemFunc(nullptr, false);                                           \
+    }                                                                        \
+    auto converted_params =                                                  \
+        ConvertTypes(__VA_ARGS__, workspace_size_addr, executor_addr);       \
+    static auto getWorkspaceSizeFunc =                                       \
+        ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);      \
+    auto workspace_status = call(getWorkspaceSizeFunc, converted_params);    \
+    TORCH_CHECK(                                                             \
+        workspace_status == 0,                                               \
+        "call " #aclnn_api " failed, detail:",                               \
+        aclGetRecentErrMsg(),                                                \
+        OPS_ERROR(ErrCode::INTERNAL));                                       \
+    void* workspace_addr = nullptr;                                          \
+    at::Tensor workspace_tensor;                                             \
+    if (workspace_size != 0) {                                               \
+      workspace_tensor =                                                     \
+          at_npu::native::OpPreparation::unsafe_empty_workspace(             \
+              workspace_size);                                               \
+      workspace_addr = const_cast<void*>(workspace_tensor.storage().data()); \
+    }                                                                        \
+    auto acl_call = [converted_params,                                       \
+                     workspace_addr,                                         \
+                     workspace_size,                                         \
+                     acl_stream,                                             \
+                     executor]() -> int {                                    \
+      OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);      \
+      auto api_ret =                                                         \
+          opApiFunc(workspace_addr, workspace_size, executor, acl_stream);   \
+      TORCH_CHECK(                                                           \
+          api_ret == 0,                                                      \
+          "call " #aclnn_api " failed, detail:",                             \
+          aclGetRecentErrMsg(),                                              \
+          OPS_ERROR(ErrCode::INTERNAL));                                     \
+      ReleaseConvertTypes(converted_params);                                 \
+      ReleaseHugeMem releaseMemFunc =                                        \
+          reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                  \
+      if (releaseMemFunc) {                                                  \
+        releaseMemFunc(nullptr, false);                                      \
+      }                                                                      \
+      return api_ret;                                                        \
+    };                                                                       \
+    at_npu::native::OpCommand cmd;                                           \
+    cmd.Name(#aclnn_api);                                                    \
+    cmd.SetCustomHandler(acl_call);                                          \
+    cmd.Run();                                                               \
+    if (unInitMemFunc) {                                                     \
+      unInitMemFunc(nullptr, false);                                         \
+    }                                                                        \
+    UnInitCacheThreadLocal();                                                \
+  } while (false)
 
-template <typename Tuple> class ConvertedParams {
-public:
-    explicit ConvertedParams(Tuple &&convertedParams, ReleaseHugeMem releaseMemFunc,
-                             UnInitHugeMemThreadLocal unInitMemFunc) : convertedParams_(std::move(convertedParams)),
-                                                                       releaseMemFunc_(releaseMemFunc),
-                                                                       unInitMemFunc_(unInitMemFunc){};
-    ConvertedParams(ConvertedParams &&other) : convertedParams_(std::move(other.convertedParams_))
-    {
-        other.validParams_ = false;
-    };
-    ConvertedParams &operator=(ConvertedParams &&other)
-    {
-        if (this == &other) {
-            return *this;
-        }
-
-        convertedParams_ = std::move(other.convertedParams_);
-        validParams_ = true;
-        other.validParams_ = false;
-        return *this;
+template <typename Tuple>
+class ConvertedParams {
+ public:
+  explicit ConvertedParams(
+      Tuple&& convertedParams,
+      ReleaseHugeMem releaseMemFunc,
+      UnInitHugeMemThreadLocal unInitMemFunc)
+      : convertedParams_(std::move(convertedParams)),
+        releaseMemFunc_(releaseMemFunc),
+        unInitMemFunc_(unInitMemFunc){};
+  ConvertedParams(ConvertedParams&& other)
+      : convertedParams_(std::move(other.convertedParams_)) {
+    other.validParams_ = false;
+  };
+  ConvertedParams& operator=(ConvertedParams&& other) {
+    if (this == &other) {
+      return *this;
     }
 
-    ConvertedParams() = delete;
-    ConvertedParams(const ConvertedParams &other) = delete;
-    ConvertedParams &operator=(const ConvertedParams &other) = delete;
+    convertedParams_ = std::move(other.convertedParams_);
+    validParams_ = true;
+    other.validParams_ = false;
+    return *this;
+  }
 
-    ~ConvertedParams()
-    {
-        if (validParams_) {
-            ReleaseConvertTypes(convertedParams_);
-            if (releaseMemFunc_) {
-                releaseMemFunc_(nullptr, false);
-            }
-            if (unInitMemFunc_) {
-                unInitMemFunc_(nullptr, false);
-            }
-        }
+  ConvertedParams() = delete;
+  ConvertedParams(const ConvertedParams& other) = delete;
+  ConvertedParams& operator=(const ConvertedParams& other) = delete;
+
+  ~ConvertedParams() {
+    if (validParams_) {
+      ReleaseConvertTypes(convertedParams_);
+      if (releaseMemFunc_) {
+        releaseMemFunc_(nullptr, false);
+      }
+      if (unInitMemFunc_) {
+        unInitMemFunc_(nullptr, false);
+      }
     }
+  }
 
-    const Tuple &GetConvertedParams() const
-    {
-        return convertedParams_;
-    }
+  const Tuple& GetConvertedParams() const {
+    return convertedParams_;
+  }
 
-    template <size_t i> auto Get()
-    {
-        return std::get<i>(convertedParams_);
-    }
+  template <size_t i>
+  auto Get() {
+    return std::get<i>(convertedParams_);
+  }
 
-private:
-    Tuple convertedParams_;
-    ReleaseHugeMem releaseMemFunc_ = nullptr;
-    UnInitHugeMemThreadLocal unInitMemFunc_ = nullptr;
-    bool validParams_{true};
+ private:
+  Tuple convertedParams_;
+  ReleaseHugeMem releaseMemFunc_ = nullptr;
+  UnInitHugeMemThreadLocal unInitMemFunc_ = nullptr;
+  bool validParams_{true};
 };
 
 /**
  * 同步调用npu执行，返回把aten的tensor, scalar, array等转换后的参数,
  */
-#define EXEC_NPU_CMD_SYNC(aclnn_api, ...)                                                                              \
-    [](const char *apiName, const char *workspaceSizeApiName, auto &...args) -> auto {                                 \
-        static const auto getWorkspaceSizeFuncAddr = GetOpApiFuncAddr(workspaceSizeApiName);                           \
-        static const auto opApiFuncAddr = GetOpApiFuncAddr(apiName);                                                   \
-        static const auto initMemAddr = GetOpApiFuncAddr("InitHugeMemThreadLocal");                                    \
-        static const auto unInitMemAddr = GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                                \
-        static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");                                         \
-        static const auto initPTACacheThreadLocalAddr = GetOpApiFuncAddr("InitPTACacheThreadLocal");                   \
-        static const auto setPTAHashKeyAddr = GetOpApiFuncAddr("SetPTAHashKey");                                       \
-        TORCH_CHECK(getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr, #aclnn_api, " and ",              \
-                    #aclnn_api "GetWorkspaceSize", " not in ", GetOpApiLibName(), ", or ", GetOpApiLibName(),          \
-                    "not found.", OPS_ERROR(ErrCode::PTR));                                                            \
-        auto acl_stream = c10_npu::getCurrentNPUStream().stream();                                                     \
-        uint64_t workspace_size = 0;                                                                                   \
-        uint64_t *workspace_size_addr = &workspace_size;                                                               \
-        aclOpExecutor *executor = nullptr;                                                                             \
-        aclOpExecutor **executor_addr = &executor;                                                                     \
-        InitHugeMemThreadLocal initMemFunc = reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);                    \
-        UnInitHugeMemThreadLocal unInitMemFunc = reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);            \
-        ReleaseHugeMem releaseMemFunc = reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                              \
-        InitPTACacheThreadLocal initPTACacheThreadLocalFunc =                                                          \
-            reinterpret_cast<InitPTACacheThreadLocal>(initPTACacheThreadLocalAddr);                                    \
-        SetPTAHashKey setPTAHashKeyFunc = reinterpret_cast<SetPTAHashKey>(setPTAHashKeyAddr);                          \
-        if (initPTACacheThreadLocalFunc && setPTAHashKeyFunc) {                                                        \
-            initPTACacheThreadLocalFunc();                                                                             \
-            setPTAHashKeyFunc(0);                                                                                      \
-        }                                                                                                              \
-        at_npu::native::SetDeterministic();                                                                            \
-        if (initMemFunc) {                                                                                             \
-            initMemFunc(nullptr, false);                                                                               \
-        }                                                                                                              \
-        auto converted_params = ConvertTypes(args..., workspace_size_addr, executor_addr);                             \
-        static auto getWorkspaceSizeFunc = ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);             \
-        auto workspace_status = call(getWorkspaceSizeFunc, converted_params);                                          \
-        TORCH_CHECK(workspace_status == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg(),                \
-            OPS_ERROR(ErrCode::INTERNAL));                                                                             \
-        void *workspace_addr = nullptr;                                                                                \
-        at::Tensor workspace_tensor;                                                                                   \
-        if (workspace_size != 0) {                                                                                     \
-            workspace_tensor = at_npu::native::OpPreparation::unsafe_empty_workspace(workspace_size);                  \
-            workspace_addr = const_cast<void *>(workspace_tensor.storage().data());                                    \
-        }                                                                                                              \
-        auto acl_call = [converted_params, workspace_addr, workspace_size, acl_stream, executor, apiName]()-> int {    \
-            OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);                                          \
-            auto api_ret = opApiFunc(workspace_addr, workspace_size, executor, acl_stream);                            \
-            TORCH_CHECK(api_ret == 0, "call " #aclnn_api " failed, detail:", aclGetRecentErrMsg(),                     \
-                OPS_ERROR(ErrCode::INTERNAL));                                                                         \
-            return api_ret;                                                                                            \
-        };                                                                                                             \
-        at_npu::native::OpCommand cmd;                                                                                 \
-        cmd.Name(apiName);                                                                                             \
-        cmd.SetCustomHandler(acl_call);                                                                                \
-        cmd.Run();                                                                                                     \
-        UnInitCacheThreadLocal();                                                                                      \
-        cmd.Sync();                                                                                                    \
-        return ConvertedParams<decltype(converted_params)>(std::move(converted_params),                                \
-            releaseMemFunc, unInitMemFunc);                                                                            \
-    }(#aclnn_api, #aclnn_api "GetWorkspaceSize", __VA_ARGS__)
+#define EXEC_NPU_CMD_SYNC(aclnn_api, ...)                                    \
+  [](const char* apiName,                                                    \
+     const char* workspaceSizeApiName,                                       \
+     auto&... args) -> auto {                                                \
+    static const auto getWorkspaceSizeFuncAddr =                             \
+        GetOpApiFuncAddr(workspaceSizeApiName);                              \
+    static const auto opApiFuncAddr = GetOpApiFuncAddr(apiName);             \
+    static const auto initMemAddr =                                          \
+        GetOpApiFuncAddr("InitHugeMemThreadLocal");                          \
+    static const auto unInitMemAddr =                                        \
+        GetOpApiFuncAddr("UnInitHugeMemThreadLocal");                        \
+    static const auto releaseMemAddr = GetOpApiFuncAddr("ReleaseHugeMem");   \
+    static const auto initPTACacheThreadLocalAddr =                          \
+        GetOpApiFuncAddr("InitPTACacheThreadLocal");                         \
+    static const auto setPTAHashKeyAddr = GetOpApiFuncAddr("SetPTAHashKey"); \
+    TORCH_CHECK(                                                             \
+        getWorkspaceSizeFuncAddr != nullptr && opApiFuncAddr != nullptr,     \
+        #aclnn_api,                                                          \
+        " and ",                                                             \
+        #aclnn_api "GetWorkspaceSize",                                       \
+        " not in ",                                                          \
+        GetOpApiLibName(),                                                   \
+        ", or ",                                                             \
+        GetOpApiLibName(),                                                   \
+        "not found.",                                                        \
+        OPS_ERROR(ErrCode::PTR));                                            \
+    auto acl_stream = c10::npu::getCurrentNPUStream().stream();              \
+    uint64_t workspace_size = 0;                                             \
+    uint64_t* workspace_size_addr = &workspace_size;                         \
+    aclOpExecutor* executor = nullptr;                                       \
+    aclOpExecutor** executor_addr = &executor;                               \
+    InitHugeMemThreadLocal initMemFunc =                                     \
+        reinterpret_cast<InitHugeMemThreadLocal>(initMemAddr);               \
+    UnInitHugeMemThreadLocal unInitMemFunc =                                 \
+        reinterpret_cast<UnInitHugeMemThreadLocal>(unInitMemAddr);           \
+    ReleaseHugeMem releaseMemFunc =                                          \
+        reinterpret_cast<ReleaseHugeMem>(releaseMemAddr);                    \
+    InitPTACacheThreadLocal initPTACacheThreadLocalFunc =                    \
+        reinterpret_cast<InitPTACacheThreadLocal>(                           \
+            initPTACacheThreadLocalAddr);                                    \
+    SetPTAHashKey setPTAHashKeyFunc =                                        \
+        reinterpret_cast<SetPTAHashKey>(setPTAHashKeyAddr);                  \
+    if (initPTACacheThreadLocalFunc && setPTAHashKeyFunc) {                  \
+      initPTACacheThreadLocalFunc();                                         \
+      setPTAHashKeyFunc(0);                                                  \
+    }                                                                        \
+    at_npu::native::SetDeterministic();                                      \
+    if (initMemFunc) {                                                       \
+      initMemFunc(nullptr, false);                                           \
+    }                                                                        \
+    auto converted_params =                                                  \
+        ConvertTypes(args..., workspace_size_addr, executor_addr);           \
+    static auto getWorkspaceSizeFunc =                                       \
+        ConvertToOpApiFunc(converted_params, getWorkspaceSizeFuncAddr);      \
+    auto workspace_status = call(getWorkspaceSizeFunc, converted_params);    \
+    TORCH_CHECK(                                                             \
+        workspace_status == 0,                                               \
+        "call " #aclnn_api " failed, detail:",                               \
+        aclGetRecentErrMsg(),                                                \
+        OPS_ERROR(ErrCode::INTERNAL));                                       \
+    void* workspace_addr = nullptr;                                          \
+    at::Tensor workspace_tensor;                                             \
+    if (workspace_size != 0) {                                               \
+      workspace_tensor =                                                     \
+          at_npu::native::OpPreparation::unsafe_empty_workspace(             \
+              workspace_size);                                               \
+      workspace_addr = const_cast<void*>(workspace_tensor.storage().data()); \
+    }                                                                        \
+    auto acl_call = [converted_params,                                       \
+                     workspace_addr,                                         \
+                     workspace_size,                                         \
+                     acl_stream,                                             \
+                     executor,                                               \
+                     apiName]() -> int {                                     \
+      OpApiFunc opApiFunc = reinterpret_cast<OpApiFunc>(opApiFuncAddr);      \
+      auto api_ret =                                                         \
+          opApiFunc(workspace_addr, workspace_size, executor, acl_stream);   \
+      TORCH_CHECK(                                                           \
+          api_ret == 0,                                                      \
+          "call " #aclnn_api " failed, detail:",                             \
+          aclGetRecentErrMsg(),                                              \
+          OPS_ERROR(ErrCode::INTERNAL));                                     \
+      return api_ret;                                                        \
+    };                                                                       \
+    at_npu::native::OpCommand cmd;                                           \
+    cmd.Name(apiName);                                                       \
+    cmd.SetCustomHandler(acl_call);                                          \
+    cmd.Run();                                                               \
+    UnInitCacheThreadLocal();                                                \
+    cmd.Sync();                                                              \
+    return ConvertedParams<decltype(converted_params)>(                      \
+        std::move(converted_params), releaseMemFunc, unInitMemFunc);         \
+  }                                                                          \
+  (#aclnn_api, #aclnn_api "GetWorkspaceSize", __VA_ARGS__)
 
 #endif //  TORCHNPU_TORCH_NPU_CSRC_ATEN_OPS_OP_API_PTA_COMMON_H_

--- a/npu/core/DeviceUtils.h
+++ b/npu/core/DeviceUtils.h
@@ -46,13 +46,13 @@ inline c10::DeviceType get_npu_device_type() {
 
 inline void maybe_initialize_npu(const at::TensorOptions& options) {
   if (torch_npu::utils::is_npu(options)) {
-    c10_npu::TryInitDevice(options.device().index());
+    c10::npu::TryInitDevice(options.device().index());
   }
 }
 
 inline void maybe_initialize_npu(const at::Device& device) {
   if (torch_npu::utils::is_npu(device)) {
-    c10_npu::TryInitDevice(device.index());
+    c10::npu::TryInitDevice(device.index());
   }
 }
 

--- a/npu/core/NPUErrorCodes.h
+++ b/npu/core/NPUErrorCodes.h
@@ -2,7 +2,7 @@
 
 #include <unordered_map>
 
-namespace c10_npu::acl {
+namespace c10::npu::acl {
 
 class AclErrorCode {
  public:
@@ -556,4 +556,4 @@ on the device."},
         Rectify the fault based on the error information in the ascend log."},
   }; /* aclError code */
 };
-} // namespace c10_npu::acl
+} // namespace c10::npu::acl

--- a/npu/core/NPUException.cpp
+++ b/npu/core/NPUException.cpp
@@ -30,8 +30,8 @@ std::unordered_map<ErrCode, std::string> errCodeMap = {
 std::string formatErrorCode(SubModule submodule, ErrCode errorCode) {
   std::ostringstream oss;
   c10::DeviceIndex deviceIndex = -1;
-  c10_npu::GetDevice(&deviceIndex);
-  auto rank_id = c10_npu::option::OptionsManager::GetRankId();
+  c10::npu::GetDevice(&deviceIndex);
+  auto rank_id = c10::npu::option::OptionsManager::GetRankId();
   oss << "\n[ERROR] " << getCurrentTimestamp() << " (PID:" << getpid()
       << ", Device:" << deviceIndex << ", RankID:" << rank_id << ") ";
   oss << "ERR" << std::setw(2) << std::setfill('0')
@@ -60,14 +60,14 @@ static std::string getCurrentTimestamp() {
   return oss.str();
 }
 
-namespace c10_npu {
+namespace c10::npu {
 
 const char* getDeviceErrorMessage() {
   return aclGetRecentErrMsg();
 }
 
 const std::string getErrorMessage(int error_code) {
-  static c10_npu::acl::AclErrorCode aclErrorCode;
+  static c10::npu::acl::AclErrorCode aclErrorCode;
   auto itr = aclErrorCode.error_code_map.find(error_code);
   if (itr == aclErrorCode.error_code_map.end()) {
     return "";
@@ -75,4 +75,4 @@ const std::string getErrorMessage(int error_code) {
   return "\n[Error]: " + itr->second;
 }
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/NPUException.h
+++ b/npu/core/NPUException.h
@@ -15,20 +15,20 @@
 #include "csrc/core/Macros.h"
 #include "npu/core/NPUErrorCodes.h"
 
-#define C10_NPU_SHOW_ERR_MSG()                                  \
-  do {                                                          \
-    std::cout << c10_npu::getDeviceErrorMessage() << std::endl; \
+#define C10_NPU_SHOW_ERR_MSG()                                   \
+  do {                                                           \
+    std::cout << c10::npu::getDeviceErrorMessage() << std::endl; \
   } while (0)
 
-#define NPU_CHECK_WARN(err_code)             \
-  do {                                       \
-    auto Error = err_code;                   \
-    if ((Error) != ACL_ERROR_NONE) {         \
-      TORCH_BACKEND_FORMAT_WARN(             \
-          err_code,                          \
-          c10_npu::getErrorMessage(Error),   \
-          c10_npu::getDeviceErrorMessage()); \
-    }                                        \
+#define NPU_CHECK_WARN(err_code)              \
+  do {                                        \
+    auto Error = err_code;                    \
+    if ((Error) != ACL_ERROR_NONE) {          \
+      TORCH_BACKEND_FORMAT_WARN(              \
+          err_code,                           \
+          c10::npu::getErrorMessage(Error),   \
+          c10::npu::getDeviceErrorMessage()); \
+    }                                         \
   } while (0)
 
 #define TORCH_NPU_WARN(...) TORCH_BACKEND_WARN(__VA_ARGS__)
@@ -80,11 +80,11 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
     if ((Error) != ACL_ERROR_NONE) {                  \
       TORCH_BACKEND_FORMAT_ERROR(                     \
           Error,                                      \
-          c10_npu::getErrorMessage(Error),            \
+          c10::npu::getErrorMessage(Error),           \
           " NPU function error: ",                    \
           getErrorFunction(#err_code, ##__VA_ARGS__), \
           PTA_ERROR(ErrCode::ACL),                    \
-          c10_npu::getDeviceErrorMessage());          \
+          c10::npu::getDeviceErrorMessage());         \
     }                                                 \
   } while (0)
 
@@ -94,18 +94,18 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
     if ((Error) != ACL_ERROR_NONE) {                  \
       TORCH_BACKEND_FORMAT_ERROR(                     \
           Error,                                      \
-          c10_npu::getErrorMessage(Error),            \
+          c10::npu::getErrorMessage(Error),           \
           " OPS function error: ",                    \
           getErrorFunction(#err_code, ##__VA_ARGS__), \
           OPS_ERROR(ErrCode::ACL),                    \
-          c10_npu::getDeviceErrorMessage())           \
+          c10::npu::getDeviceErrorMessage())          \
     }                                                 \
   } while (0)
 
 #define NPU_CHECK_SUPPORTED_OR_ERROR(err_code)                      \
   do {                                                              \
     auto Error = err_code;                                          \
-    static c10_npu::acl::AclErrorCode err_map;                      \
+    static c10::npu::acl::AclErrorCode err_map;                     \
     if ((Error) != ACL_ERROR_NONE) {                                \
       if ((Error) == ACL_ERROR_RT_FEATURE_NOT_SUPPORT) {            \
         static auto feature_not_support_warn_once = []() {          \
@@ -121,15 +121,15 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
       } else {                                                      \
         TORCH_BACKEND_FORMAT_ERROR(                                 \
             Error,                                                  \
-            c10_npu::getErrorMessage(Error),                        \
-            c10_npu::getDeviceErrorMessage());                      \
+            c10::npu::getErrorMessage(Error),                       \
+            c10::npu::getDeviceErrorMessage());                     \
       }                                                             \
     }                                                               \
   } while (0)
-namespace c10_npu {
+namespace c10::npu {
 
 C10_BACKEND_API const char* getDeviceErrorMessage();
 
 C10_BACKEND_API const std::string getErrorMessage(int error_code);
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/NPUPeerToPeerAccess.cpp
+++ b/npu/core/NPUPeerToPeerAccess.cpp
@@ -2,10 +2,10 @@
 
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
-#include "csrc/npu/NPUFunctions.h"
 #include <npu/acl/include/acl/acl_rt.h>
-#include "npu/core/NPUPeerToPeerAccess.h"
+#include "csrc/npu/NPUFunctions.h"
 #include "npu/core/NPUException.h"
+#include "npu/core/NPUPeerToPeerAccess.h"
 
 // A maximum of 8 P2P links can be created on a NPU device
 #define C10_P2P_ACCESS_MAX_NPUS 8
@@ -14,7 +14,7 @@ namespace at_npu {
 namespace native {
 
 NpuP2pCtrl::NpuP2pCtrl() {
-  num_devices_ = c10_npu::device_count();
+  num_devices_ = c10::npu::device_count();
 
   device_enabled_count_.clear();
   device_enabled_count_.resize(num_devices_, 1);

--- a/npu/core/NPUQueue.cpp
+++ b/npu/core/NPUQueue.cpp
@@ -6,14 +6,14 @@
 #include "npu/framework/utils/NpuUtils.h"
 
 #include <ATen/record_function.h>
+#include <npu/acl/include/acl/acl_rt.h>
 #include <sys/eventfd.h>
 #include <sys/prctl.h>
 #include <sys/time.h>
-#include <npu/acl/include/acl/acl_rt.h>
 #include <unistd.h>
 #include <sstream>
 
-namespace c10_npu {
+namespace c10::npu {
 
 struct timeval delay = {0, 1};
 
@@ -168,22 +168,22 @@ static constexpr size_t kQueueCapacity = 4096;
 static std::string repo_error;
 
 std::string get_func_error_msg(void* error_paras) {
-  auto queueParam = static_cast<c10_npu::queue::QueueParas*>(error_paras);
+  auto queueParam = static_cast<c10::npu::queue::QueueParas*>(error_paras);
   auto type = queueParam->paramType;
   std::stringstream result;
-  if (type == c10_npu::queue::COMPILE_AND_EXECUTE) {
+  if (type == c10::npu::queue::COMPILE_AND_EXECUTE) {
     auto cur_paras =
         static_cast<at_npu::native::ExecuteParas*>(queueParam->paramVal);
     auto op_name = cur_paras->opType;
     result << "the current working operator name is " << op_name;
-  } else if (type == c10_npu::queue::ASYNC_MEMCPY) {
+  } else if (type == c10::npu::queue::ASYNC_MEMCPY) {
     auto cur_paras =
-        static_cast<c10_npu::queue::CopyParas*>(queueParam->paramVal);
+        static_cast<c10::npu::queue::CopyParas*>(queueParam->paramVal);
     result << "the current copy params are srclen=" << cur_paras->srcLen
            << ", dstlen=" << cur_paras->dstLen << ", kind=" << cur_paras->kind;
   } else {
     auto cur_paras =
-        static_cast<c10_npu::queue::EventParas*>(queueParam->paramVal);
+        static_cast<c10::npu::queue::EventParas*>(queueParam->paramVal);
     result << "the current working event is " << cur_paras->event;
   }
   return result.str();
@@ -501,7 +501,7 @@ void StartConsume(Repository* repo, c10::DeviceIndex device_id) {
     ASCEND_LOGE("set thread name failed!");
   }
 
-  aclError ret = c10_npu::SetDevice(device_id);
+  aclError ret = c10::npu::SetDevice(device_id);
   if (ret != 0) {
     C10_NPU_SHOW_ERR_MSG();
     ASCEND_LOGE(
@@ -676,4 +676,4 @@ void ReleaseQueue::ChangeStatus(RepoStatus expected, RepoStatus desired) {
 
   repo_status.compare_exchange_strong(expected, desired);
 }
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/NPUQueue.h
+++ b/npu/core/NPUQueue.h
@@ -9,7 +9,7 @@
 #include <npu/acl/include/acl/acl_op.h>
 #include "npu/core/npu_log.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
 struct sring_idx {
   bool working = false;
@@ -159,7 +159,7 @@ class NPUCallBackRegisterBuilder {
 
 #define REGISTER_QUEUE_FUNC(                                                 \
     execF, copyF, releaseF, newF, deleteF, copyReleaseParamF, releaseParamF) \
-  static ::c10_npu::register_queue_cb::NPUCallBackRegisterBuilder            \
+  static ::c10::npu::register_queue_cb::NPUCallBackRegisterBuilder           \
       register_queue_func_builder(                                           \
           execF,                                                             \
           copyF,                                                             \
@@ -168,4 +168,4 @@ class NPUCallBackRegisterBuilder {
           deleteF,                                                           \
           copyReleaseParamF,                                                 \
           releaseParamF);
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/NpuVariables.cpp
+++ b/npu/core/NpuVariables.cpp
@@ -5,7 +5,7 @@
 #include "npu/core/NpuVariables.h"
 #include "npu/core/register/OptionsManager.h"
 
-namespace c10_npu {
+namespace c10::npu {
 static SocVersion g_curSocVersion = SocVersion::UnsupportedSocVersion;
 
 static std::map<std::string, SocVersion> socVersionMap = {
@@ -58,7 +58,7 @@ const SocVersion& GetSocVersion() {
 }
 
 bool IsSupportInfNan() {
-  if (!c10_npu::option::OptionsManager::CheckInfNanModeEnable()) {
+  if (!c10::npu::option::OptionsManager::CheckInfNanModeEnable()) {
     return false;
   }
   const static bool supportInfNan = []() -> bool {
@@ -72,4 +72,4 @@ bool IsSupportInfNan() {
 bool IsBF16Supported() {
   return GetSocVersion() >= SocVersion::Ascend910B1;
 }
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/NpuVariables.h
+++ b/npu/core/NpuVariables.h
@@ -1,7 +1,7 @@
 #ifndef NPUVARIABLES_H
 #define NPUVARIABLES_H
 
-namespace c10_npu {
+namespace c10::npu {
 enum class SocVersion {
   UnsupportedSocVersion = -1,
   Ascend910PremiumA = 100,
@@ -38,5 +38,5 @@ const SocVersion& GetSocVersion();
 bool IsSupportInfNan();
 
 bool IsBF16Supported();
-} // namespace c10_npu
+} // namespace c10::npu
 #endif

--- a/npu/core/OverflowUtils.cpp
+++ b/npu/core/OverflowUtils.cpp
@@ -1,8 +1,8 @@
 #include <ATen/ATen.h>
 
+#include "npu/aten/OpInterface.h"
 #include "npu/core/OverflowUtils.h"
 #include "npu/core/sys_ctrl/npu_sys_ctrl.h"
-#include "npu/aten/OpInterface.h"
 
 namespace torch_npu {
 namespace utils {

--- a/npu/core/interface/AsyncTaskQueueInterface.cpp
+++ b/npu/core/interface/AsyncTaskQueueInterface.cpp
@@ -1,9 +1,9 @@
 #include "AsyncTaskQueueInterface.h"
 #include <ATen/record_function.h>
-#include "npu/core/register/OptionsManager.h"
 #include "npu/acl/include/acl/acl_rt.h"
+#include "npu/core/register/OptionsManager.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace queue {
 std::atomic<uint64_t> QueueParas::g_correlation_id{0};
 std::map<int64_t, std::string> CopyParas::COPY_PARAS_MAP{
@@ -61,14 +61,14 @@ AsyncCopyTask::AsyncCopyTask(
 void AsyncCopyTask::LaunchCopyTask() {
   RECORD_FUNCTION(
       CopyParas::COPY_PARAS_MAP[copyParam_.kind], std::vector<c10::IValue>({}));
-    c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
-    NPU_CHECK_ERROR(aclrtMemcpyAsync(
-        copyParam_.dst,
-        copyParam_.dstLen,
-        copyParam_.src,
-        copyParam_.srcLen,
-        copyParam_.kind,
-        stream));
+  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
+  NPU_CHECK_ERROR(aclrtMemcpyAsync(
+      copyParam_.dst,
+      copyParam_.dstLen,
+      copyParam_.src,
+      copyParam_.srcLen,
+      copyParam_.kind,
+      stream));
 }
 
 aclError LaunchAsyncCopyTask(
@@ -83,4 +83,4 @@ aclError LaunchAsyncCopyTask(
 }
 
 } // namespace queue
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/interface/AsyncTaskQueueInterface.h
+++ b/npu/core/interface/AsyncTaskQueueInterface.h
@@ -4,7 +4,7 @@
 #include "csrc/npu/NPUStream.h"
 #include "npu/acl/include/acl/acl_rt.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace queue {
 struct CopyParas {
   void* dst = nullptr;
@@ -60,4 +60,4 @@ aclError LaunchAsyncCopyTask(
     aclrtMemcpyKind kind);
 
 } // namespace queue
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/npu_log.h
+++ b/npu/core/npu_log.h
@@ -3,8 +3,8 @@
 #include <stdio.h>
 #include <iostream>
 #include <string>
-#include "npu/core/register/OptionsManager.h"
 #include "npu/acl/include/acl/acl_base.h"
+#include "npu/core/register/OptionsManager.h"
 
 #define NPUStatus std::string
 #define SUCCESS "SUCCESS"
@@ -13,11 +13,35 @@
 #define ALLOC_ERROR "ALLOC_ERROR"
 #define FAILED "FAILED"
 
-#define ASCEND_LOGE(fmt, ...)                                           \
+#define ASCEND_LOGE(fmt, ...)                                            \
+  do {                                                                   \
+    if (c10::npu::option::OptionsManager::isACLGlobalLogOn(ACL_ERROR)) { \
+      aclAppLog(                                                         \
+          ACL_ERROR,                                                     \
+          __FILENAME__,                                                  \
+          __FUNCTION__,                                                  \
+          __LINE__,                                                      \
+          "[PTA]:" #fmt,                                                 \
+          ##__VA_ARGS__);                                                \
+    }                                                                    \
+  } while (0);
+#define ASCEND_LOGW(fmt, ...)                                              \
+  do {                                                                     \
+    if (c10::npu::option::OptionsManager::isACLGlobalLogOn(ACL_WARNING)) { \
+      aclAppLog(                                                           \
+          ACL_WARNING,                                                     \
+          __FILENAME__,                                                    \
+          __FUNCTION__,                                                    \
+          __LINE__,                                                        \
+          "[PTA]:" #fmt,                                                   \
+          ##__VA_ARGS__);                                                  \
+    }                                                                      \
+  } while (0);
+#define ASCEND_LOGI(fmt, ...)                                           \
   do {                                                                  \
-    if (c10_npu::option::OptionsManager::isACLGlobalLogOn(ACL_ERROR)) { \
+    if (c10::npu::option::OptionsManager::isACLGlobalLogOn(ACL_INFO)) { \
       aclAppLog(                                                        \
-          ACL_ERROR,                                                    \
+          ACL_INFO,                                                     \
           __FILENAME__,                                                 \
           __FUNCTION__,                                                 \
           __LINE__,                                                     \
@@ -25,39 +49,15 @@
           ##__VA_ARGS__);                                               \
     }                                                                   \
   } while (0);
-#define ASCEND_LOGW(fmt, ...)                                             \
-  do {                                                                    \
-    if (c10_npu::option::OptionsManager::isACLGlobalLogOn(ACL_WARNING)) { \
-      aclAppLog(                                                          \
-          ACL_WARNING,                                                    \
-          __FILENAME__,                                                   \
-          __FUNCTION__,                                                   \
-          __LINE__,                                                       \
-          "[PTA]:" #fmt,                                                  \
-          ##__VA_ARGS__);                                                 \
-    }                                                                     \
-  } while (0);
-#define ASCEND_LOGI(fmt, ...)                                          \
-  do {                                                                 \
-    if (c10_npu::option::OptionsManager::isACLGlobalLogOn(ACL_INFO)) { \
-      aclAppLog(                                                       \
-          ACL_INFO,                                                    \
-          __FILENAME__,                                                \
-          __FUNCTION__,                                                \
-          __LINE__,                                                    \
-          "[PTA]:" #fmt,                                               \
-          ##__VA_ARGS__);                                              \
-    }                                                                  \
-  } while (0);
-#define ASCEND_LOGD(fmt, ...)                                           \
-  do {                                                                  \
-    if (c10_npu::option::OptionsManager::isACLGlobalLogOn(ACL_DEBUG)) { \
-      aclAppLog(                                                        \
-          ACL_DEBUG,                                                    \
-          __FILENAME__,                                                 \
-          __FUNCTION__,                                                 \
-          __LINE__,                                                     \
-          "[PTA]:" #fmt,                                                \
-          ##__VA_ARGS__);                                               \
-    }                                                                   \
+#define ASCEND_LOGD(fmt, ...)                                            \
+  do {                                                                   \
+    if (c10::npu::option::OptionsManager::isACLGlobalLogOn(ACL_DEBUG)) { \
+      aclAppLog(                                                         \
+          ACL_DEBUG,                                                     \
+          __FILENAME__,                                                  \
+          __FUNCTION__,                                                  \
+          __LINE__,                                                      \
+          "[PTA]:" #fmt,                                                 \
+          ##__VA_ARGS__);                                                \
+    }                                                                    \
   } while (0);

--- a/npu/core/register/FunctionLoader.cpp
+++ b/npu/core/register/FunctionLoader.cpp
@@ -3,7 +3,7 @@
 #include "npu/core/NPUException.h"
 #include "npu/core/register/FunctionLoader.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace option {
 
 FunctionLoader::FunctionLoader(const std::string& name) {
@@ -94,4 +94,4 @@ FunctionRegisterBuilder::FunctionRegisterBuilder(
 } // namespace register_function
 
 } // namespace option
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/register/FunctionLoader.h
+++ b/npu/core/register/FunctionLoader.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace c10_npu {
+namespace c10::npu {
 namespace option {
 
 /**
@@ -88,19 +88,19 @@ class FunctionRegisterBuilder {
 
 } // namespace register_function
 
-#define REGISTER_LIBRARY(soName)                                              \
-  auto library_##soName = ::std::unique_ptr<c10_npu::option::FunctionLoader>( \
-      new c10_npu::option::FunctionLoader(#soName));                          \
-  static c10_npu::option::register_function::FunctionRegisterBuilder          \
+#define REGISTER_LIBRARY(soName)                                               \
+  auto library_##soName = ::std::unique_ptr<c10::npu::option::FunctionLoader>( \
+      new c10::npu::option::FunctionLoader(#soName));                          \
+  static c10::npu::option::register_function::FunctionRegisterBuilder          \
       register_library_##soName(#soName, library_##soName);
 
-#define REGISTER_FUNCTION(soName, funcName)                          \
-  static c10_npu::option::register_function::FunctionRegisterBuilder \
+#define REGISTER_FUNCTION(soName, funcName)                           \
+  static c10::npu::option::register_function::FunctionRegisterBuilder \
       register_function_##funcName(#soName, #funcName);
 
-#define GET_FUNCTION(soName, funcName)                                      \
-  c10_npu::option::register_function::FunctionRegister::GetInstance()->Get( \
+#define GET_FUNCTION(soName, funcName)                                       \
+  c10::npu::option::register_function::FunctionRegister::GetInstance()->Get( \
       #soName, #funcName);
 
 } // namespace option
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/register/OptionRegister.cpp
+++ b/npu/core/register/OptionRegister.cpp
@@ -3,7 +3,7 @@
 #include "npu/core/NPUException.h"
 #include "npu/core/register/OptionRegister.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace option {
 
 OptionInterface::OptionInterface(OptionCallBack callback) {
@@ -86,4 +86,4 @@ c10::optional<std::string> GetOption(const std::string& key) {
 }
 
 } // namespace option
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/register/OptionRegister.h
+++ b/npu/core/register/OptionRegister.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace c10_npu {
+namespace c10::npu {
 namespace option {
 
 typedef void (*OptionCallBack)(const std::string&);
@@ -105,27 +105,27 @@ c10::optional<std::string> GetOption(const std::string& key);
 
 #define REGISTER_OPTION_INIT_BY_ENV(name) REGISTER_OPTION_UNIQ(name, name, env)
 
-#define REGISTER_OPTION_UNIQ(id, name, type)                       \
-  auto options_interface_##id =                                    \
-      ::std::unique_ptr<c10_npu::option::OptionInterface>(         \
-          new c10_npu::option::OptionInterface());                 \
-  static c10_npu::option::register_options::OptionInterfaceBuilder \
+#define REGISTER_OPTION_UNIQ(id, name, type)                        \
+  auto options_interface_##id =                                     \
+      ::std::unique_ptr<c10::npu::option::OptionInterface>(         \
+          new c10::npu::option::OptionInterface());                 \
+  static c10::npu::option::register_options::OptionInterfaceBuilder \
       register_options_interface_##id(#name, options_interface_##id, #type);
 
 #define REGISTER_OPTION_HOOK(name, ...) \
   REGISTER_OPTION_HOOK_UNIQ(name, name, __VA_ARGS__)
 
-#define REGISTER_OPTION_HOOK_UNIQ(id, name, ...)                   \
-  auto options_interface_##id =                                    \
-      ::std::unique_ptr<c10_npu::option::OptionInterface>(         \
-          new c10_npu::option::OptionInterface(                    \
-              c10_npu::option::OptionCallBack(__VA_ARGS__)));      \
-  static c10_npu::option::register_options::OptionInterfaceBuilder \
+#define REGISTER_OPTION_HOOK_UNIQ(id, name, ...)                    \
+  auto options_interface_##id =                                     \
+      ::std::unique_ptr<c10::npu::option::OptionInterface>(         \
+          new c10::npu::option::OptionInterface(                    \
+              c10::npu::option::OptionCallBack(__VA_ARGS__)));      \
+  static c10::npu::option::register_options::OptionInterfaceBuilder \
       register_options_interface_##id(#name, options_interface_##id);
 
 #define REGISTER_OPTION_BOOL_FUNCTION(func, key, defaultVal, trueVal) \
   bool func() {                                                       \
-    auto val = c10_npu::option::GetOption(#key);                      \
+    auto val = c10::npu::option::GetOption(#key);                     \
     if (val.value_or(defaultVal) == (trueVal)) {                      \
       return true;                                                    \
     }                                                                 \
@@ -134,26 +134,26 @@ c10::optional<std::string> GetOption(const std::string& key);
 
 #define REGISTER_OPTION_BOOL_FUNCTION_UNIQ(func, key, defaultVal, trueVal) \
   bool func() {                                                            \
-    static auto val = c10_npu::option::GetOption(#key);                    \
+    static auto val = c10::npu::option::GetOption(#key);                   \
     if (val.value_or(defaultVal) == (trueVal)) {                           \
       return true;                                                         \
     }                                                                      \
     return false;                                                          \
   }
 
-#define REGISTER_OPTION_BOOL_FUNCTION_ALL_CASE(  \
-    func, key, defaultVal, falseVal, trueVal)    \
-  bool func() {                                  \
-    auto val = c10_npu::option::GetOption(#key); \
-    if (val.has_value()) {                       \
-      if (val.value() == (trueVal)) {            \
-        return true;                             \
-      }                                          \
-      if (val.value() == (falseVal)) {           \
-        return false;                            \
-      }                                          \
-    }                                            \
-    return (defaultVal) == (trueVal);            \
+#define REGISTER_OPTION_BOOL_FUNCTION_ALL_CASE(   \
+    func, key, defaultVal, falseVal, trueVal)     \
+  bool func() {                                   \
+    auto val = c10::npu::option::GetOption(#key); \
+    if (val.has_value()) {                        \
+      if (val.value() == (trueVal)) {             \
+        return true;                              \
+      }                                           \
+      if (val.value() == (falseVal)) {            \
+        return false;                             \
+      }                                           \
+    }                                             \
+    return (defaultVal) == (trueVal);             \
   }
 
 #define REGISTER_OPTION_CACHE(type, valueName, ...)        \
@@ -176,6 +176,6 @@ c10::optional<std::string> GetOption(const std::string& key);
 #define SET_OPTION_WITH_CACHE(valueName, value) SetWithCache##valueName(value)
 
 } // namespace option
-} // namespace c10_npu
+} // namespace c10::npu
 
 #endif // __TORCH_NPU_OPTION_REGISTER_H__

--- a/npu/core/register/OptionsManager.cpp
+++ b/npu/core/register/OptionsManager.cpp
@@ -4,7 +4,7 @@
 #include "npu/core/register/OptionRegister.h"
 #include "npu/core/register/OptionsManager.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace option {
 
 using namespace std;
@@ -132,4 +132,4 @@ std::unordered_map<std::string, std::string> OptionsManager::ParsePerfConfig(
 }
 
 } // namespace option
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/register/OptionsManager.h
+++ b/npu/core/register/OptionsManager.h
@@ -7,7 +7,7 @@
 #include "csrc/core/Macros.h"
 #include "npu/core/NPUException.h"
 
-namespace c10_npu {
+namespace c10::npu {
 namespace option {
 
 class OptionsManager {
@@ -29,4 +29,4 @@ class OptionsManager {
 };
 
 } // namespace option
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/core/sys_ctrl/npu_sys_ctrl.cpp
+++ b/npu/core/sys_ctrl/npu_sys_ctrl.cpp
@@ -40,9 +40,9 @@ NpuSysCtrl::NpuSysCtrl(c10::DeviceIndex device_id) : need_finalize_(true){
 
   // Init allocator
   static c10_npu::NPUCachingAllocator::CachingAllocatorHelper helper;
-  c10_backend::CachingAllocator::registerHelper(&helper);
+  c10::backend::CachingAllocator::registerHelper(&helper);
   const auto num_devices = c10_npu::device_count_ensure_non_zero();
-  c10_backend::CachingAllocator::init(num_devices);
+  c10::backend::CachingAllocator::init(num_devices);
 
   c10_npu::NPUCachingAllocator::init(c10_backend::CachingAllocator::get());
 

--- a/npu/core/sys_ctrl/npu_sys_ctrl.h
+++ b/npu/core/sys_ctrl/npu_sys_ctrl.h
@@ -5,12 +5,12 @@
 #include <map>
 #include <string>
 #include <vector>
+#include "c10/core/Device.h"
 #include "c10/macros/Export.h"
 #include "csrc/core/Macros.h"
 #include "npu/core/npu_log.h"
-#include "c10/core/Device.h"
 
-namespace c10_npu {
+namespace c10::npu {
 
 void TryInitDevice(c10::DeviceIndex device_id = -1);
 class NpuSysCtrl {
@@ -18,9 +18,10 @@ class NpuSysCtrl {
   virtual ~NpuSysCtrl();
 
   friend void TryInitDevice(c10::DeviceIndex device_id);
+
  private:
   NpuSysCtrl(c10::DeviceIndex device_id);
   bool need_finalize_;
 };
 
-} // namespace c10_npu
+} // namespace c10::npu

--- a/npu/framework/OpCommand.cpp
+++ b/npu/framework/OpCommand.cpp
@@ -2,9 +2,9 @@
 #include <string>
 
 #include "csrc/aten/generated/CustomFunctions.h"
-#include "npu/core/NPUException.h"
-#include "csrc/npu/NPUFunctions.h"
 #include "csrc/npu/NPUCachingHostAllocator.h"
+#include "csrc/npu/NPUFunctions.h"
+#include "npu/core/NPUException.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
 #include "npu/core/register/OptionsManager.h"
 #include "npu/framework/OpCmdHelper.h"
@@ -153,9 +153,9 @@ OpCommand& OpCommand::Output(
 void OpCommand::Run() {
   aclCmd->SetEnginePriority();
   const string& op_name = aclCmd->GetName();
-    aclCmd->Run(sync, sync_index, outputTensor);
-    if (c10_npu::option::OptionsManager::CheckBlockingEnable()) {
-      Sync();
+  aclCmd->Run(sync, sync_index, outputTensor);
+  if (c10::npu::option::OptionsManager::CheckBlockingEnable()) {
+    Sync();
     aclCmd->releaseSource();
   }
   aclCmds->Pop();
@@ -170,7 +170,7 @@ OpCommand& OpCommand::Sync(c10::SmallVector<int64_t, N>& index) {
 }
 
 OpCommand& OpCommand::Sync() {
-  c10_npu::NPUStream stream = c10_npu::getCurrentNPUStream();
+  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
   NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(stream, -1));
   return *this;
 }
@@ -261,7 +261,7 @@ at::Tensor OpCommand::CopyHostToDevice(
 at::Tensor OpCommand::CopyHostToDevice(const at::Tensor& cpuTensor) {
   at::Tensor cpuPinMemTensor = cpuTensor.pin_memory();
   c10::DeviceIndex deviceIndex = 0;
-  NPU_CHECK_ERROR(c10_npu::GetDevice(&deviceIndex));
+  NPU_CHECK_ERROR(c10::npu::GetDevice(&deviceIndex));
   auto tensor = cpuPinMemTensor.to(
       c10::Device(c10::DeviceType::PrivateUse1, deviceIndex),
       cpuPinMemTensor.scalar_type(),

--- a/npu/framework/OpParamMaker.h
+++ b/npu/framework/OpParamMaker.h
@@ -19,8 +19,8 @@ namespace native {
 
 typedef union {
   ExecuteParas exeParas;
-  c10_npu::queue::CopyParas copyParas;
-  c10_npu::queue::EventParas eventParas;
+  c10::npu::queue::CopyParas copyParas;
+  c10::npu::queue::EventParas eventParas;
 } TaskParas;
 constexpr size_t MAX_PARAS_BYTE_SIZE = sizeof(TaskParas);
 

--- a/npu/framework/contiguous/ContiguousOpt.cpp
+++ b/npu/framework/contiguous/ContiguousOpt.cpp
@@ -214,7 +214,7 @@ bool TransContiguous::ContiguousOptimizeWithBaseFormat(
   // In non-specific cases, classify the cases and simplify judgement.
   ContiguousTensorDesc src_desc = GetTensorDescInfo(src, opt_cases);
   if (OpenCombined &&
-      c10_npu::option::OptionsManager::CheckCombinedOptimizerEnable()) {
+      c10::npu::option::OptionsManager::CheckCombinedOptimizerEnable()) {
     src_desc.add_optimization_case("combined");
   }
   return cached_contiguous_optimize_with_anyformat_(self, src, src_desc);

--- a/npu/framework/interface/AclOpCompileInterface.cpp
+++ b/npu/framework/interface/AclOpCompileInterface.cpp
@@ -24,7 +24,7 @@ LOAD_FUNCTION(aclopCompileAndExecuteV2)
 LOAD_FUNCTION(aclrtCtxSetSysParamOpt)
 
 aclError AclSetCompileopt(aclCompileOpt opt, const char* value) {
-  bool ge_init_disable = c10_npu::option::OptionsManager::CheckGeInitDisable();
+  bool ge_init_disable = c10::npu::option::OptionsManager::CheckGeInitDisable();
   if (ge_init_disable) {
     return ACL_ERROR_NONE;
   }

--- a/npu/framework/interface/EnvVariables.cpp
+++ b/npu/framework/interface/EnvVariables.cpp
@@ -85,10 +85,10 @@ bool IsAllowFP32ToFP16() {
   // must_keep_origin_dtype, and the default value for others is
   // allow_fp32_to_fp16.
   bool is_allow_fp32_to_fp16 =
-      c10_npu::GetSocVersion() < c10_npu::SocVersion::Ascend910B1;
+      c10::npu::GetSocVersion() < c10::npu::SocVersion::Ascend910B1;
 
   static const std::string precision_mode = "ACL_PRECISION_MODE";
-  auto precision_mode_val = c10_npu::option::GetOption(precision_mode);
+  auto precision_mode_val = c10::npu::option::GetOption(precision_mode);
   if (precision_mode_val.has_value()) {
     if (precision_mode_val.value() == "must_keep_origin_dtype") {
       is_allow_fp32_to_fp16 = false;
@@ -137,7 +137,7 @@ REGISTER_OPTION_BOOL_FUNCTION_UNIQ(
 
 REGISTER_OPTION_HOOK(ALLOW_CONV_HF32, [](const std::string& val) {
   static const std::string mm_hf32_option_name = "ALLOW_MATMUL_HF32";
-  auto mm_hf32_val = c10_npu::option::GetOption(mm_hf32_option_name);
+  auto mm_hf32_val = c10::npu::option::GetOption(mm_hf32_option_name);
   // default value is False;
   std::string mm_hf32 = "0";
   if (mm_hf32_val.has_value() && (mm_hf32_val.value() == "enable")) {
@@ -159,7 +159,7 @@ REGISTER_OPTION_BOOL_FUNCTION_ALL_CASE(
 
 REGISTER_OPTION_HOOK(ALLOW_MATMUL_HF32, [](const std::string& val) {
   static const std::string conv_hf32_option_name = "ALLOW_CONV_HF32";
-  auto conv_hf32_val = c10_npu::option::GetOption(conv_hf32_option_name);
+  auto conv_hf32_val = c10::npu::option::GetOption(conv_hf32_option_name);
   // default value is True;
   std::string conv_hf32 = "1";
   if (conv_hf32_val.has_value() && (conv_hf32_val.value() == "disable")) {

--- a/npu/framework/utils/NpuUtils.cpp
+++ b/npu/framework/utils/NpuUtils.cpp
@@ -3,9 +3,9 @@
 
 #include "csrc/aten/generated/CustomFunctions.h"
 #include "csrc/aten/generated/NPUNativeFunctions.h"
-#include "npu/core/NPUBridge.h"
-#include "csrc/npu/NPUStorageImpl.h"
 #include "csrc/npu/NPUFunctions.h"
+#include "csrc/npu/NPUStorageImpl.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/StorageDescHelper.h"
 #include "npu/framework/contiguous/ContiguousOpt.h"
@@ -260,8 +260,8 @@ bool NpuUtils::IsOomError(aclError ret, int index) {
     // free devcie cached memory when return value of the first op execution is
     // oom
     if (index == 1) {
-      NPU_CHECK_ERROR(c10_npu::GetDevice(&deviceId));
-      c10_npu::NPUCachingAllocator::emptyDeviceCache(deviceId);
+      NPU_CHECK_ERROR(c10::npu::GetDevice(&deviceId));
+      c10::npu::NPUCachingAllocator::emptyDeviceCache(deviceId);
       return true;
     }
     AT_ERROR("NPU out of memory. device id: ", deviceId);

--- a/npu/framework/utils/OpPreparation.cpp
+++ b/npu/framework/utils/OpPreparation.cpp
@@ -2,8 +2,8 @@
 #include <ATen/record_function.h>
 #include "csrc/aten/generated/CustomFunctions.h"
 #include "csrc/aten/generated/NPUNativeFunctions.h"
-#include "npu/core/NPUBridge.h"
 #include "csrc/npu/NPUStorageImpl.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/InferFormat.h"
 #include "npu/framework/utils/CalcuOpUtil.h"
@@ -457,7 +457,7 @@ at::Tensor OpPreparation::apply_tensor_without_format(
 
 at::Tensor OpPreparation::unsafe_empty_workspace(uint64_t workspace_size) {
   ASCEND_LOGD("Alloc workspace %zu bytes unsafely.", workspace_size);
-  c10::Allocator* allocator = c10_npu::NPUCachingAllocator::get();
+  c10::Allocator* allocator = c10::npu::NPUCachingAllocator::get();
   c10::intrusive_ptr<c10::StorageImpl> storage_impl =
       c10::make_intrusive<torch_npu::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),

--- a/test/cpp/core/device.cpp
+++ b/test/cpp/core/device.cpp
@@ -4,6 +4,6 @@
 
 TEST(DeviceGuardTest, StaticType) {
   EXPECT_EQ(
-      c10_backend::impl::PrivateUse1GuardImpl::static_type,
+      c10::backend::impl::PrivateUse1GuardImpl::static_type,
       c10::DeviceType::PrivateUse1);
 }

--- a/test/cpp/npu/npu_context_test.cpp
+++ b/test/cpp/npu/npu_context_test.cpp
@@ -2,10 +2,10 @@
 #include "csrc/npu/NPUContext.h"
 
 TEST(NPUContextTest, TestGetDeviceProperties) {
-  if (!c10_npu::is_available()) {
+  if (!c10::npu::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto prop = c10_npu::getDeviceProperties(0);
+  auto prop = c10::npu::getDeviceProperties(0);
   EXPECT_NE(prop->name, " ");
 }

--- a/test/cpp/npu/npu_generator_test.cpp
+++ b/test/cpp/npu/npu_generator_test.cpp
@@ -3,7 +3,7 @@
 #include "csrc/npu/NPUContext.h"
 
 TEST(NPUGeneratorImpl, TestSingletonDefaultGenerator) {
-  if (!c10_npu::is_available()) {
+  if (!c10::npu::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -13,7 +13,7 @@ TEST(NPUGeneratorImpl, TestSingletonDefaultGenerator) {
 }
 
 TEST(NPUGeneratorImpl, TestCloning) {
-  if (!c10_npu::is_available()) {
+  if (!c10::npu::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -31,7 +31,7 @@ TEST(NPUGeneratorImpl, TestCloning) {
 }
 
 TEST(NPUGeneratorImpl, TestGetSetCurrentSeed) {
-  if (!c10_npu::is_available()) {
+  if (!c10::npu::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -47,7 +47,7 @@ TEST(NPUGeneratorImpl, TestDeviceType) {
 }
 
 TEST(NPUGeneratorImpl, TestGetSetOffset) {
-  if (!c10_npu::is_available()) {
+  if (!c10::npu::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -58,7 +58,7 @@ TEST(NPUGeneratorImpl, TestGetSetOffset) {
 }
 
 TEST(NPUGeneratorImpl, TestGetSetPhiloxOffset) {
-  if (!c10_npu::is_available()) {
+  if (!c10::npu::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 

--- a/torch_npu/csrc/core/python_tensor.cpp
+++ b/torch_npu/csrc/core/python_tensor.cpp
@@ -51,7 +51,7 @@ static PyObject* Tensor_new(
   }();
 
   TORCH_CHECK_TYPE(
-      c10_npu::device_count() != 0,
+      c10::npu::device_count() != 0,
       "type ",
       tensor_type.name,
       " not available.",

--- a/torch_npu/csrc/npu/Device.cpp
+++ b/torch_npu/csrc/npu/Device.cpp
@@ -15,10 +15,10 @@
 
 void RegisterNPUDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
-  py::class_<c10_npu::NPUDeviceProp>(m, "_NPUDeviceProperties")
-      .def_readonly("name", &c10_npu::NPUDeviceProp::name)
-      .def_readonly("total_memory", &c10_npu::NPUDeviceProp::totalGlobalMem)
-      .def("__repr__", [](const c10_npu::NPUDeviceProp& prop) {
+  py::class_<c10::npu::NPUDeviceProp>(m, "_NPUDeviceProperties")
+      .def_readonly("name", &c10::npu::NPUDeviceProp::name)
+      .def_readonly("total_memory", &c10::npu::NPUDeviceProp::totalGlobalMem)
+      .def("__repr__", [](const c10::npu::NPUDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_NPUDeviceProperties(name='" << prop.name
                << "', total_memory="
@@ -28,7 +28,7 @@ void RegisterNPUDeviceProperties(PyObject* module) {
       });
 
   m.def("_npu_isHistoryEnabled", []() {
-    return c10_npu::NPUCachingAllocator::isHistoryEnabled();
+    return c10::npu::NPUCachingAllocator::isHistoryEnabled();
   });
 }
 
@@ -36,8 +36,8 @@ void BindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_npu_getDeviceProperties",
-      [](c10::DeviceIndex deviceid) -> c10_npu::NPUDeviceProp* {
-        return c10_npu::getDeviceProperties(deviceid);
+      [](c10::DeviceIndex deviceid) -> c10::npu::NPUDeviceProp* {
+        return c10::npu::getDeviceProperties(deviceid);
       },
       py::return_value_policy::reference);
 }
@@ -45,7 +45,7 @@ void BindGetDeviceProperties(PyObject* module) {
 PyObject* THNPModule_npuSynchronize(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
   pybind11::gil_scoped_release no_gil;
-  c10_npu::device_synchronize();
+  c10::npu::device_synchronize();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -59,7 +59,7 @@ PyObject* THNPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   }
 
   auto device = THPUtils_unpackLong(arg);
-  c10_npu::set_device(static_cast<c10::DeviceIndex>(device));
+  c10::npu::set_device(static_cast<c10::DeviceIndex>(device));
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -69,14 +69,14 @@ PyObject* THNPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   torch::utils::device_lazy_init(at::kPrivateUse1);
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-  auto device = static_cast<int32_t>(c10_npu::current_device());
+  auto device = static_cast<int32_t>(c10::npu::current_device());
   return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THNPModule_getDeviceCount_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  return THPUtils_packUInt64(c10_npu::device_count());
+  return THPUtils_packUInt64(c10::npu::device_count());
   END_HANDLE_TH_ERRORS
 }
 
@@ -93,7 +93,8 @@ PyObject* THNPModule_npuCanDeviceAccessPeer_wrap(
   c10::DeviceIndex device_id = THPUtils_unpackDeviceIndex(value_1);
   c10::DeviceIndex peer_device_id = THPUtils_unpackDeviceIndex(value_2);
   int32_t can_access_peer = 0;
-  NPU_CHECK_ERROR(aclrtDeviceCanAccessPeer(&can_access_peer, device_id, peer_device_id));
+  NPU_CHECK_ERROR(
+      aclrtDeviceCanAccessPeer(&can_access_peer, device_id, peer_device_id));
   auto can_device_access_peer = can_access_peer != 0;
   return PyBool_FromLong(can_device_access_peer);
   END_HANDLE_TH_ERRORS

--- a/torch_npu/csrc/npu/Event.cpp
+++ b/torch_npu/csrc/npu/Event.cpp
@@ -42,7 +42,7 @@ static PyObject* THNPEvent_pynew(
   unsigned int flags = 0;
   flags =
       enable_timing ? (ACL_EVENT_TIME_LINE | ACL_EVENT_SYNC) : ACL_EVENT_SYNC;
-  new (&self->npu_event) c10_npu::NPUEvent(flags);
+  new (&self->npu_event) c10::npu::NPUEvent(flags);
 
   return (PyObject*)ptr.release();
   END_HANDLE_TH_ERRORS

--- a/torch_npu/csrc/npu/Event.h
+++ b/torch_npu/csrc/npu/Event.h
@@ -5,7 +5,7 @@
 #include "csrc/npu/NPUEvent.h"
 
 struct THNPEvent {
-  PyObject_HEAD c10_npu::NPUEvent npu_event;
+  PyObject_HEAD c10::npu::NPUEvent npu_event;
 };
 extern PyObject* THNPEventClass;
 

--- a/torch_npu/csrc/npu/Init.cpp
+++ b/torch_npu/csrc/npu/Init.cpp
@@ -22,7 +22,7 @@ static PyObject* THNPModule_initExtension(PyObject* self, PyObject* noargs) {
       throw python_error();
     }
   };
-  c10::DeviceIndex num_npus = c10_npu::device_count();
+  c10::DeviceIndex num_npus = c10::npu::device_count();
   auto default_npu_generators = PyTuple_New(static_cast<Py_ssize_t>(num_npus));
   for (c10::DeviceIndex i = 0; i < num_npus; i++) {
     auto gen = at_npu::detail::getDefaultNPUGenerator(i);

--- a/torch_npu/csrc/npu/Lock.cpp
+++ b/torch_npu/csrc/npu/Lock.cpp
@@ -1,5 +1,5 @@
 #include "torch_npu/csrc/npu/Lock.h"
-#include <pybind11/gil.h>
+#include <pybind11/pybind11.h>
 #include "csrc/npu/NPUFunctions.h"
 
 // We need to ensure that as long as a thread will NEVER loose the GIL as long

--- a/torch_npu/csrc/npu/Lock.cpp
+++ b/torch_npu/csrc/npu/Lock.cpp
@@ -1,6 +1,6 @@
 #include "torch_npu/csrc/npu/Lock.h"
-#include "csrc/npu/NPUFunctions.h"
 #include <pybind11/gil.h>
+#include "csrc/npu/NPUFunctions.h"
 
 // We need to ensure that as long as a thread will NEVER loose the GIL as long
 // as it holds the NPU mutex. Otherwise another thread might be scheduled and
@@ -11,7 +11,7 @@
 static PyGILState_STATE npuMutexGILState;
 
 PyObject* THNPModule_npuLockMutex(PyObject* module, PyObject* noargs) {
-  auto mutex = c10_npu::getFreeMutex();
+  auto mutex = c10::npu::getFreeMutex();
   // This has to be a busy loop because we **absolutely need to** hold the GIL
   // or it's a recipe for a deadlock otherwise (if we let other Python threads
   // run while we have the cudaMutex, but not the GIL, they might try to e.g.
@@ -32,7 +32,7 @@ PyObject* THNPModule_npuLockMutex(PyObject* module, PyObject* noargs) {
 }
 
 PyObject* THNPModule_npuUnlockMutex(PyObject* module, PyObject* noargs) {
-  auto mutex = c10_npu::getFreeMutex();
+  auto mutex = c10::npu::getFreeMutex();
   PyGILState_Release(npuMutexGILState);
   mutex->unlock();
   Py_RETURN_NONE;

--- a/torch_npu/csrc/npu/Memory.cpp
+++ b/torch_npu/csrc/npu/Memory.cpp
@@ -24,7 +24,7 @@ PyObject* THNPModule_setMemoryFraction(PyObject* _unused, PyObject* args) {
   double fraction = PyFloat_AsDouble(fraction_o);
   int64_t device = PyLong_AsLongLong(device_o);
 
-  c10_npu::NPUCachingAllocator::setMemoryFraction(fraction, device);
+  c10::npu::NPUCachingAllocator::setMemoryFraction(fraction, device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -38,7 +38,7 @@ PyObject* THNPModule_resetAccumulatedMemoryStats(
       "invalid argument to reset_accumulated_memory_stats",
       PTA_ERROR(ErrCode::PARAM));
   const int device = (int)THPUtils_unpackLong(arg);
-  c10_npu::NPUCachingAllocator::resetAccumulatedStats(device);
+  c10::npu::NPUCachingAllocator::resetAccumulatedStats(device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -50,7 +50,7 @@ PyObject* THNPModule_resetPeakMemoryStats(PyObject* _unused, PyObject* arg) {
       "invalid argument to reset_peak_memory_stats",
       PTA_ERROR(ErrCode::PARAM));
   const int device = (int)THPUtils_unpackLong(arg);
-  c10_npu::NPUCachingAllocator::resetPeakStats(device);
+  c10::npu::NPUCachingAllocator::resetPeakStats(device);
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }
@@ -143,7 +143,7 @@ PyObject* THNPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
     return segmentDict;
   };
 
-  auto snapshot = c10_npu::NPUCachingAllocator::snapshot();
+  auto snapshot = c10::npu::NPUCachingAllocator::snapshot();
   py::list segments;
 
   for (const auto& segmentInfo : snapshot.segments) {
@@ -243,7 +243,7 @@ PyObject* THNPModule_attachOutOfMemoryObserver(
     Py_XDECREF(result);
   };
   torch::utils::device_lazy_init(at::kPrivateUse1);
-  c10_npu::NPUCachingAllocator::attachOutOfMemoryObserver(std::move(obs));
+  c10::npu::NPUCachingAllocator::attachOutOfMemoryObserver(std::move(obs));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -265,7 +265,8 @@ PyObject* THNPModule_npuCachingAllocator_raw_alloc(
   }
   ssize_t size = PyLong_AsSsize_t(size_o);
   aclrtStream stream = static_cast<aclrtStream>(PyLong_AsVoidPtr(stream_o));
-  void* mem = c10_npu::NPUCachingAllocator::raw_alloc_with_stream(size, stream);
+  void* mem =
+      c10::npu::NPUCachingAllocator::raw_alloc_with_stream(size, stream);
   return PyLong_FromVoidPtr(mem);
   END_HANDLE_TH_ERRORS
 }
@@ -275,14 +276,14 @@ PyObject* THNPModule_npuCachingAllocator_raw_delete(
     PyObject* obj) {
   HANDLE_TH_ERRORS
   void* mem_ptr = PyLong_AsVoidPtr(obj);
-  c10_npu::NPUCachingAllocator::raw_delete(mem_ptr);
+  c10::npu::NPUCachingAllocator::raw_delete(mem_ptr);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THNPModule_getAllocatorBackend(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  return THPUtils_packString(c10_npu::NPUCachingAllocator::name());
+  return THPUtils_packString(c10::npu::NPUCachingAllocator::name());
   END_HANDLE_TH_ERRORS
 }
 
@@ -320,7 +321,7 @@ PyObject* THNPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   };
 
   const DeviceStats stats =
-      c10_npu::NPUCachingAllocator::getDeviceStats(device);
+      c10::npu::NPUCachingAllocator::getDeviceStats(device);
 
   py::dict result;
   result["num_alloc_retries"] = stats.num_alloc_retries;
@@ -343,7 +344,7 @@ PyObject* THNPModule_memoryStats(PyObject* _unused, PyObject* arg) {
 
 PyObject* THNPModule_emptyCache(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  c10_npu::NPUCachingAllocator::emptyCache();
+  c10::npu::NPUCachingAllocator::emptyCache();
   END_HANDLE_TH_ERRORS
   Py_RETURN_NONE;
 }

--- a/torch_npu/csrc/npu/Memory.cpp
+++ b/torch_npu/csrc/npu/Memory.cpp
@@ -69,8 +69,8 @@ torch::CapturedTraceback* getFromContext(
 PyObject* THNPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
 
-  using c10_backend::CachingAllocator::BlockInfo;
-  using c10_backend::CachingAllocator::SegmentInfo;
+  using c10::backend::CachingAllocator::BlockInfo;
+  using c10::backend::CachingAllocator::SegmentInfo;
 
   py::str device_s = "device";
   py::str address_s = "address";
@@ -164,7 +164,7 @@ PyObject* THNPModule_memorySnapshot(PyObject* _unused, PyObject* noargs) {
   py::str oom_s = "oom";
   py::str device_free_s = "device_free";
 
-  using namespace c10_backend::CachingAllocator;
+  using namespace c10::backend::CachingAllocator;
 
   auto action_to_str = [&](TraceEntry::Action action) {
     switch (action) {
@@ -294,10 +294,10 @@ PyObject* THNPModule_memoryStats(PyObject* _unused, PyObject* arg) {
       PTA_ERROR(ErrCode::PARAM));
   const int device = (int)THPUtils_unpackLong(arg);
 
-  using c10_backend::CachingAllocator::DeviceStats;
-  using c10_backend::CachingAllocator::Stat;
-  using c10_backend::CachingAllocator::StatArray;
-  using c10_backend::CachingAllocator::StatType;
+  using c10::backend::CachingAllocator::DeviceStats;
+  using c10::backend::CachingAllocator::Stat;
+  using c10::backend::CachingAllocator::StatArray;
+  using c10::backend::CachingAllocator::StatType;
 
   const auto statToDict = [](const Stat& stat) {
     py::dict dict;

--- a/torch_npu/csrc/npu/Stream.cpp
+++ b/torch_npu/csrc/npu/Stream.cpp
@@ -18,7 +18,7 @@ static PyObject* THNPStream_pynew(
   HANDLE_TH_ERRORS
 
   c10::DeviceIndex current_device;
-  NPU_CHECK_ERROR(c10_npu::GetDevice(&current_device));
+  NPU_CHECK_ERROR(c10::npu::GetDevice(&current_device));
 
   int priority = 0;
   int64_t stream_id = 0;
@@ -52,16 +52,16 @@ static PyObject* THNPStream_pynew(
     return nullptr;
   }
 
-  c10_npu::NPUStream stream = (stream_id || device_index || device_type)
-      ? c10_npu::NPUStream::unpack3(
+  c10::npu::NPUStream stream = (stream_id || device_index || device_type)
+      ? c10::npu::NPUStream::unpack3(
             stream_id, device_index, static_cast<c10::DeviceType>(device_type))
-      : c10_npu::getStreamFromPool(false);
+      : c10::npu::getStreamFromPool(false);
 
   THNPStream* self = (THNPStream*)ptr.get();
   self->stream_id = static_cast<int64_t>(stream.id());
   self->device_index = static_cast<int64_t>(stream.device_index());
   self->device_type = static_cast<int64_t>(stream.device_type());
-  new (&self->npu_stream) c10_npu::NPUStream(stream);
+  new (&self->npu_stream) c10::npu::NPUStream(stream);
 
   return (PyObject*)ptr.release();
   END_HANDLE_TH_ERRORS
@@ -220,7 +220,7 @@ void THNPStream_init(PyObject* module) {
   }
 }
 
-std::vector<c10::optional<c10_npu::NPUStream>>
+std::vector<c10::optional<c10::npu::NPUStream>>
 THNPUtils_PySequence_to_NPUStreamList(PyObject* obj) {
   if (!PySequence_Check(obj)) {
     throw std::runtime_error(
@@ -234,13 +234,13 @@ THNPUtils_PySequence_to_NPUStreamList(PyObject* obj) {
         PTA_ERROR(ErrCode::PARAM));
   }
 
-  std::vector<c10::optional<c10_npu::NPUStream>> streams;
+  std::vector<c10::optional<c10::npu::NPUStream>> streams;
   Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
   for (Py_ssize_t i = 0; i < length; i++) {
     PyObject* stream = PySequence_Fast_GET_ITEM(seq.get(), i);
 
     if (PyObject_IsInstance(stream, THNPStreamClass)) {
-      streams.emplace_back(c10_npu::NPUStream::unpack3(
+      streams.emplace_back(c10::npu::NPUStream::unpack3(
           (reinterpret_cast<THNPStream*>(stream))->stream_id,
           (reinterpret_cast<THNPStream*>(stream))->device_index,
           static_cast<c10::DeviceType>(
@@ -265,7 +265,7 @@ PyObject* THNPModule_getCurrentStream_wrap(
       "invalid argument to getCurrentStream",
       PTA_ERROR(ErrCode::PARAM));
   c10::DeviceIndex device = THPUtils_unpackDeviceIndex(device_index);
-  auto stream = c10_npu::getCurrentNPUStream(device);
+  auto stream = c10::npu::getCurrentNPUStream(device);
   PyObject* output_tuple = PyTuple_New(3);
   PyTuple_SetItem(
       output_tuple, 0, THPUtils_packInt64(static_cast<int64_t>(stream.id())));
@@ -290,7 +290,7 @@ PyObject* THNPModule_getDefaultStream_wrap(
       "invalid argument to getDefaultStream",
       PTA_ERROR(ErrCode::PARAM));
   c10::DeviceIndex device = THPUtils_unpackDeviceIndex(device_index);
-  auto stream = c10_npu::getDefaultNPUStream(device);
+  auto stream = c10::npu::getDefaultNPUStream(device);
   PyObject* output_tuple = PyTuple_New(3);
   PyTuple_SetItem(
       output_tuple, 0, THPUtils_packInt64(static_cast<int64_t>(stream.id())));
@@ -328,16 +328,16 @@ PyObject* THNPModule_setStream_wrap(
           &device_type)) {
   }
 
-  auto stream = c10_npu::NPUStream::unpack3(
+  auto stream = c10::npu::NPUStream::unpack3(
       stream_id,
       static_cast<c10::DeviceIndex>(device_index),
       static_cast<c10::DeviceType>(device_type));
 
-  auto device = c10_npu::current_device();
+  auto device = c10::npu::current_device();
   if (device != stream.device_index()) {
-    c10_npu::set_device(stream.device_index());
+    c10::npu::set_device(stream.device_index());
   }
-  c10_npu::setCurrentNPUStream(stream);
+  c10::npu::setCurrentNPUStream(stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch_npu/csrc/npu/Stream.h
+++ b/torch_npu/csrc/npu/Stream.h
@@ -6,7 +6,7 @@
 #include "csrc/npu/NPUStream.h"
 
 struct THNPStream : THPStream {
-  c10_npu::NPUStream npu_stream;
+  c10::npu::NPUStream npu_stream;
 };
 
 TORCH_BACKEND_API void THNPStream_init(PyObject* module);


### PR DESCRIPTION
Following torch namespace convention, change namespace 
- `c10_backend` -> `c10::backend`
- `c10_npu` -> `c10::npu`