### PR TITLE
Refactor namespace separate logic by module

### DIFF
--- a/torch_npu/csrc/Module.cpp
+++ b/torch_npu/csrc/Module.cpp
@@ -11,6 +11,8 @@
 #include "torch_npu/csrc/npu/Memory.h"
 #include "torch_npu/csrc/npu/Stream.h"
 
+#define BACKEND_MODULE_NAME "torch_npu._C"
+
 PyObject* module;
 static std::vector<PyMethodDef> methods;
 
@@ -25,15 +27,14 @@ PyObject* initModule() {
   THPUtils_addPyMethodDefs(methods, torch::backend::stream::python_functions());
   THPUtils_addPyMethodDefs(methods, torch::backend::tensor::python_functions());
 
-  static struct PyModuleDef torchnpu_module = {
-      PyModuleDef_HEAD_INIT, "torch_npu._C", nullptr, -1, methods.data()};
-  module = PyModule_Create(&torchnpu_module);
+  static struct PyModuleDef torch_backend_module = {
+      PyModuleDef_HEAD_INIT, BACKEND_MODULE_NAME, nullptr, -1, methods.data()};
+  module = PyModule_Create(&torch_backend_module);
 
-  torch::backend::stream::THNPStream_init(module);
-  THNPEvent_init(module);
+  torch::backend::stream::init(module);
+  torch::backend::event::init(module);
+  torch::backend::device::init(module);
 
-  torch::backend::device::RegisterNPUDeviceProperties(module);
-  torch::backend::device::BindGetDeviceProperties(module);
   torch::installCapturedTracebackPython();
   return module;
 }

--- a/torch_npu/csrc/Module.cpp
+++ b/torch_npu/csrc/Module.cpp
@@ -1,7 +1,7 @@
 #include <ATen/Parallel.h>
 #include <Python.h>
-#include <torch/csrc/utils.h>
 #include <torch/csrc/profiler/python/combined_traceback.h>
+#include <torch/csrc/utils.h>
 
 #include "torch_npu/csrc/core/python_tensor.h"
 #include "torch_npu/csrc/npu/Device.h"
@@ -18,11 +18,11 @@ extern "C" C10_EXPORT PyObject* initModule();
 PyObject* initModule() {
   at::internal::lazy_init_num_threads();
 
-  THPUtils_addPyMethodDefs(methods, THNPModule_init_methods());
-  THPUtils_addPyMethodDefs(methods, THNPModule_lock_methods());
-  THPUtils_addPyMethodDefs(methods, THNPModule_device_methods());
-  THPUtils_addPyMethodDefs(methods, THNPModule_memory_methods());
-  THPUtils_addPyMethodDefs(methods, THNPModule_stream_methods());
+  THPUtils_addPyMethodDefs(methods, torch::backend::init::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::backend::lock::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::backend::device::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::backend::memory::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::backend::stream::python_functions());
   THPUtils_addPyMethodDefs(methods, torch::backend::tensor::python_functions());
 
   static struct PyModuleDef torchnpu_module = {

--- a/torch_npu/csrc/Module.cpp
+++ b/torch_npu/csrc/Module.cpp
@@ -29,11 +29,11 @@ PyObject* initModule() {
       PyModuleDef_HEAD_INIT, "torch_npu._C", nullptr, -1, methods.data()};
   module = PyModule_Create(&torchnpu_module);
 
-  THNPStream_init(module);
+  torch::backend::stream::THNPStream_init(module);
   THNPEvent_init(module);
 
-  RegisterNPUDeviceProperties(module);
-  BindGetDeviceProperties(module);
+  torch::backend::device::RegisterNPUDeviceProperties(module);
+  torch::backend::device::BindGetDeviceProperties(module);
   torch::installCapturedTracebackPython();
   return module;
 }

--- a/torch_npu/csrc/npu/Device.cpp
+++ b/torch_npu/csrc/npu/Device.cpp
@@ -120,6 +120,10 @@ static struct PyMethodDef THNPModule_methods[] = {
      nullptr},
     {nullptr}};
 
-PyMethodDef* THNPModule_device_methods() {
+namespace torch::backend::device {
+
+PyMethodDef* python_functions() {
   return THNPModule_methods;
 }
+
+} // namespace torch::backend::device

--- a/torch_npu/csrc/npu/Device.cpp
+++ b/torch_npu/csrc/npu/Device.cpp
@@ -14,6 +14,8 @@
 
 #define CHANGE_UNIT_SIZE 1024.0
 
+namespace torch::backend::device {
+
 void RegisterNPUDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   py::class_<c10::npu::NPUDeviceProp>(m, "_NPUDeviceProperties")
@@ -119,8 +121,6 @@ static struct PyMethodDef THNPModule_methods[] = {
      METH_VARARGS,
      nullptr},
     {nullptr}};
-
-namespace torch::backend::device {
 
 PyMethodDef* python_functions() {
   return THNPModule_methods;

--- a/torch_npu/csrc/npu/Device.cpp
+++ b/torch_npu/csrc/npu/Device.cpp
@@ -16,7 +16,7 @@
 
 namespace torch::backend::device {
 
-void RegisterNPUDeviceProperties(PyObject* module) {
+void registerDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   py::class_<c10::npu::NPUDeviceProp>(m, "_NPUDeviceProperties")
       .def_readonly("name", &c10::npu::NPUDeviceProp::name)
@@ -35,7 +35,7 @@ void RegisterNPUDeviceProperties(PyObject* module) {
   });
 }
 
-void BindGetDeviceProperties(PyObject* module) {
+void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_npu_getDeviceProperties",
@@ -43,6 +43,11 @@ void BindGetDeviceProperties(PyObject* module) {
         return c10::npu::getDeviceProperties(deviceid);
       },
       py::return_value_policy::reference);
+}
+
+void init(PyObject* module) {
+  registerDeviceProperties(module);
+  bindGetDeviceProperties(module);
 }
 
 PyObject* THNPModule_npuSynchronize(PyObject* _unused, PyObject* noargs) {

--- a/torch_npu/csrc/npu/Device.h
+++ b/torch_npu/csrc/npu/Device.h
@@ -6,7 +6,7 @@
 namespace torch::backend::device {
 
 TORCH_BACKEND_API PyMethodDef* python_functions();
-TORCH_BACKEND_API void RegisterNPUDeviceProperties(PyObject* module);
-TORCH_BACKEND_API void BindGetDeviceProperties(PyObject* module);
+
+TORCH_BACKEND_API void init(PyObject* module);
 
 } // namespace torch::backend::device

--- a/torch_npu/csrc/npu/Device.h
+++ b/torch_npu/csrc/npu/Device.h
@@ -6,8 +6,7 @@
 namespace torch::backend::device {
 
 TORCH_BACKEND_API PyMethodDef* python_functions();
-
-}
-
 TORCH_BACKEND_API void RegisterNPUDeviceProperties(PyObject* module);
 TORCH_BACKEND_API void BindGetDeviceProperties(PyObject* module);
+
+} // namespace torch::backend::device

--- a/torch_npu/csrc/npu/Device.h
+++ b/torch_npu/csrc/npu/Device.h
@@ -3,6 +3,11 @@
 #include <Python.h>
 #include "csrc/core/Macros.h"
 
-TORCH_BACKEND_API PyMethodDef* THNPModule_device_methods();
+namespace torch::backend::device {
+
+TORCH_BACKEND_API PyMethodDef* python_functions();
+
+}
+
 TORCH_BACKEND_API void RegisterNPUDeviceProperties(PyObject* module);
 TORCH_BACKEND_API void BindGetDeviceProperties(PyObject* module);

--- a/torch_npu/csrc/npu/Event.cpp
+++ b/torch_npu/csrc/npu/Event.cpp
@@ -8,6 +8,8 @@
 #include "torch_npu/csrc/npu/Event.h"
 #include "torch_npu/csrc/npu/Stream.h"
 
+namespace torch::backend::event {
+
 PyObject* THNPEventClass = nullptr;
 
 static PyObject* THNPEvent_pynew(
@@ -172,7 +174,7 @@ PyTypeObject THNPEventType = {
     THNPEvent_pynew, /* tp_new */
 };
 
-void THNPEvent_init(PyObject* module) {
+void init(PyObject* module) {
   THNPEventClass = (PyObject*)&THNPEventType;
   if (PyType_Ready(&THNPEventType) < 0) {
     throw python_error();
@@ -183,3 +185,5 @@ void THNPEvent_init(PyObject* module) {
     throw python_error();
   }
 }
+
+} // namespace torch::backend::event

--- a/torch_npu/csrc/npu/Event.cpp
+++ b/torch_npu/csrc/npu/Event.cpp
@@ -70,14 +70,18 @@ static PyObject* THNPEvent_get_device(THNPEvent* self, void* unused) {
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THNPEvent_record(THNPEvent* self, THNPStream* stream) {
+static PyObject* THNPEvent_record(
+    THNPEvent* self,
+    torch::backend::stream::THNPStream* stream) {
   HANDLE_TH_ERRORS
   self->npu_event.record(stream->npu_stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject* THNPEvent_wait(THNPEvent* self, THNPStream* stream) {
+static PyObject* THNPEvent_wait(
+    THNPEvent* self,
+    torch::backend::stream::THNPStream* stream) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
     self->npu_event.block(stream->npu_stream);

--- a/torch_npu/csrc/npu/Event.h
+++ b/torch_npu/csrc/npu/Event.h
@@ -4,9 +4,13 @@
 #include "csrc/core/Macros.h"
 #include "csrc/npu/NPUEvent.h"
 
+namespace torch::backend::event {
+
 struct THNPEvent {
   PyObject_HEAD c10::npu::NPUEvent npu_event;
 };
 extern PyObject* THNPEventClass;
 
-TORCH_BACKEND_API void THNPEvent_init(PyObject* module);
+TORCH_BACKEND_API void init(PyObject* module);
+
+} // namespace torch::backend::event

--- a/torch_npu/csrc/npu/Init.cpp
+++ b/torch_npu/csrc/npu/Init.cpp
@@ -41,6 +41,10 @@ static PyMethodDef THNPModule_methods[] = {
     {"_npu_init", (PyCFunction)THNPModule_initExtension, METH_NOARGS, nullptr},
     {nullptr, nullptr, 0, nullptr}};
 
-PyMethodDef* THNPModule_init_methods() {
+namespace torch::backend::init {
+
+PyMethodDef* python_functions() {
   return THNPModule_methods;
 }
+
+} // namespace torch::backend::init

--- a/torch_npu/csrc/npu/Init.cpp
+++ b/torch_npu/csrc/npu/Init.cpp
@@ -6,6 +6,8 @@
 #include "csrc/npu/NPUFunctions.h"
 #include "csrc/npu/NPUGeneratorImpl.h"
 
+namespace torch::backend::init {
+
 static PyObject* THNPModule_initExtension(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
@@ -40,8 +42,6 @@ static PyObject* THNPModule_initExtension(PyObject* self, PyObject* noargs) {
 static PyMethodDef THNPModule_methods[] = {
     {"_npu_init", (PyCFunction)THNPModule_initExtension, METH_NOARGS, nullptr},
     {nullptr, nullptr, 0, nullptr}};
-
-namespace torch::backend::init {
 
 PyMethodDef* python_functions() {
   return THNPModule_methods;

--- a/torch_npu/csrc/npu/Init.h
+++ b/torch_npu/csrc/npu/Init.h
@@ -3,4 +3,8 @@
 #include <Python.h>
 #include "csrc/core/Macros.h"
 
-TORCH_BACKEND_API PyMethodDef* THNPModule_init_methods();
+namespace torch::backend::init {
+
+TORCH_BACKEND_API PyMethodDef* python_functions();
+
+} // namespace torch::backend::init

--- a/torch_npu/csrc/npu/Lock.cpp
+++ b/torch_npu/csrc/npu/Lock.cpp
@@ -2,6 +2,8 @@
 #include <pybind11/pybind11.h>
 #include "csrc/npu/NPUFunctions.h"
 
+namespace torch::backend::lock {
+
 // We need to ensure that as long as a thread will NEVER loose the GIL as long
 // as it holds the NPU mutex. Otherwise another thread might be scheduled and
 // try to e.g. allocate a new tensor which will cause a deadlock. It's enough to
@@ -48,8 +50,6 @@ static PyMethodDef THNPModule_methods[] = {
      METH_NOARGS,
      nullptr},
     {nullptr, nullptr, 0, nullptr}};
-
-namespace torch::backend::lock {
 
 PyMethodDef* python_functions() {
   return THNPModule_methods;

--- a/torch_npu/csrc/npu/Lock.cpp
+++ b/torch_npu/csrc/npu/Lock.cpp
@@ -49,6 +49,10 @@ static PyMethodDef THNPModule_methods[] = {
      nullptr},
     {nullptr, nullptr, 0, nullptr}};
 
-PyMethodDef* THNPModule_lock_methods() {
+namespace torch::backend::lock {
+
+PyMethodDef* python_functions() {
   return THNPModule_methods;
 }
+
+} // namespace torch::backend::lock

--- a/torch_npu/csrc/npu/Lock.h
+++ b/torch_npu/csrc/npu/Lock.h
@@ -3,4 +3,8 @@
 #include <Python.h>
 #include "csrc/core/Macros.h"
 
-TORCH_BACKEND_API PyMethodDef* THNPModule_lock_methods();
+namespace torch::backend::lock {
+
+TORCH_BACKEND_API PyMethodDef* python_functions();
+
+} // namespace torch::backend::lock

--- a/torch_npu/csrc/npu/Memory.cpp
+++ b/torch_npu/csrc/npu/Memory.cpp
@@ -7,6 +7,8 @@
 #include <torch/csrc/utils/python_numbers.h>
 #include "csrc/npu/NPUCachingAllocator.h"
 
+namespace torch::backend::memory {
+
 PyObject* THNPModule_setMemoryFraction(PyObject* _unused, PyObject* args) {
   HANDLE_TH_ERRORS
   PyObject* fraction_o = nullptr;
@@ -384,8 +386,6 @@ static struct PyMethodDef THNPModule_methods[] = {
      METH_NOARGS,
      nullptr},
     {nullptr}};
-
-namespace torch::backend::memory {
 
 PyMethodDef* python_functions() {
   return THNPModule_methods;

--- a/torch_npu/csrc/npu/Memory.cpp
+++ b/torch_npu/csrc/npu/Memory.cpp
@@ -385,6 +385,10 @@ static struct PyMethodDef THNPModule_methods[] = {
      nullptr},
     {nullptr}};
 
-PyMethodDef* THNPModule_memory_methods() {
+namespace torch::backend::memory {
+
+PyMethodDef* python_functions() {
   return THNPModule_methods;
 }
+
+} // namespace torch::backend::memory

--- a/torch_npu/csrc/npu/Memory.h
+++ b/torch_npu/csrc/npu/Memory.h
@@ -3,4 +3,8 @@
 #include <Python.h>
 #include "csrc/core/Macros.h"
 
-TORCH_BACKEND_API PyMethodDef* THNPModule_memory_methods();
+namespace torch::backend::memory {
+
+TORCH_BACKEND_API PyMethodDef* python_functions();
+
+} // namespace torch::backend::memory

--- a/torch_npu/csrc/npu/Stream.cpp
+++ b/torch_npu/csrc/npu/Stream.cpp
@@ -342,6 +342,10 @@ static struct PyMethodDef THNPModule_methods[] = {
      nullptr},
     {nullptr}};
 
-PyMethodDef* THNPModule_stream_methods() {
+namespace torch::backend::stream {
+
+PyMethodDef* python_functions() {
   return THNPModule_methods;
 }
+
+} // namespace torch::backend::stream

--- a/torch_npu/csrc/npu/Stream.cpp
+++ b/torch_npu/csrc/npu/Stream.cpp
@@ -5,6 +5,8 @@
 #include <torch/csrc/THP.h>
 #include "csrc/npu/NPUGuard.h"
 
+namespace torch::backend::stream {
+
 PyObject* THNPStreamClass = nullptr;
 
 static PyObject* THNPStream_pynew(
@@ -341,8 +343,6 @@ static struct PyMethodDef THNPModule_methods[] = {
      METH_VARARGS | METH_KEYWORDS,
      nullptr},
     {nullptr}};
-
-namespace torch::backend::stream {
 
 PyMethodDef* python_functions() {
   return THNPModule_methods;

--- a/torch_npu/csrc/npu/Stream.cpp
+++ b/torch_npu/csrc/npu/Stream.cpp
@@ -198,7 +198,7 @@ PyTypeObject THNPStreamType = {
     THNPStream_pynew, /* tp_new */
 };
 
-void THNPStream_init(PyObject* module) {
+void init(PyObject* module) {
   Py_INCREF(THPStreamClass);
   THNPStreamType.tp_base = THPStreamClass;
   THNPStreamClass = (PyObject*)&THNPStreamType;

--- a/torch_npu/csrc/npu/Stream.h
+++ b/torch_npu/csrc/npu/Stream.h
@@ -5,13 +5,13 @@
 #include "csrc/core/Macros.h"
 #include "csrc/npu/NPUStream.h"
 
+namespace torch::backend::stream {
+
 struct THNPStream : THPStream {
   c10::npu::NPUStream npu_stream;
 };
 
 TORCH_BACKEND_API void THNPStream_init(PyObject* module);
-
-namespace torch::backend::stream {
 
 TORCH_BACKEND_API PyMethodDef* python_functions();
 

--- a/torch_npu/csrc/npu/Stream.h
+++ b/torch_npu/csrc/npu/Stream.h
@@ -10,4 +10,9 @@ struct THNPStream : THPStream {
 };
 
 TORCH_BACKEND_API void THNPStream_init(PyObject* module);
-TORCH_BACKEND_API PyMethodDef* THNPModule_stream_methods();
+
+namespace torch::backend::stream {
+
+TORCH_BACKEND_API PyMethodDef* python_functions();
+
+} // namespace torch::backend::stream

--- a/torch_npu/csrc/npu/Stream.h
+++ b/torch_npu/csrc/npu/Stream.h
@@ -11,7 +11,7 @@ struct THNPStream : THPStream {
   c10::npu::NPUStream npu_stream;
 };
 
-TORCH_BACKEND_API void THNPStream_init(PyObject* module);
+TORCH_BACKEND_API void init(PyObject* module);
 
 TORCH_BACKEND_API PyMethodDef* python_functions();
 


### PR DESCRIPTION
Based on namespace design in [here](https://docs.google.com/spreadsheets/d/1iYXjSMNsn2BSeFTQ4YuvCCP1Gw98bFANiOSCERLrM3E/edit?gid=0#gid=0), refactor module namespace, make it clear and easy to extend.