### PR TITLE
Refactor namespace in csrc/backend

### DIFF
--- a/csrc/backend/NPUCachingAllocator.cpp
+++ b/csrc/backend/NPUCachingAllocator.cpp
@@ -2,9 +2,9 @@
 #include <c10/util/Optional.h>
 #include <c10/util/irange.h>
 #include <iostream>
-#include "csrc/core/allocator/CachingAllocator.h"
 #include "csrc/backend/NPUFunctions.h"
 #include "csrc/backend/NPUStream.h"
+#include "csrc/core/allocator/CachingAllocator.h"
 #include "npu/acl/include/acl/acl_base.h"
 #include "npu/acl/include/acl/acl_rt.h"
 
@@ -82,7 +82,7 @@ class CachingAllocatorHelper
       override {
     aclrtContext compiler_ctx = aclrtContext();
     aclError ret_ctx = aclrtGetCurrentContext(&compiler_ctx);
-    aclrtSetCurrentContext(c10::npu::GetDeviceContext(device));
+    aclrtSetCurrentContext(c10::backend::GetDeviceContext(device));
     fn();
     if (ret_ctx == ACL_ERROR_NONE) {
       aclrtSetCurrentContext(compiler_ctx);
@@ -98,7 +98,7 @@ class CachingAllocatorHelper
   }
 
   virtual void deviceSynchronize() override {
-    c10::npu::device_synchronize();
+    c10::backend::device_synchronize();
   }
 
   int memFree(void* devPtr) override {
@@ -176,7 +176,8 @@ REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &defaultNPUAllocator);
 void init(CachingAllocator* delegate) {
   static c10::npu::NPUCachingAllocator::CachingAllocatorHelper helper;
   c10::backend::CachingAllocator::registerHelper(&helper);
-  c10::backend::CachingAllocator::init(c10::npu::device_count_ensure_non_zero());
+  c10::backend::CachingAllocator::init(
+      c10::backend::device_count_ensure_non_zero());
 
   defaultNPUAllocator.init(delegate);
 }

--- a/csrc/backend/NPUCachingAllocator.cpp
+++ b/csrc/backend/NPUCachingAllocator.cpp
@@ -90,7 +90,7 @@ class CachingAllocatorHelper
   }
 
   void* getCurrentStream(c10::DeviceIndex device_index) override {
-    return c10::npu::getCurrentNPUStream(device_index);
+    return c10::backend::getCurrentNPUStream(device_index);
   }
 
   int synchronizeStream(void* stream) override {

--- a/csrc/backend/NPUCachingHostAllocator.cpp
+++ b/csrc/backend/NPUCachingHostAllocator.cpp
@@ -11,12 +11,14 @@
 #include <unordered_set>
 #include <utility>
 
-#include "csrc/core/allocator/EventPool.h"
 #include "csrc/backend/NPUCachingHostAllocator.h"
 #include "csrc/backend/NPUEvent.h"
 #include "csrc/backend/NPUFunctions.h"
+#include "csrc/core/allocator/EventPool.h"
 
 namespace c10::npu {
+
+using namespace c10::backend;
 
 using Block = at::HostBlock<NPUStream>;
 struct HostAllocator
@@ -108,7 +110,7 @@ void raw_local_deleter(void* ptr) {
 bool NPUCachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
-    c10::npu::NPUStream stream) {
+    c10::backend::NPUStream stream) {
   return npu_caching_host_allocator.record_event(ptr, ctx, stream);
 }
 

--- a/csrc/backend/NPUCachingHostAllocator.cpp
+++ b/csrc/backend/NPUCachingHostAllocator.cpp
@@ -37,7 +37,7 @@ struct HostAllocator
 
     // TODO(FFFrog): implement aclrtMallocHost which don`t need explicitly
     // to create context
-    c10::npu::current_device();
+    c10::backend::current_device();
     NPU_CHECK_ERROR(aclrtMallocHost(ptr, size));
     pinned_ptrs.insert(*ptr);
   }

--- a/csrc/backend/NPUCachingHostAllocator.h
+++ b/csrc/backend/NPUCachingHostAllocator.h
@@ -2,8 +2,8 @@
 
 #include <c10/core/Allocator.h>
 
-#include "csrc/core/Macros.h"
 #include "csrc/backend/NPUStream.h"
+#include "csrc/core/Macros.h"
 #include "npu/core/NPUException.h"
 
 c10::Allocator* getNPUCachingHostAllocator(void);
@@ -11,7 +11,7 @@ c10::Allocator* getNPUCachingHostAllocator(void);
 bool NPUCachingHostAllocator_recordEvent(
     void* ptr,
     void* ctx,
-    c10::npu::NPUStream stream);
+    c10::backend::NPUStream stream);
 
 void NPUCachingHostAllocator_emptyCache(void);
 

--- a/csrc/backend/NPUContext.cpp
+++ b/csrc/backend/NPUContext.cpp
@@ -20,13 +20,13 @@ std::deque<c10::once_flag> device_prop_flags;
 std::vector<NPUDeviceProp> device_properties;
 
 void initNPUContextVectors() {
-  num_npus = c10::npu::device_count();
+  num_npus = c10::backend::device_count();
   device_prop_flags.resize(num_npus);
   device_properties.resize(num_npus);
 }
 
 void initDeviceProperty(c10::DeviceIndex device) {
-  c10::npu::get_device_properties(&device_properties[device], device);
+  c10::backend::get_device_properties(&device_properties[device], device);
 }
 
 inline void check_device(c10::DeviceIndex device) {
@@ -43,7 +43,7 @@ inline void check_device(c10::DeviceIndex device) {
 NPUDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
   c10::call_once(init_flag, initNPUContextVectors);
   if (device == -1)
-    device = c10::npu::current_device();
+    device = c10::backend::current_device();
   check_device(device);
   c10::call_once(device_prop_flags[device], initDeviceProperty, device);
   return &device_properties[device];

--- a/csrc/backend/NPUContext.cpp
+++ b/csrc/backend/NPUContext.cpp
@@ -4,7 +4,7 @@
 #include <c10/util/CallOnce.h>
 #include "csrc/backend/NPUContext.h"
 
-namespace c10::npu {
+namespace c10::backend {
 namespace {
 
 /*
@@ -49,4 +49,4 @@ NPUDeviceProp* getDeviceProperties(c10::DeviceIndex device) {
   return &device_properties[device];
 }
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUContext.h
+++ b/csrc/backend/NPUContext.h
@@ -7,7 +7,7 @@ namespace c10::backend {
 
 // NPU is available if we compiled with NPU.
 inline bool is_available() {
-  return c10::npu::device_count() > 0;
+  return c10::backend::device_count() > 0;
 }
 
 NPUDeviceProp* getDeviceProperties(c10::DeviceIndex device);

--- a/csrc/backend/NPUContext.h
+++ b/csrc/backend/NPUContext.h
@@ -3,7 +3,7 @@
 #include "csrc/backend/NPUDeviceProp.h"
 #include "csrc/backend/NPUFunctions.h"
 
-namespace c10::npu {
+namespace c10::backend {
 
 // NPU is available if we compiled with NPU.
 inline bool is_available() {
@@ -12,4 +12,4 @@ inline bool is_available() {
 
 NPUDeviceProp* getDeviceProperties(c10::DeviceIndex device);
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUDeviceProp.h
+++ b/csrc/backend/NPUDeviceProp.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-namespace c10::npu {
+namespace c10::backend {
 
 struct NPUDeviceProp {
   std::string name{};

--- a/csrc/backend/NPUEvent.h
+++ b/csrc/backend/NPUEvent.h
@@ -2,13 +2,13 @@
 
 #include <cstdint>
 #include <utility>
-#include "csrc/core/Macros.h"
 #include "csrc/backend/NPUGuard.h"
 #include "csrc/backend/NPUStream.h"
+#include "csrc/core/Macros.h"
 #include "npu/acl/include/acl/acl.h"
 #include "npu/core/NPUException.h"
 
-namespace c10::npu {
+namespace c10::backend {
 /*
  * NPUEvents are movable not copyable wrappers around NPU's events.
  * NPUEvents are constructed lazily when first recorded.
@@ -159,4 +159,4 @@ struct C10_BACKEND_API NPUEvent {
   }
 };
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUFunctions.cpp
+++ b/csrc/backend/NPUFunctions.cpp
@@ -204,7 +204,7 @@ std::mutex* getFreeMutex() {
 }
 
 void get_device_properties(
-    c10::npu::NPUDeviceProp* device_prop,
+    c10::backend::NPUDeviceProp* device_prop,
     c10::DeviceIndex device) {
   const char* device_name;
   device_name = aclrtGetSocName();

--- a/csrc/backend/NPUFunctions.cpp
+++ b/csrc/backend/NPUFunctions.cpp
@@ -4,7 +4,7 @@
 #include "csrc/backend/NPUStream.h"
 #include "npu/adapter/acl_device_adapter.h"
 
-namespace c10::npu {
+namespace c10::backend {
 
 int device_count_impl() {
   int count = 0;
@@ -44,12 +44,12 @@ c10::DeviceIndex device_count_ensure_non_zero() {
 
 c10::DeviceIndex current_device() {
   c10::DeviceIndex cur_device = -1;
-  NPU_CHECK_ERROR(c10::npu::GetDevice(&cur_device));
+  NPU_CHECK_ERROR(c10::backend::GetDevice(&cur_device));
   return cur_device;
 }
 
 void set_device(c10::DeviceIndex device) {
-  NPU_CHECK_ERROR(c10::npu::SetDevice(device));
+  NPU_CHECK_ERROR(c10::backend::SetDevice(device));
 }
 
 void device_synchronize() {
@@ -143,7 +143,7 @@ aclError SetDevice(c10::DeviceIndex device) {
 
 aclError MaybeSetDevice(c10::DeviceIndex device) {
   if (hasPrimaryContext(device)) {
-    return c10::npu::SetDevice(device);
+    return c10::backend::SetDevice(device);
   }
   targetDeviceIndex = device;
   return ACL_ERROR_NONE;
@@ -190,7 +190,7 @@ c10::DeviceIndex MaybeExchangeDevice(c10::DeviceIndex to_device) {
 
 void SetTargetDevice() {
   if (targetDeviceIndex >= 0) {
-    NPU_CHECK_ERROR(c10::npu::SetDevice(targetDeviceIndex));
+    NPU_CHECK_ERROR(c10::backend::SetDevice(targetDeviceIndex));
   }
 }
 
@@ -215,4 +215,4 @@ void get_device_properties(
   }
 }
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUFunctions.h
+++ b/csrc/backend/NPUFunctions.h
@@ -17,7 +17,7 @@
 #include "csrc/core/Macros.h"
 #include "npu/core/NPUException.h"
 
-namespace c10::npu {
+namespace c10::backend {
 
 C10_BACKEND_API c10::DeviceIndex device_count() noexcept;
 
@@ -88,4 +88,4 @@ C10_BACKEND_API void get_device_properties(
     c10::backend::NPUDeviceProp* device_prop,
     c10::DeviceIndex device);
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUFunctions.h
+++ b/csrc/backend/NPUFunctions.h
@@ -13,8 +13,8 @@
 #include <npu/acl/include/acl/acl.h>
 #include <mutex>
 #include <optional>
-#include "csrc/core/Macros.h"
 #include "csrc/backend/NPUDeviceProp.h"
+#include "csrc/core/Macros.h"
 #include "npu/core/NPUException.h"
 
 namespace c10::npu {
@@ -85,7 +85,7 @@ getDeviceIndexWithPrimaryContext();
 C10_BACKEND_API std::mutex* getFreeMutex();
 
 C10_BACKEND_API void get_device_properties(
-    c10::npu::NPUDeviceProp* device_prop,
+    c10::backend::NPUDeviceProp* device_prop,
     c10::DeviceIndex device);
 
 } // namespace c10::npu

--- a/csrc/backend/NPUGeneratorImpl.cpp
+++ b/csrc/backend/NPUGeneratorImpl.cpp
@@ -5,7 +5,7 @@
 #include "csrc/aten/generated/NPUNativeFunctions.h"
 #include "csrc/backend/NPUFunctions.h"
 
-namespace at_npu {
+namespace c10::backend {
 namespace detail {
 
 namespace {
@@ -27,7 +27,7 @@ static std::vector<at::Generator> default_gens_npu;
  * Warning: this function must only be called once!
  */
 static void initNPUGenVector() {
-  num_npus = c10::npu::device_count();
+  num_npus = c10::backend::device_count();
   npu_gens_init_flag.resize(num_npus);
   default_gens_npu.resize(num_npus);
 }
@@ -46,7 +46,7 @@ const at::Generator& getDefaultNPUGenerator(c10::DeviceIndex device_index) {
   std::call_once(num_npu_init_flag, initNPUGenVector);
   c10::DeviceIndex idx = device_index;
   if (idx == -1) {
-    idx = c10::npu::current_device();
+    idx = c10::backend::current_device();
   } else {
     TORCH_CHECK(idx >= 0 && idx < num_npus, PTA_ERROR(ErrCode::VALUE));
   }
@@ -64,7 +64,7 @@ at::Generator createNPUGenerator(c10::DeviceIndex device_index) {
   std::call_once(num_npu_init_flag, initNPUGenVector);
   c10::DeviceIndex idx = device_index;
   if (idx == -1) {
-    idx = c10::npu::current_device();
+    idx = c10::backend::current_device();
   }
   TORCH_CHECK(
       idx >= 0 && idx < num_npus,
@@ -309,4 +309,4 @@ at::Generator make_npu_generator(c10::DeviceIndex device_index) {
 
 REGISTER_GENERATOR_PRIVATEUSE1(make_npu_generator)
 
-} // namespace at_npu
+} // namespace c10::backend

--- a/csrc/backend/NPUGeneratorImpl.h
+++ b/csrc/backend/NPUGeneratorImpl.h
@@ -8,7 +8,7 @@
 #include "csrc/core/Macros.h"
 #include "csrc/core/generator/GeneratorImpl.h"
 
-namespace at_npu {
+namespace c10::backend {
 /**
  * Note [NPU Graph-safe RNG states]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -155,4 +155,4 @@ TORCH_BACKEND_API at::Generator createNPUGenerator(
     c10::DeviceIndex device_index = -1);
 
 } // namespace detail
-} // namespace at_npu
+} // namespace c10::backend

--- a/csrc/backend/NPUGuard.h
+++ b/csrc/backend/NPUGuard.h
@@ -3,14 +3,12 @@
 #include <c10/core/DeviceType.h>
 #include <c10/core/impl/InlineDeviceGuard.h>
 #include <c10/core/impl/InlineStreamGuard.h>
-#include "csrc/core/guard/PrivateUse1Guard.h"
 #include "csrc/backend/NPUGuardImpl.h"
+#include "csrc/core/guard/PrivateUse1Guard.h"
 
 #include <cstddef>
 
-namespace c10::npu {
-
-using namespace c10::backend::Guard;
+namespace c10::backend {
 
 // This code is kind of boilerplatey.  See Note [Whither the DeviceGuard
 // boilerplate]
@@ -20,10 +18,9 @@ using namespace c10::backend::Guard;
 /// more efficient than DeviceGuard (it compiles to straight line
 /// NPUSetDevice/NPUGetDevice calls); however, it can only be used
 /// from code that links against NPU directly.
-struct NPUGuard : public PrivateUse1Guard<impl::NPUGuardImpl> {
-  using PrivateUse1Guard = PrivateUse1Guard<impl::NPUGuardImpl>;
+struct NPUGuard : public Guard::PrivateUse1Guard<impl::NPUGuardImpl> {
+  using PrivateUse1Guard = Guard::PrivateUse1Guard<impl::NPUGuardImpl>;
   using PrivateUse1Guard::PrivateUse1Guard;
-
   // Copy is not allowed
   NPUGuard(const NPUGuard&) = delete;
   NPUGuard& operator=(const NPUGuard&) = delete;
@@ -35,8 +32,10 @@ struct NPUGuard : public PrivateUse1Guard<impl::NPUGuardImpl> {
 
 /// A variant of OptionalDeviceGuard that is specialized for NPU.  See
 /// NPUGuard for when you can use this.
-struct OptionalNPUGuard : public OptionalPrivateUse1Guard<impl::NPUGuardImpl> {
-  using OptionalPrivateUse1Guard = OptionalPrivateUse1Guard<impl::NPUGuardImpl>;
+struct OptionalNPUGuard
+    : public Guard::OptionalPrivateUse1Guard<impl::NPUGuardImpl> {
+  using OptionalPrivateUse1Guard =
+      Guard::OptionalPrivateUse1Guard<impl::NPUGuardImpl>;
   using OptionalPrivateUse1Guard::OptionalPrivateUse1Guard;
 
   // Copy is not allowed
@@ -109,7 +108,7 @@ struct NPUStreamGuard {
   }
 
  private:
-  c10::impl::InlineStreamGuard<c10::npu::impl::NPUGuardImpl> guard_;
+  c10::impl::InlineStreamGuard<c10::backend::impl::NPUGuardImpl> guard_;
 };
 
 /// A variant of OptionalStreamGuard that is specialized for NPU.  See NPUGuard
@@ -178,7 +177,7 @@ struct OptionalNPUStreamGuard {
   }
 
  private:
-  c10::impl::InlineOptionalStreamGuard<c10::npu::impl::NPUGuardImpl> guard_;
+  c10::impl::InlineOptionalStreamGuard<c10::backend::impl::NPUGuardImpl> guard_;
 };
 
 /// A variant of MultiStreamGuard that is specialized for NPU.
@@ -197,7 +196,7 @@ struct NPUMultiStreamGuard {
   NPUMultiStreamGuard& operator=(NPUMultiStreamGuard&& other) = delete;
 
  private:
-  c10::impl::InlineMultiStreamGuard<c10::npu::impl::NPUGuardImpl> guard_;
+  c10::impl::InlineMultiStreamGuard<c10::backend::impl::NPUGuardImpl> guard_;
 
   static std::vector<c10::Stream> unwrapStreams(
       at::ArrayRef<NPUStream> NPUStreams) {
@@ -210,4 +209,4 @@ struct NPUMultiStreamGuard {
   }
 };
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUGuardImpl.cpp
+++ b/csrc/backend/NPUGuardImpl.cpp
@@ -1,7 +1,7 @@
 #include "csrc/backend/NPUGuardImpl.h"
 
-namespace c10::npu::impl {
+namespace c10::backend::impl {
 
 C10_REGISTER_GUARD_IMPL(PrivateUse1, NPUGuardImpl);
 
-} // namespace c10::npu::impl
+} // namespace c10::backend::impl

--- a/csrc/backend/NPUGuardImpl.h
+++ b/csrc/backend/NPUGuardImpl.h
@@ -31,13 +31,13 @@ struct NPUGuardImpl final : public PrivateUse1GuardImpl {
         PTA_ERROR(ErrCode::PARAM));
     c10::Device old_device = getDevice();
     if (old_device.index() != d.index()) {
-      NPU_CHECK_ERROR(c10::npu::SetDevice(d.index()));
+      NPU_CHECK_ERROR(c10::backend::SetDevice(d.index()));
     }
     return old_device;
   }
   c10::Device getDevice() const override {
     c10::DeviceIndex device = 0;
-    NPU_CHECK_ERROR(c10::npu::GetDevice(&device));
+    NPU_CHECK_ERROR(c10::backend::GetDevice(&device));
     return c10::Device(c10::DeviceType::PrivateUse1, device);
   }
   void setDevice(c10::Device d) const override {
@@ -46,10 +46,10 @@ struct NPUGuardImpl final : public PrivateUse1GuardImpl {
         "DeviceType must be 'c10::DeviceType::PrivateUse1'. Actual DeviceType is: ",
         d.type(),
         PTA_ERROR(ErrCode::PARAM));
-    NPU_CHECK_ERROR(c10::npu::SetDevice(d.index()));
+    NPU_CHECK_ERROR(c10::backend::SetDevice(d.index()));
   }
   void uncheckedSetDevice(c10::Device d) const noexcept override {
-    NPU_CHECK_WARN(c10::npu::SetDevice(d.index()));
+    NPU_CHECK_WARN(c10::backend::SetDevice(d.index()));
   }
   c10::Stream getStream(c10::Device d) const noexcept override {
     return c10::backend::getCurrentNPUStream(d.index()).unwrap();
@@ -70,7 +70,7 @@ struct NPUGuardImpl final : public PrivateUse1GuardImpl {
     return old_stream.unwrap();
   }
   c10::DeviceIndex deviceCount() const noexcept override {
-    static c10::DeviceIndex count = c10::npu::device_count();
+    static c10::DeviceIndex count = c10::backend::device_count();
     return count;
   }
 
@@ -86,10 +86,10 @@ struct NPUGuardImpl final : public PrivateUse1GuardImpl {
       return;
     auto acl_event = static_cast<aclrtEvent>(event);
     c10::DeviceIndex orig_device{-1};
-    NPU_CHECK_WARN(c10::npu::GetDevice(&orig_device));
-    NPU_CHECK_WARN(c10::npu::SetDevice(device_index));
+    NPU_CHECK_WARN(c10::backend::GetDevice(&orig_device));
+    NPU_CHECK_WARN(c10::backend::SetDevice(device_index));
     NPU_CHECK_WARN(aclrtDestroyEvent(acl_event));
-    NPU_CHECK_WARN(c10::npu::SetDevice(orig_device));
+    NPU_CHECK_WARN(c10::backend::SetDevice(orig_device));
   }
 
   void record(

--- a/csrc/backend/NPUGuardImpl.h
+++ b/csrc/backend/NPUGuardImpl.h
@@ -6,14 +6,14 @@
 
 #include <npu/acl/include/acl/acl.h>
 #include "csrc/aten/generated/NPUNativeFunctions.h"
-#include "csrc/core/guard/PrivateUse1GuardImpl.h"
 #include "csrc/backend/NPUFunctions.h"
 #include "csrc/backend/NPUStream.h"
+#include "csrc/core/guard/PrivateUse1GuardImpl.h"
 #include "npu/core/NPUException.h"
 
-namespace c10::npu {
+namespace c10::backend {
 namespace impl {
-struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
+struct NPUGuardImpl final : public PrivateUse1GuardImpl {
   NPUGuardImpl() = default;
 
   explicit NPUGuardImpl(c10::DeviceType t) {
@@ -52,21 +52,21 @@ struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
     NPU_CHECK_WARN(c10::npu::SetDevice(d.index()));
   }
   c10::Stream getStream(c10::Device d) const noexcept override {
-    return c10::npu::getCurrentNPUStream(d.index()).unwrap();
+    return c10::backend::getCurrentNPUStream(d.index()).unwrap();
   }
   c10::Stream getDefaultStream(c10::Device d) const override {
-    return c10::npu::getDefaultNPUStream(d.index());
+    return c10::backend::getDefaultNPUStream(d.index());
   }
   c10::Stream getStreamFromGlobalPool(
       c10::Device d,
       bool isHighPriority = false) const override {
-    return c10::npu::getStreamFromPool(isHighPriority, d.index());
+    return c10::backend::getStreamFromPool(isHighPriority, d.index());
   }
   // NB: These do NOT set the current device
   c10::Stream exchangeStream(c10::Stream s) const noexcept override {
     NPUStream cs(s);
-    auto old_stream = c10::npu::getCurrentNPUStream(s.device().index());
-    c10::npu::setCurrentNPUStream(cs);
+    auto old_stream = c10::backend::getCurrentNPUStream(s.device().index());
+    c10::backend::setCurrentNPUStream(cs);
     return old_stream.unwrap();
   }
   c10::DeviceIndex deviceCount() const noexcept override {
@@ -156,4 +156,4 @@ struct NPUGuardImpl final : public c10::backend::impl::PrivateUse1GuardImpl {
 };
 
 } // namespace impl
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUHooks.cpp
+++ b/csrc/backend/NPUHooks.cpp
@@ -26,7 +26,7 @@ void NPUHooks::resizePrivateUse1Bytes(
     const c10::Storage& storage,
     size_t new_bytes) const {
   auto storage_impl =
-      static_cast<torch_backend::NPUStorageImpl*>(storage.unsafeGetStorageImpl());
+      static_cast<c10::backend::NPUStorageImpl*>(storage.unsafeGetStorageImpl());
   auto format = storage_impl->npu_desc_.npu_format_;
   if (!at_npu::native::FormatHelper::IsBaseFormatType(format)) {
     AT_ERROR("Try to resize a storage without base format");

--- a/csrc/backend/NPUHooks.cpp
+++ b/csrc/backend/NPUHooks.cpp
@@ -1,16 +1,16 @@
 #include "csrc/backend/NPUHooks.h"
-#include "csrc/core/Register.h"
 #include "csrc/backend/NPUCachingHostAllocator.h"
 #include "csrc/backend/NPUFunctions.h"
 #include "csrc/backend/NPUStorageImpl.h"
+#include "csrc/core/Register.h"
 #include "npu/aten/common/ResizeNpu.h"
 #include "npu/framework/FormatHelper.h"
 
-namespace c10::npu {
+namespace c10::backend {
 
 TORCH_DECLARE_REGISTRY(PrivateUse1HooksRegistry, NPUHooks, NPUHooksArgs);
 
-AT_REGISTER_PRIVATEUSE1_HOOKS_INTERFACE(c10::npu::get_npu_hooks());
+AT_REGISTER_PRIVATEUSE1_HOOKS_INTERFACE(c10::backend::get_npu_hooks());
 
 C10_DEFINE_REGISTRY(PrivateUse1HooksRegistry, NPUHooks, NPUHooksArgs)
 
@@ -19,14 +19,14 @@ void NPUHooks::initPrivateUse1() const {
 }
 
 bool NPUHooks::hasPrimaryContext(c10::DeviceIndex device_index) const {
-  return c10::npu::hasPrimaryContext(device_index);
+  return hasPrimaryContext(device_index);
 }
 
 void NPUHooks::resizePrivateUse1Bytes(
     const c10::Storage& storage,
     size_t new_bytes) const {
-  auto storage_impl =
-      static_cast<c10::backend::NPUStorageImpl*>(storage.unsafeGetStorageImpl());
+  auto storage_impl = static_cast<c10::backend::NPUStorageImpl*>(
+      storage.unsafeGetStorageImpl());
   auto format = storage_impl->npu_desc_.npu_format_;
   if (!at_npu::native::FormatHelper::IsBaseFormatType(format)) {
     AT_ERROR("Try to resize a storage without base format");
@@ -51,4 +51,4 @@ at::PrivateUse1HooksInterface* get_npu_hooks() {
   c10::call_once(once, [] { npu_hooks = new NPUHooks(); });
   return npu_hooks;
 }
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUHooks.h
+++ b/csrc/backend/NPUHooks.h
@@ -3,14 +3,14 @@
 #include <c10/core/Storage.h>
 #include "csrc/backend/NPUGeneratorImpl.h"
 
-namespace c10::npu {
+namespace c10::backend {
 
 struct TORCH_API NPUHooks : public at::PrivateUse1HooksInterface {
   virtual ~NPUHooks() = default;
   const at::Generator& getDefaultGenerator(
       c10::DeviceIndex device_index) override {
     static auto device_gen =
-        at_npu::detail::getDefaultNPUGenerator(device_index);
+        c10::backend::detail::getDefaultNPUGenerator(device_index);
     return device_gen;
   }
   void initPrivateUse1() const override;

--- a/csrc/backend/NPUSerialization.cpp
+++ b/csrc/backend/NPUSerialization.cpp
@@ -1,13 +1,15 @@
-#include <torch/csrc/jit/serialization/pickler.h>
 #include "csrc/backend/NPUSerialization.h"
+#include <torch/csrc/jit/serialization/pickler.h>
 #include "csrc/aten/generated/NPUNativeFunctions.h"
 #include "csrc/core/Register.h"
 #include "npu/acl/include/acl/acl_base.h"
 #include "npu/framework/StorageDescHelper.h"
 
-namespace torch_backend {
+namespace c10::backend {
 
-REGISTER_TENSOR_BACKEND_META_REGISTRY(torch_backend::npu_info_serialization, torch_backend::npu_info_deserialization);
+REGISTER_TENSOR_BACKEND_META_REGISTRY(
+    c10::backend::npu_info_serialization,
+    c10::backend::npu_info_deserialization);
 
 std::unordered_map<std::string, aclFormat> FORMAT_INFO = {
     {"NC1HWC0", ACL_FORMAT_NC1HWC0},
@@ -61,4 +63,4 @@ void npu_info_deserialization(
   }
 }
 
-} // namespace torch_backend
+} // namespace c10::backend

--- a/csrc/backend/NPUSerialization.h
+++ b/csrc/backend/NPUSerialization.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace torch_backend {
+namespace c10::backend {
 // Serialize npu-related information, mainly related to private formats
 void npu_info_serialization(
     const at::Tensor& t,
@@ -13,4 +13,4 @@ void npu_info_serialization(
 void npu_info_deserialization(
     const at::Tensor& t,
     std::unordered_map<std::string, bool>& mate_map);
-} // namespace torch_backend
+} // namespace c10::backend

--- a/csrc/backend/NPUStorageImpl.cpp
+++ b/csrc/backend/NPUStorageImpl.cpp
@@ -1,9 +1,9 @@
 #include "csrc/backend/NPUStorageImpl.h"
 #include "csrc/core/Register.h"
 
-namespace torch_backend {
+namespace c10::backend {
 
-C10_SET_STORAGE_IMPL_CREATE(&torch_backend::make_npu_storage_impl);
+C10_SET_STORAGE_IMPL_CREATE(&c10::backend::make_npu_storage_impl);
 
 NPUStorageImpl::NPUStorageImpl(
     use_byte_size_t use_byte_size,
@@ -44,4 +44,4 @@ c10::intrusive_ptr<c10::StorageImpl> make_npu_storage_impl(
   return npu_storage_impl;
 }
 
-} // namespace torch_backend
+} // namespace c10::backend

--- a/csrc/backend/NPUStorageImpl.h
+++ b/csrc/backend/NPUStorageImpl.h
@@ -10,7 +10,7 @@
 #include "npu/acl/include/acl/acl_base.h"
 #include "npu/acl/include/acl/acl_rt.h"
 
-namespace torch_backend {
+namespace c10::backend {
 
 struct NPUStorageDesc {
  public:
@@ -53,4 +53,4 @@ c10::intrusive_ptr<c10::StorageImpl> make_npu_storage_impl(
     c10::Allocator* allocator,
     bool resizable);
 
-} // namespace torch_backend
+} // namespace c10::backend

--- a/csrc/backend/NPUStream.cpp
+++ b/csrc/backend/NPUStream.cpp
@@ -146,7 +146,7 @@ c10::StreamId makeStreamId(StreamIdType st, size_t si) {
 }
 
 static void initGlobalStreamState() {
-  num_npus = c10::npu::device_count();
+  num_npus = c10::backend::device_count();
   // Check if the number of NPUs matches the expected compile-time max number
   // of NPUs.
   AT_ASSERTM(
@@ -266,7 +266,7 @@ aclrtStream NPUStream::stream() const {
 NPUStream getStreamFromPool(const int priority, c10::DeviceIndex device_index) {
   initNPUStreamsOnce();
   if (device_index == -1) {
-    device_index = c10::npu::current_device();
+    device_index = c10::backend::current_device();
   }
 
   check_npu(device_index);
@@ -301,7 +301,7 @@ NPUStream getStreamFromExternal(
 NPUStream getDefaultNPUStream(c10::DeviceIndex device_index) {
   initNPUStreamsOnce();
   if (device_index == -1) {
-    device_index = c10::npu::current_device();
+    device_index = c10::backend::current_device();
   }
   check_npu(device_index);
   return NPUStreamForId(device_index, makeStreamId(StreamIdType::DEFAULT, 0));
@@ -310,7 +310,7 @@ NPUStream getDefaultNPUStream(c10::DeviceIndex device_index) {
 NPUStream getCurrentNPUStream(c10::DeviceIndex device_index) {
   initNPUStreamsOnce();
   if (device_index == -1) {
-    device_index = c10::npu::current_device();
+    device_index = c10::backend::current_device();
   }
   check_npu(device_index);
   return NPUStreamForId(device_index, current_streams[device_index]);
@@ -327,10 +327,10 @@ std::ostream& operator<<(std::ostream& stream, const NPUStream& s) {
 
 aclError DestroyUsedStreams() {
   c10::DeviceIndex cur_device = 0;
-  NPU_CHECK_ERROR(c10::npu::GetDevice(&cur_device));
+  NPU_CHECK_ERROR(c10::backend::GetDevice(&cur_device));
   std::vector<c10::DeviceIndex> device_idx_vec = acl_adapter::GetUsedDevices();
   for (const auto deviceId : device_idx_vec) {
-    NPU_CHECK_ERROR(c10::npu::SetDevice(deviceId));
+    NPU_CHECK_ERROR(c10::backend::SetDevice(deviceId));
     for (const auto i : c10::irange(kStreamsPerPool)) {
       for (const auto p : c10::irange(max_compile_time_stream_priorities)) {
         aclrtStream stream = streams[p][deviceId][i];
@@ -344,7 +344,7 @@ aclError DestroyUsedStreams() {
       }
     }
   }
-  NPU_CHECK_ERROR(c10::npu::SetDevice(cur_device));
+  NPU_CHECK_ERROR(c10::backend::SetDevice(cur_device));
   return ACL_ERROR_NONE;
 }
 } // namespace c10::backend

--- a/csrc/backend/NPUStream.cpp
+++ b/csrc/backend/NPUStream.cpp
@@ -13,7 +13,7 @@
 
 #define C10_COMPILE_TIME_MAX_NPUS 16
 
-namespace c10::npu {
+namespace c10::backend {
 namespace {
 
 // Global stream state and constants
@@ -164,9 +164,7 @@ static void initSingleStream(int p, c10::DeviceIndex device_index, int i) {
   auto pri = -p; // lower number is higher priority
 
   NPU_CHECK_SUPPORTED_OR_ERROR(aclrtCreateStreamWithConfig(
-        &stream,
-        0,
-        (ACL_STREAM_FAST_LAUNCH | ACL_STREAM_FAST_SYNC)));
+      &stream, 0, (ACL_STREAM_FAST_LAUNCH | ACL_STREAM_FAST_SYNC)));
   priority_counters[p][device_index] = 0;
 }
 
@@ -268,7 +266,7 @@ aclrtStream NPUStream::stream() const {
 NPUStream getStreamFromPool(const int priority, c10::DeviceIndex device_index) {
   initNPUStreamsOnce();
   if (device_index == -1) {
-    device_index = current_device();
+    device_index = c10::npu::current_device();
   }
 
   check_npu(device_index);
@@ -303,7 +301,7 @@ NPUStream getStreamFromExternal(
 NPUStream getDefaultNPUStream(c10::DeviceIndex device_index) {
   initNPUStreamsOnce();
   if (device_index == -1) {
-    device_index = current_device();
+    device_index = c10::npu::current_device();
   }
   check_npu(device_index);
   return NPUStreamForId(device_index, makeStreamId(StreamIdType::DEFAULT, 0));
@@ -312,7 +310,7 @@ NPUStream getDefaultNPUStream(c10::DeviceIndex device_index) {
 NPUStream getCurrentNPUStream(c10::DeviceIndex device_index) {
   initNPUStreamsOnce();
   if (device_index == -1) {
-    device_index = current_device();
+    device_index = c10::npu::current_device();
   }
   check_npu(device_index);
   return NPUStreamForId(device_index, current_streams[device_index]);
@@ -329,10 +327,10 @@ std::ostream& operator<<(std::ostream& stream, const NPUStream& s) {
 
 aclError DestroyUsedStreams() {
   c10::DeviceIndex cur_device = 0;
-  NPU_CHECK_ERROR(GetDevice(&cur_device));
+  NPU_CHECK_ERROR(c10::npu::GetDevice(&cur_device));
   std::vector<c10::DeviceIndex> device_idx_vec = acl_adapter::GetUsedDevices();
   for (const auto deviceId : device_idx_vec) {
-    NPU_CHECK_ERROR(SetDevice(deviceId));
+    NPU_CHECK_ERROR(c10::npu::SetDevice(deviceId));
     for (const auto i : c10::irange(kStreamsPerPool)) {
       for (const auto p : c10::irange(max_compile_time_stream_priorities)) {
         aclrtStream stream = streams[p][deviceId][i];
@@ -346,7 +344,7 @@ aclError DestroyUsedStreams() {
       }
     }
   }
-  NPU_CHECK_ERROR(SetDevice(cur_device));
+  NPU_CHECK_ERROR(c10::npu::SetDevice(cur_device));
   return ACL_ERROR_NONE;
 }
-} // namespace c10::npu
+} // namespace c10::backend

--- a/csrc/backend/NPUStream.h
+++ b/csrc/backend/NPUStream.h
@@ -55,7 +55,7 @@
  * a kernel on the same stream from two different threads.
  */
 
-namespace c10::npu {
+namespace c10::backend {
 
 static constexpr int max_compile_time_stream_priorities = 2;
 
@@ -230,12 +230,12 @@ C10_BACKEND_API void setCurrentNPUStream(NPUStream stream);
 std::ostream& operator<<(std::ostream& stream, const NPUStream& s);
 
 aclError DestroyUsedStreams();
-} // namespace c10::npu
+} // namespace c10::backend
 
 namespace std {
 template <>
-struct hash<c10::npu::NPUStream> {
-  size_t operator()(c10::npu::NPUStream s) const noexcept {
+struct hash<c10::backend::NPUStream> {
+  size_t operator()(c10::backend::NPUStream s) const noexcept {
     return std::hash<c10::Stream>{}(s.unwrap());
   }
 };

--- a/csrc/backend/NPUTensorImpl.cpp
+++ b/csrc/backend/NPUTensorImpl.cpp
@@ -6,7 +6,7 @@
 #include "csrc/backend/NPUStorageImpl.h"
 #include "csrc/backend/NPUTensorImpl.h"
 
-namespace torch_backend {
+namespace c10::backend {
 NPUTensorImpl::NPUTensorImpl(
     c10::Storage&& storage,
     const caffe2::TypeMeta& data_type)
@@ -54,4 +54,4 @@ c10::intrusive_ptr<c10::TensorImpl> NPUTensorImpl::shallow_copy_and_detach(
   return impl;
 }
 NPUTensorImpl::~NPUTensorImpl() {}
-} // namespace torch_backend
+} // namespace c10::backend

--- a/csrc/backend/NPUTensorImpl.h
+++ b/csrc/backend/NPUTensorImpl.h
@@ -4,7 +4,7 @@
 #include <c10/core/TensorImpl.h>
 #include "csrc/backend/NPUStorageImpl.h"
 
-namespace torch_backend {
+namespace c10::backend {
 
 // NPUTensorImpl class is derived from c10::TensorImpl, and it is only used to
 // handle an NPU tensor. Its scope is just to handle an NPUTensor.

--- a/npu/aten/common/ChangeDataPtr.cpp
+++ b/npu/aten/common/ChangeDataPtr.cpp
@@ -32,9 +32,9 @@ int64_t NPUNativeFunctions::npu_change_data_ptr(
       PTA_ERROR(ErrCode::TYPE));
 
   auto dst_sizes =
-      torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_.storage_sizes_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_.storage_sizes_;
   auto src_sizes =
-      torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_.storage_sizes_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_.storage_sizes_;
   int64_t dst_storage_size = c10::multiply_integers(dst_sizes);
   int64_t src_storage_size = c10::multiply_integers(src_sizes);
 

--- a/npu/aten/common/CopyKernel.cpp
+++ b/npu/aten/common/CopyKernel.cpp
@@ -315,12 +315,12 @@ void copy_d2d_dtype(
     const at::Tensor& src,
     bool non_blocking) {
   if (!is_same_format(self, src)) {
-    auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+    auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
     if (src.is_contiguous() && FormatHelper::IsBaseFormatType(src) &&
         src_desc.base_sizes_.size() == 1) {
       StorageDescHelper::ReflushDescBySelf(src);
       copy_d2d_format_cast(self, src);
-      torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_ =
+      c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_ =
           std::move(src_desc);
       return;
     }

--- a/npu/aten/common/CopyKernel.cpp
+++ b/npu/aten/common/CopyKernel.cpp
@@ -97,8 +97,8 @@ void copy_d2d(at::Tensor& self, const at::Tensor& src, bool non_blocking) {
           self.device().index());
     }
     guard.reset_device(self.device());
-    c10::npu::NPUStream dst_stream =
-        c10::npu::getCurrentNPUStream(self.device().index());
+    c10::backend::NPUStream dst_stream =
+        c10::backend::getCurrentNPUStream(self.device().index());
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(dst_stream, -1));
     guard.reset_device(src.device());
   }
@@ -110,7 +110,7 @@ void copy_d2d(at::Tensor& self, const at::Tensor& src, bool non_blocking) {
   copy_d2d_dtype(self, src, non_blocking);
   // synchronize src stream for different devices copy
   if (self.device().index() != src.device().index()) {
-    c10::npu::NPUStream copy_stream = c10::npu::getCurrentNPUStream();
+    c10::backend::NPUStream copy_stream = c10::backend::getCurrentNPUStream();
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(copy_stream, -1));
   }
 }
@@ -124,7 +124,7 @@ void copy_between_host_and_device(
     aclrtMemcpyKind kind,
     bool non_blocking) {
   int64_t nbytes = dst.numel() * dst.element_size();
-  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
+  c10::backend::NPUStream stream = c10::backend::getCurrentNPUStream();
 
   if (non_blocking) {
     auto ret = CalcuOpUtil::LaunchAsyncCopyTaskWithModeSwitch(

--- a/npu/aten/common/CopyMemoryKernel.cpp
+++ b/npu/aten/common/CopyMemoryKernel.cpp
@@ -32,8 +32,8 @@ at::Tensor& NPUNativeFunctions::copy_memory_(
       src.device().index() == self.device().index(),
       "input tensors of copy_memory_ should have same device index",
       OPS_ERROR(ErrCode::PARAM));
-  auto dst_desc = torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
-  auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto dst_desc = c10::backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
+  auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
 
   int dst_size = 0;
   int src_size = 0;

--- a/npu/aten/common/CopyMemoryKernel.cpp
+++ b/npu/aten/common/CopyMemoryKernel.cpp
@@ -67,7 +67,7 @@ at::Tensor& NPUNativeFunctions::copy_memory_(
   NPU_CHECK_ERROR(ret);
 
   if (!non_blocking) {
-    c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
+    c10::backend::NPUStream stream = c10::backend::getCurrentNPUStream();
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(stream, -1));
   }
   return self;

--- a/npu/aten/common/FormatCastHelper.cpp
+++ b/npu/aten/common/FormatCastHelper.cpp
@@ -12,9 +12,9 @@ bool FormatCastHelper::IsSameGroupType(
     const at::Tensor& src,
     const at::Tensor& dst) {
   auto src_format =
-      torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_.npu_format_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_.npu_format_;
   auto dst_format =
-      torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_.npu_format_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_.npu_format_;
   return FormatHelper::GetBaseFormat(src_format) ==
       FormatHelper::GetBaseFormat(dst_format);
 }
@@ -38,7 +38,7 @@ void FormatCastHelper::format_cast_as_base_format(
       "src format must be base format",
       PTA_ERROR(ErrCode::PARAM));
 
-  auto& src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto& src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   // due to CANN principle : if the ori format of a tensor is the
   // same as the npu format, then its base shape must be same as storage shape
   // so we should not change the storage shape when format cast between base

--- a/npu/aten/common/FormatCastKernelNpu.cpp
+++ b/npu/aten/common/FormatCastKernelNpu.cpp
@@ -1,8 +1,8 @@
 #include "csrc/aten/generated/CustomFunctions.h"
 #include "csrc/aten/generated/NPUNativeFunctions.h"
+#include "csrc/backend/NPUStorageImpl.h"
 #include "npu/aten/common/FormatCastHelper.h"
 #include "npu/core/NPUBridge.h"
-#include "csrc/backend/NPUStorageImpl.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/utils/NpuStorageOffsetGuard.h"
 #include "npu/framework/utils/OpAdapter.h"
@@ -38,8 +38,8 @@ at::Tensor& NPUNativeFunctions::npu_format_cast_(
     const at::Tensor& src) {
   torch_backend::utils::torch_check_npu(dst);
   torch_backend::utils::torch_check_npu(src);
-  auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
-  auto dst_desc = torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
+  auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto dst_desc = c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
   if (src_desc.npu_format_ == dst_desc.npu_format_) {
     dst.copy_(src);
     return dst;
@@ -53,7 +53,7 @@ at::Tensor& NPUNativeFunctions::npu_format_cast_(
 
 // conver self to acl_format, write the result into new result tensor
 at::Tensor npu_format_cast_impl(const at::Tensor& src, int64_t acl_format) {
-  auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   if (src_desc.npu_format_ == acl_format) {
     ASCEND_LOGD("no need to do format cast");
     return src;
@@ -82,7 +82,7 @@ at::Tensor NPUNativeFunctions::npu_format_cast(
     const at::Tensor& src,
     const at::Tensor& dst) {
   torch_backend::utils::torch_check_npu(dst);
-  auto dst_desc = torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
+  auto dst_desc = c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
   int64_t dst_format = dst_desc.npu_format_;
   return custom_ops::npu_format_cast(src, dst_format);
 }
@@ -92,7 +92,7 @@ at::Tensor& NPUNativeFunctions::npu_format_cast_(
     at::Tensor& src,
     int64_t acl_format) {
   torch_backend::utils::torch_check_npu(src);
-  auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   if (src_desc.npu_format_ == acl_format) {
     return src;
   }
@@ -118,7 +118,7 @@ at::Tensor& NPUNativeFunctions::npu_format_cast_(
 
 int64_t NPUNativeFunctions::get_npu_format(const at::Tensor& src) {
   torch_backend::utils::torch_check_npu(src);
-  auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   return src_desc.npu_format_;
 }
 

--- a/npu/aten/common/LocalScalarDenseNpu.cpp
+++ b/npu/aten/common/LocalScalarDenseNpu.cpp
@@ -20,7 +20,8 @@ c10::Scalar NPUNativeFunctions::_local_scalar_dense(const at::Tensor& self) {
       "_local_scalar_dense_npu",
       [&] {
         scalar_t value = 0;
-        c10::npu::NPUStream copy_stream = c10::npu::getCurrentNPUStream();
+        c10::backend::NPUStream copy_stream =
+            c10::backend::getCurrentNPUStream();
         // Synchronous copy after stream synchronization
         aclError error = aclrtSynchronizeStreamWithTimeout(copy_stream, -1);
         if (error != ACL_ERROR_NONE) {

--- a/npu/aten/common/ResizeNpu.h
+++ b/npu/aten/common/ResizeNpu.h
@@ -2,9 +2,9 @@
 
 #include <ATen/ATen.h>
 
-#include "npu/core/NPUBridge.h"
 #include "csrc/backend/NPUStorageImpl.h"
 #include "csrc/backend/NPUStream.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/StorageDescHelper.h"
@@ -15,7 +15,7 @@ namespace at_npu {
 namespace native {
 
 static void storage_resize_npu(
-    torch_backend::NPUStorageImpl& storage,
+    c10::backend::NPUStorageImpl& storage,
     ptrdiff_t size,
     c10::IntArrayRef new_size) {
   if (!storage.resizable()) {
@@ -25,7 +25,7 @@ static void storage_resize_npu(
 
   at::DataPtr new_data = storage.allocator()->allocate(size);
   auto storage_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(&storage)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(&storage)->npu_desc_;
   size_t itemsize = storage_desc.data_type_.itemsize();
   at::DataPtr old_data = storage.set_data_ptr(std::move(new_data));
   ptrdiff_t old_size = static_cast<ptrdiff_t>(storage.nbytes());
@@ -45,7 +45,7 @@ static void storage_resize_npu(
   // It is necessary to properly refresh the storage according to sizes and
   // strides, not just new sizes.
   StorageDescHelper::UpdateDesc(
-      torch_backend::NPUBridge::GetNpuStorageImpl(&storage)->npu_desc_,
+      c10::backend::NPUBridge::GetNpuStorageImpl(&storage)->npu_desc_,
       resize_shape,
       new_size);
 
@@ -81,7 +81,7 @@ static inline void maybe_resize_storage_npu(
         static_cast<int64_t>(self->dtype().itemsize());
     if (new_size_bytes > static_cast<int64_t>(self->storage().nbytes())) {
       storage_resize_npu(
-          *torch_backend::NPUBridge::GetNpuStorageImpl(
+          *c10::backend::NPUBridge::GetNpuStorageImpl(
               self->storage().unsafeGetStorageImpl()),
           new_size_bytes,
           size);

--- a/npu/aten/common/SetNpu.cpp
+++ b/npu/aten/common/SetNpu.cpp
@@ -62,7 +62,7 @@ at::Tensor& NPUNativeFunctions::set_(
 at::Tensor& NPUNativeFunctions::set_(at::Tensor& self) {
   caffe2::TypeMeta dtype = self.dtype();
   c10::intrusive_ptr<c10::StorageImpl> npu_storage_impl =
-      c10::make_intrusive<torch_backend::NPUStorageImpl>(
+      c10::make_intrusive<c10::backend::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
           0,
           c10::npu::NPUCachingAllocator::get()->allocate(0),
@@ -113,7 +113,7 @@ at::Tensor set_tensor_with_storage_format(c10::Storage src) {
     // The storage object src has complete description information,
     // and the tensor object self needs to be brushed to be the same
     auto desc =
-        torch_backend::NPUBridge::GetNpuStorageImpl(src.unsafeGetStorageImpl())
+        c10::backend::NPUBridge::GetNpuStorageImpl(src.unsafeGetStorageImpl())
             ->npu_desc_;
     auto dist_tensor = NPUNativeFunctions::empty(
         {0},

--- a/npu/aten/common/StorageSizeNpu.cpp
+++ b/npu/aten/common/StorageSizeNpu.cpp
@@ -7,8 +7,8 @@ namespace native {
 
 int64_t NPUNativeFunctions::get_storage_size(const at::Tensor& self) {
   torch_backend::utils::torch_check_npu(self);
-  auto sizes =
-      torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_.storage_sizes_;
+  auto sizes = c10::backend::NPUBridge::GetNpuStorageImpl(self)
+                   ->npu_desc_.storage_sizes_;
   int64_t n = 1;
   for (auto s : sizes) {
     n *= s;

--- a/npu/aten/common/TensorFactories.cpp
+++ b/npu/aten/common/TensorFactories.cpp
@@ -126,7 +126,7 @@ at::Tensor NPUNativeFunctions::empty(
   auto dtype = c10::scalarTypeToTypeMeta(dtype_or_default(dtype_opt));
   int64_t size_bytes = nelements * dtype.itemsize();
   c10::intrusive_ptr<c10::StorageImpl> storage_impl =
-      c10::make_intrusive<torch_backend::NPUStorageImpl>(
+      c10::make_intrusive<c10::backend::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
           size_bytes,
           allocator->allocate(size_bytes),
@@ -134,7 +134,7 @@ at::Tensor NPUNativeFunctions::empty(
           true);
 
   auto tensor =
-      at::detail::make_tensor<torch_backend::NPUTensorImpl>(storage_impl, dtype);
+      at::detail::make_tensor<c10::backend::NPUTensorImpl>(storage_impl, dtype);
 
   // Default at::TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
@@ -260,8 +260,8 @@ at::Tensor empty_like_npu(
       result = at::empty(
           self.sizes(), options.memory_format(memory_format), c10::nullopt);
     } else {
-      auto npu_format =
-          torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_.npu_format_;
+      auto npu_format = c10::backend::NPUBridge::GetNpuStorageImpl(self)
+                            ->npu_desc_.npu_format_;
       result = OpPreparation::ApplyTensorWithFormat(
           self.sizes(), options, npu_format);
     }
@@ -320,7 +320,7 @@ at::Tensor NPUNativeFunctions::empty_with_format(
   int64_t nelements = StorageDescHelper::GetMemorySize(size, format, dtype);
   int64_t size_bytes = nelements * dtype.itemsize();
   c10::intrusive_ptr<c10::StorageImpl> storage_impl =
-      c10::make_intrusive<torch_backend::NPUStorageImpl>(
+      c10::make_intrusive<c10::backend::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
           size_bytes,
           allocator->allocate(size_bytes),
@@ -328,7 +328,7 @@ at::Tensor NPUNativeFunctions::empty_with_format(
           true);
 
   auto tensor =
-      at::detail::make_tensor<torch_backend::NPUTensorImpl>(storage_impl, dtype);
+      at::detail::make_tensor<c10::backend::NPUTensorImpl>(storage_impl, dtype);
 
   // Default NPUTensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {

--- a/npu/aten/common/from_blob.cpp
+++ b/npu/aten/common/from_blob.cpp
@@ -43,7 +43,7 @@ at::Tensor TensorMaker::make_tensor() {
   c10::DataPtr data_ptr{data_, *device_};
 
   c10::intrusive_ptr<c10::StorageImpl> storage_impl =
-      c10::make_intrusive<torch_backend::NPUStorageImpl>(
+      c10::make_intrusive<c10::backend::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
           size_bytes,
           std::move(data_ptr),
@@ -51,7 +51,7 @@ at::Tensor TensorMaker::make_tensor() {
           true);
 
   auto tensor =
-      at::detail::make_tensor<torch_backend::NPUTensorImpl>(storage_impl, dtype);
+      at::detail::make_tensor<c10::backend::NPUTensorImpl>(storage_impl, dtype);
 
   at_npu::native::StorageDescHelper::SetDesc(tensor, sizes_, tensor.strides());
 

--- a/npu/aten/common/from_blob.cpp
+++ b/npu/aten/common/from_blob.cpp
@@ -15,8 +15,8 @@ namespace native {
 
 at::Tensor TensorMaker::make_tensor() {
   if (device_ == c10::nullopt) {
-    device_ =
-        c10::Device(at::DeviceType::PrivateUse1, c10::npu::current_device());
+    device_ = c10::Device(
+        at::DeviceType::PrivateUse1, c10::backend::current_device());
   }
 
   if (opts_.device().has_index()) {

--- a/npu/aten/ops/FlattenDenseTensorsKernelNpu.cpp
+++ b/npu/aten/ops/FlattenDenseTensorsKernelNpu.cpp
@@ -8,7 +8,8 @@ at::Tensor NPUNativeFunctions::flatten_dense_tensors(at::TensorList tensors) {
   static auto cast_back_to_ori_format = [](const at::Tensor& t) {
     return custom_ops::npu_format_cast(
         t,
-        torch_backend::NPUBridge::GetNpuStorageImpl(t)->npu_desc_.origin_format_);
+        c10::backend::NPUBridge::GetNpuStorageImpl(t)
+            ->npu_desc_.origin_format_);
   };
   static auto flatten = [](const at::Tensor& t) {
     return cast_back_to_ori_format(t).contiguous().view({-1});

--- a/npu/aten/ops/StreamAndEventKernelNpu.cpp
+++ b/npu/aten/ops/StreamAndEventKernelNpu.cpp
@@ -8,7 +8,7 @@ void NPUNativeFunctions::record_stream(at::Tensor& self, c10::Stream stream) {
   struct c10::StreamData3 data = stream.pack3();
   c10::npu::NPUCachingAllocator::recordStream(
       self.storage().data_ptr(),
-      c10::npu::NPUStream::unpack3(
+      c10::backend::NPUStream::unpack3(
           data.stream_id, data.device_index, data.device_type));
 }
 

--- a/npu/aten/ops/base/aclops/AddKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/AddKernelNpu.cpp
@@ -132,7 +132,7 @@ at::Tensor stride_add_tensor_get(const at::Tensor& src) {
   if (src.is_contiguous()) {
     return src;
   } else {
-    auto src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+    auto src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
     at::Tensor src_new = npu_preparation::apply_tensor_with_format(
         src_desc.base_sizes_, src.options(), ACL_FORMAT_NC1HWC0);
     src_new.set_(

--- a/npu/aten/ops/base/aclops/AddmmKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/AddmmKernelNpu.cpp
@@ -41,7 +41,7 @@ bool is_transpose_last_two_dims_flex(const at::Tensor& tensor) {
 bool is_transpose_last_two_dims_strict(
     const at::Tensor& tensor,
     bool is_transpose_flex) {
-  auto base_sizes = torch_backend::NPUBridge::GetNpuStorageImpl(tensor)
+  auto base_sizes = c10::backend::NPUBridge::GetNpuStorageImpl(tensor)
                         ->get_npu_desc()
                         .base_sizes_;
   if (is_transpose_flex &&
@@ -106,9 +106,9 @@ at::Tensor& addmm_out_npu_nocheck(
     const at::Tensor& mat1,
     const at::Tensor& mat2) {
   const auto mat1_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_;
   const auto mat2_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
   bool is_mat1_t_flex = is_transpose_last_two_dims_flex(mat1);
   bool is_mat2_t_flex = is_transpose_last_two_dims_flex(mat2);
   bool is_mat1_t_strict =
@@ -131,10 +131,10 @@ at::Tensor& addmm_out_npu_nocheck(
   // Recover storage desc of view-transpose tensors, i.e. the inverse process of
   // set_transposed_npu_desc
   if (is_mat1_t_flex && (!is_mat1_t_strict)) {
-    torch_backend::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_ = mat1_desc;
+    c10::backend::NPUBridge::GetNpuStorageImpl(mat1)->npu_desc_ = mat1_desc;
   }
   if (is_mat2_t_flex && (!is_mat2_t_strict)) {
-    torch_backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
+    c10::backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
   }
   return result;
 }

--- a/npu/aten/ops/base/aclops/BernoulliKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/BernoulliKernelNpu.cpp
@@ -22,86 +22,114 @@
 #include "npu/aten/utils/OpAdapter.h"
 
 namespace acl_op {
-    using npu_preparation = at_npu::native::OpPreparation;
-    using npu_compile_type = at_npu::native::CompileType;
-    using npu_utils = at_npu::native::NpuUtils;
+using npu_preparation = at_npu::native::OpPreparation;
+using npu_compile_type = at_npu::native::CompileType;
+using npu_utils = at_npu::native::NpuUtils;
 
 namespace {
-    at::Tensor &bernoulli_npu_nocheck(at::Tensor &result, double p, c10::optional<at::Generator> gen) {
-        auto gen_ = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen, at_npu::detail::getDefaultNPUGenerator());
-        auto pair = gen_->philox_engine_inputs(10);
-        const int64_t seed = static_cast<int64_t>(pair.first);
-        const int64_t offset = static_cast<int64_t>(pair.second);
+at::Tensor& bernoulli_npu_nocheck(
+    at::Tensor& result,
+    double p,
+    c10::optional<at::Generator> gen) {
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen, c10::backend::detail::getDefaultNPUGenerator());
+  auto pair = gen_->philox_engine_inputs(10);
+  const int64_t seed = static_cast<int64_t>(pair.first);
+  const int64_t offset = static_cast<int64_t>(pair.second);
 
-        at_npu::native::OpCommand cmd;
-        cmd.Name("StatelessBernoulli")
-            .Input(result.sizes(), at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(at::Scalar(p), at::kFloat)
-            .Input(at::Scalar(seed), at::kLong)
-            .Input(at::Scalar(offset), at::kLong)
-            .Output(result)
-            .Attr("dtype", result.scalar_type())
-            .Run();
-        return result;
-    }
+  at_npu::native::OpCommand cmd;
+  cmd.Name("StatelessBernoulli")
+      .Input(
+          result.sizes(),
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(at::Scalar(p), at::kFloat)
+      .Input(at::Scalar(seed), at::kLong)
+      .Input(at::Scalar(offset), at::kLong)
+      .Output(result)
+      .Attr("dtype", result.scalar_type())
+      .Run();
+  return result;
+}
 
-    at::Tensor &bernoulli_npu_nocheck(at::Tensor &result, const at::Tensor &p, c10::optional<at::Generator> gen) {
-        auto gen_ = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen, at_npu::detail::getDefaultNPUGenerator());
-        auto pair = gen_->philox_engine_inputs(10);
-        const int64_t seed = static_cast<int64_t>(pair.first);
-        const int64_t offset = static_cast<int64_t>(pair.second);
+at::Tensor& bernoulli_npu_nocheck(
+    at::Tensor& result,
+    const at::Tensor& p,
+    c10::optional<at::Generator> gen) {
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen, c10::backend::detail::getDefaultNPUGenerator());
+  auto pair = gen_->philox_engine_inputs(10);
+  const int64_t seed = static_cast<int64_t>(pair.first);
+  const int64_t offset = static_cast<int64_t>(pair.second);
 
-        at_npu::native::OpCommand cmd;
-        cmd.Name("StatelessBernoulli")
-            .Input(result.sizes(), at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(p)
-            .Input(at::Scalar(seed), at::kLong)
-            .Input(at::Scalar(offset), at::kLong)
-            .Output(result)
-            .Attr("dtype", result.scalar_type())
-            .Run();
-        return result;
-    }
+  at_npu::native::OpCommand cmd;
+  cmd.Name("StatelessBernoulli")
+      .Input(
+          result.sizes(),
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(p)
+      .Input(at::Scalar(seed), at::kLong)
+      .Input(at::Scalar(offset), at::kLong)
+      .Output(result)
+      .Attr("dtype", result.scalar_type())
+      .Run();
+  return result;
+}
 } // namespace
 
-at::Tensor &bernoulli_(at::Tensor &self, double p, c10::optional<at::Generator> gen) {
-    if (!self.is_contiguous()) {
-        at::Tensor contiguous_self = npu_utils::format_contiguous(self);
-        bernoulli_npu_nocheck(contiguous_self, p, gen);
-        npu_utils::format_fresh_view(self, contiguous_self);
-    } else {
-        bernoulli_npu_nocheck(self, p, gen);
-    }
-    return self;
+at::Tensor& bernoulli_(
+    at::Tensor& self,
+    double p,
+    c10::optional<at::Generator> gen) {
+  if (!self.is_contiguous()) {
+    at::Tensor contiguous_self = npu_utils::format_contiguous(self);
+    bernoulli_npu_nocheck(contiguous_self, p, gen);
+    npu_utils::format_fresh_view(self, contiguous_self);
+  } else {
+    bernoulli_npu_nocheck(self, p, gen);
+  }
+  return self;
 }
 
-at::Tensor &bernoulli_(at::Tensor &self, const at::Tensor &p, c10::optional<at::Generator> gen) {
-    at::Tensor p_ori_format = npu_preparation::CastBackToOriFormat(p);
-    npu_preparation::CheckMemory({self, p}, {self});
+at::Tensor& bernoulli_(
+    at::Tensor& self,
+    const at::Tensor& p,
+    c10::optional<at::Generator> gen) {
+  at::Tensor p_ori_format = npu_preparation::CastBackToOriFormat(p);
+  npu_preparation::CheckMemory({self, p}, {self});
 
-    if (!self.is_contiguous()) {
-        at::Tensor contiguous_self = npu_utils::format_contiguous(self);
-        bernoulli_npu_nocheck(contiguous_self, p_ori_format, gen);
-        npu_utils::format_fresh_view(self, contiguous_self);
-    } else {
-        bernoulli_npu_nocheck(self, p_ori_format, gen);
-    }
-    return self;
+  if (!self.is_contiguous()) {
+    at::Tensor contiguous_self = npu_utils::format_contiguous(self);
+    bernoulli_npu_nocheck(contiguous_self, p_ori_format, gen);
+    npu_utils::format_fresh_view(self, contiguous_self);
+  } else {
+    bernoulli_npu_nocheck(self, p_ori_format, gen);
+  }
+  return self;
 }
 
-at::Tensor bernoulli(const at::Tensor &self, c10::optional<at::Generator> gen) {
-    at::Tensor result = npu_preparation::apply_tensor_with_format(self.sizes(), self.options(), ACL_FORMAT_ND);
-    bernoulli_npu_nocheck(result, self, gen);
-    return result;
+at::Tensor bernoulli(const at::Tensor& self, c10::optional<at::Generator> gen) {
+  at::Tensor result = npu_preparation::apply_tensor_with_format(
+      self.sizes(), self.options(), ACL_FORMAT_ND);
+  bernoulli_npu_nocheck(result, self, gen);
+  return result;
 }
 
-at::Tensor bernoulli(const at::Tensor &self, double p, c10::optional<at::Generator> gen) {
-    return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(p, gen);
+at::Tensor bernoulli(
+    const at::Tensor& self,
+    double p,
+    c10::optional<at::Generator> gen) {
+  return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT)
+      .bernoulli_(p, gen);
 }
 
-at::Tensor &bernoulli_out(const at::Tensor &self, c10::optional<at::Generator> gen, at::Tensor &result) {
-    result.resize_(self.sizes()).bernoulli_(self, gen);
-    at::namedinference::propagate_names(result, self);
-    return result;
+at::Tensor& bernoulli_out(
+    const at::Tensor& self,
+    c10::optional<at::Generator> gen,
+    at::Tensor& result) {
+  result.resize_(self.sizes()).bernoulli_(self, gen);
+  at::namedinference::propagate_names(result, self);
+  return result;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/BmmV2KernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/BmmV2KernelNpu.cpp
@@ -23,286 +23,329 @@ using npu_utils = at_npu::native::NpuUtils;
 namespace {
 static const int64_t TENSORS_DIMS_LOWER_LIMIT = 2;
 static const int64_t PENULT_DIM = -2;
-bool is_transpose_last_two_dims_v2(const at::Tensor &Tensors)
-{
-    if (Tensors.dim() < TENSORS_DIMS_LOWER_LIMIT) {
-        return false;
-    }
-    int64_t numel = at_npu::native::NPUNativeFunctions::get_storage_size(Tensors);
+bool is_transpose_last_two_dims_v2(const at::Tensor& Tensors) {
+  if (Tensors.dim() < TENSORS_DIMS_LOWER_LIMIT) {
+    return false;
+  }
+  int64_t numel = at_npu::native::NPUNativeFunctions::get_storage_size(Tensors);
 
-    int64_t dim1 = Tensors.dim() - 1;
-    int64_t dim2 = Tensors.dim() - TENSORS_DIMS_LOWER_LIMIT;
-    TORCH_CHECK(Tensors.element_size() > 0,
-                "expected Tensors valid, "
-                "but input Tensors has element_size ",
-                Tensors.element_size(),
-                OPS_ERROR(ErrCode::PARAM));
-    int64_t tensor_size = static_cast<int64_t>(Tensors.storage().nbytes()) / Tensors.element_size();
-    auto tensor_desc = torch_backend::NPUBridge::GetNpuStorageImpl(Tensors)->get_npu_desc();
-    if (tensor_desc.base_sizes_.size() == static_cast<uint64_t>(Tensors.dim()) && Tensors.stride(dim2) == 1 &&
-        Tensors.stride(dim1) == Tensors.size(dim2) && Tensors.size(dim1) == tensor_desc.base_sizes_[dim2] &&
-        Tensors.size(dim2) == tensor_desc.base_sizes_[dim1] && tensor_size == numel) {
-        return true;
+  int64_t dim1 = Tensors.dim() - 1;
+  int64_t dim2 = Tensors.dim() - TENSORS_DIMS_LOWER_LIMIT;
+  TORCH_CHECK(
+      Tensors.element_size() > 0,
+      "expected Tensors valid, "
+      "but input Tensors has element_size ",
+      Tensors.element_size(),
+      OPS_ERROR(ErrCode::PARAM));
+  int64_t tensor_size =
+      static_cast<int64_t>(Tensors.storage().nbytes()) / Tensors.element_size();
+  auto tensor_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(Tensors)->get_npu_desc();
+  if (tensor_desc.base_sizes_.size() == static_cast<uint64_t>(Tensors.dim()) &&
+      Tensors.stride(dim2) == 1 && Tensors.stride(dim1) == Tensors.size(dim2) &&
+      Tensors.size(dim1) == tensor_desc.base_sizes_[dim2] &&
+      Tensors.size(dim2) == tensor_desc.base_sizes_[dim1] &&
+      tensor_size == numel) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+c10::SmallVector<int64_t, SIZE> bmm_v2_output_size(
+    const at::Tensor& mat1,
+    const at::Tensor& mat2) {
+  auto dim_tensor1 = mat1.dim();
+  auto dim_tensor2 = mat2.dim();
+
+  int64_t m = dim_tensor1 == 1 ? 1 : mat1.size(PENULT_DIM);
+  int64_t n = dim_tensor2 == 1 ? 1 : mat2.size(-1);
+
+  auto batch_a = op_infer::array_to_small_vector(at::IntArrayRef(
+      mat1.sizes().data(), std::max<int64_t>(dim_tensor1 + PENULT_DIM, 0)));
+  auto batch_b = op_infer::array_to_small_vector(at::IntArrayRef(
+      mat2.sizes().data(), std::max<int64_t>(dim_tensor2 + PENULT_DIM, 0)));
+
+  batch_a.insert(
+      batch_a.begin(),
+      std::max<int64_t>(batch_a.size(), batch_b.size()) - batch_a.size(),
+      1);
+  batch_b.insert(
+      batch_b.begin(),
+      std::max<int64_t>(batch_a.size(), batch_b.size()) - batch_b.size(),
+      1);
+
+  c10::SmallVector<int64_t, SIZE> output_size;
+  for (size_t i = 0; i < batch_a.size(); ++i) {
+    if (batch_a[i] == 1) {
+      output_size.emplace_back(batch_b[i]);
+    } else if (batch_b[i] == 1) {
+      output_size.emplace_back(batch_a[i]);
+    } else if (batch_a[i] != batch_b[i]) {
+      AT_ERROR(
+          "mat1 and mat2 cannot broadcast, but they are mat1 ",
+          mat1.sizes().data(),
+          " mat2 ",
+          mat2.sizes().data());
     } else {
-        return false;
+      output_size.emplace_back(batch_a[i]);
     }
+  }
+  output_size.emplace_back(m);
+  output_size.emplace_back(n);
+
+  return output_size;
 }
 
-c10::SmallVector<int64_t, SIZE> bmm_v2_output_size(const at::Tensor &mat1, const at::Tensor &mat2)
-{
-    auto dim_tensor1 = mat1.dim();
-    auto dim_tensor2 = mat2.dim();
+at::Tensor pure_bmm_v2(
+    const at::Tensor& self,
+    const at::Tensor& mat2,
+    const c10::SmallVector<int64_t, SIZE>& output_size) {
+  auto tensor1 = self.dim() == 1 ? self.view({1, self.size(0)}) : self;
+  auto tensor2 = mat2.dim() == 1 ? mat2.view({mat2.size(0), 1}) : mat2;
 
-    int64_t m = dim_tensor1 == 1 ? 1 : mat1.size(PENULT_DIM);
-    int64_t n = dim_tensor2 == 1 ? 1 : mat2.size(-1);
+  at::Tensor result = (tensor1.scalar_type() == at::ScalarType::Half)
+      ? npu_preparation::apply_tensor_with_format(
+            output_size, tensor1.options(), ACL_FORMAT_FRACTAL_NZ, true)
+      : npu_preparation::apply_tensor_with_format(
+            output_size, tensor1.options(), ACL_FORMAT_ND);
 
-    auto batch_a = op_infer::array_to_small_vector(
-        at::IntArrayRef(mat1.sizes().data(), std::max<int64_t>(dim_tensor1 + PENULT_DIM, 0)));
-    auto batch_b = op_infer::array_to_small_vector(
-        at::IntArrayRef(mat2.sizes().data(), std::max<int64_t>(dim_tensor2 + PENULT_DIM, 0)));
+  at::Tensor contiguous_self = tensor1;
+  at::Tensor contiguous_mat2 = tensor2;
+  bool is_self_t = is_transpose_last_two_dims_v2(tensor1);
+  bool is_mat2_t = is_transpose_last_two_dims_v2(tensor2);
 
-    batch_a.insert(batch_a.begin(), std::max<int64_t>(batch_a.size(), batch_b.size()) - batch_a.size(), 1);
-    batch_b.insert(batch_b.begin(), std::max<int64_t>(batch_a.size(), batch_b.size()) - batch_b.size(), 1);
+  if (!is_self_t) {
+    contiguous_self = npu_utils::format_contiguous(tensor1);
+  }
+  if (!is_mat2_t) {
+    contiguous_mat2 = npu_utils::format_contiguous(tensor2);
+  }
 
-    c10::SmallVector<int64_t, SIZE> output_size;
-    for (size_t i = 0; i < batch_a.size(); ++i) {
-        if (batch_a[i] == 1) {
-            output_size.emplace_back(batch_b[i]);
-        } else if (batch_b[i] == 1) {
-            output_size.emplace_back(batch_a[i]);
-        } else if (batch_a[i] != batch_b[i]) {
-            AT_ERROR("mat1 and mat2 cannot broadcast, but they are mat1 ", mat1.sizes().data(), " mat2 ",
-                     mat2.sizes().data());
-        } else {
-            output_size.emplace_back(batch_a[i]);
-        }
-    }
-    output_size.emplace_back(m);
-    output_size.emplace_back(n);
+  at_npu::native::OpCommand cmd;
+  cmd.Name("BatchMatMul")
+      .InputWithoutContiguous(contiguous_self)
+      .InputWithoutContiguous(contiguous_mat2)
+      .Output(result)
+      .Attr("adj_x1", is_self_t)
+      .Attr("adj_x2", is_mat2_t)
+      .Run();
 
-    return output_size;
+  return result;
 }
 
-at::Tensor pure_bmm_v2(const at::Tensor &self, const at::Tensor &mat2,
-                       const c10::SmallVector<int64_t, SIZE> &output_size)
-{
-    auto tensor1 = self.dim() == 1 ? self.view({1, self.size(0)}) : self;
-    auto tensor2 = mat2.dim() == 1 ? mat2.view({mat2.size(0), 1}) : mat2;
+at::Tensor reshape_tensor_self(
+    const at::Tensor& self,
+    c10::SmallVector<int64_t, SIZE>& expect_output_size) {
+  // self, expect_output: [5,6,7,17], [1,6,7,65]
+  // self permute + reshape: [5,6,7,17] -> [6,7,5,17] -> [6,7,85]
+  c10::SmallVector<int64_t, SIZE> self_permute_idx;
+  c10::SmallVector<int64_t, SIZE> self_batch_idx;
 
-    at::Tensor result =
-        (tensor1.scalar_type() == at::ScalarType::Half) ?
-            npu_preparation::apply_tensor_with_format(output_size, tensor1.options(), ACL_FORMAT_FRACTAL_NZ, true) :
-            npu_preparation::apply_tensor_with_format(output_size, tensor1.options(), ACL_FORMAT_ND);
-
-    at::Tensor contiguous_self = tensor1;
-    at::Tensor contiguous_mat2 = tensor2;
-    bool is_self_t = is_transpose_last_two_dims_v2(tensor1);
-    bool is_mat2_t = is_transpose_last_two_dims_v2(tensor2);
-
-    if (!is_self_t) {
-        contiguous_self = npu_utils::format_contiguous(tensor1);
+  for (int64_t i = 0; i < self.dim(); ++i) {
+    if (i < self.dim() - 2) {
+      if (expect_output_size[i] == 1) {
+        self_batch_idx.emplace_back(i);
+        continue;
+      }
+    } else if (i == self.dim() - 1) {
+      for (uint64_t j = 0; j < self_batch_idx.size(); ++j) {
+        self_permute_idx.emplace_back(self_batch_idx[j]);
+      }
     }
-    if (!is_mat2_t) {
-        contiguous_mat2 = npu_utils::format_contiguous(tensor2);
-    }
+    self_permute_idx.emplace_back(i);
+  }
+  at::Tensor tmp_self = self.permute(self_permute_idx);
 
-    at_npu::native::OpCommand cmd;
-    cmd.Name("BatchMatMul")
-        .InputWithoutContiguous(contiguous_self)
-        .InputWithoutContiguous(contiguous_mat2)
-        .Output(result)
-        .Attr("adj_x1", is_self_t)
-        .Attr("adj_x2", is_mat2_t)
-        .Run();
+  int64_t m_idx = 0;
+  c10::SmallVector<int64_t, SIZE> tmp_self_size;
+  c10::SmallVector<int64_t, SIZE> tmp_self_size_low;
 
-    return result;
+  m_idx = self.dim() - static_cast<int64_t>(self_batch_idx.size()) - 1;
+  tmp_self_size = op_infer::array_to_small_vector(tmp_self.sizes());
+  tmp_self_size_low.insert(
+      tmp_self_size_low.end(),
+      tmp_self_size.begin(),
+      tmp_self_size.begin() + m_idx);
+  tmp_self_size_low.emplace_back(-1);
+  tmp_self = tmp_self.reshape(tmp_self_size_low);
+  return tmp_self;
 }
 
-at::Tensor reshape_tensor_self(const at::Tensor &self, c10::SmallVector<int64_t, SIZE> &expect_output_size)
-{
-    // self, expect_output: [5,6,7,17], [1,6,7,65]
-    // self permute + reshape: [5,6,7,17] -> [6,7,5,17] -> [6,7,85]
-    c10::SmallVector<int64_t, SIZE> self_permute_idx;
-    c10::SmallVector<int64_t, SIZE> self_batch_idx;
+at::Tensor reshape_tensor_mat2(
+    const at::Tensor& mat2,
+    c10::SmallVector<int64_t, SIZE>& expect_output_size) {
+  // mat2, expect_output_size: [5,6,17,65], [1,6,7,65]
+  // mat2 permute + reshape: [5,6,17,65] -> [6,5,17,65] -> [6,85,65]
+  c10::SmallVector<int64_t, SIZE> mat2_permute_idx;
+  c10::SmallVector<int64_t, SIZE> mat2_batch_idx;
 
-    for (int64_t i = 0; i < self.dim(); ++i) {
-        if (i < self.dim() - 2) {
-            if (expect_output_size[i] == 1) {
-                self_batch_idx.emplace_back(i);
-                continue;
-            }
-        } else if (i == self.dim() - 1) {
-            for (uint64_t j = 0; j < self_batch_idx.size(); ++j) {
-                self_permute_idx.emplace_back(self_batch_idx[j]);
-            }
-        }
-        self_permute_idx.emplace_back(i);
+  for (int64_t i = 0; i < mat2.dim(); ++i) {
+    if (i < mat2.dim() - 2) {
+      if (expect_output_size[i] == 1) {
+        mat2_batch_idx.emplace_back(i);
+        continue;
+      }
+    } else if (i == mat2.dim() - 2) {
+      for (uint64_t j = 0; j < mat2_batch_idx.size(); ++j) {
+        mat2_permute_idx.emplace_back(mat2_batch_idx[j]);
+      }
     }
-    at::Tensor tmp_self = self.permute(self_permute_idx);
+    mat2_permute_idx.emplace_back(i);
+  }
+  at::Tensor tmp_mat2 = mat2.permute(mat2_permute_idx);
 
-    int64_t m_idx = 0;
-    c10::SmallVector<int64_t, SIZE> tmp_self_size;
-    c10::SmallVector<int64_t, SIZE> tmp_self_size_low;
+  int64_t k_idx = 0;
+  c10::SmallVector<int64_t, SIZE> tmp_mat2_size;
+  c10::SmallVector<int64_t, SIZE> tmp_mat2_size_low;
 
-    m_idx = self.dim() - static_cast<int64_t>(self_batch_idx.size()) - 1;
-    tmp_self_size = op_infer::array_to_small_vector(tmp_self.sizes());
-    tmp_self_size_low.insert(tmp_self_size_low.end(), tmp_self_size.begin(), tmp_self_size.begin() + m_idx);
-    tmp_self_size_low.emplace_back(-1);
-    tmp_self = tmp_self.reshape(tmp_self_size_low);
-    return tmp_self;
+  k_idx = mat2.dim() - static_cast<int64_t>(mat2_batch_idx.size()) - 2;
+  tmp_mat2_size = op_infer::array_to_small_vector(tmp_mat2.sizes());
+  tmp_mat2_size_low.insert(
+      tmp_mat2_size_low.end(),
+      tmp_mat2_size.begin(),
+      tmp_mat2_size.begin() + k_idx);
+  tmp_mat2_size_low.insert(tmp_mat2_size_low.end(), {-1, mat2.size(-1)});
+  tmp_mat2 = tmp_mat2.reshape(tmp_mat2_size_low);
+  return tmp_mat2;
 }
 
-at::Tensor reshape_tensor_mat2(const at::Tensor &mat2, c10::SmallVector<int64_t, SIZE> &expect_output_size)
-{
-    // mat2, expect_output_size: [5,6,17,65], [1,6,7,65]
-    // mat2 permute + reshape: [5,6,17,65] -> [6,5,17,65] -> [6,85,65]
-    c10::SmallVector<int64_t, SIZE> mat2_permute_idx;
-    c10::SmallVector<int64_t, SIZE> mat2_batch_idx;
-
-    for (int64_t i = 0; i < mat2.dim(); ++i) {
-        if (i < mat2.dim() - 2) {
-            if (expect_output_size[i] == 1) {
-                mat2_batch_idx.emplace_back(i);
-                continue;
-            }
-        } else if (i == mat2.dim() - 2) {
-            for (uint64_t j = 0; j < mat2_batch_idx.size(); ++j) {
-                mat2_permute_idx.emplace_back(mat2_batch_idx[j]);
-            }
-        }
-        mat2_permute_idx.emplace_back(i);
-    }
-    at::Tensor tmp_mat2 = mat2.permute(mat2_permute_idx);
-
-    int64_t k_idx = 0;
-    c10::SmallVector<int64_t, SIZE> tmp_mat2_size;
-    c10::SmallVector<int64_t, SIZE> tmp_mat2_size_low;
-
-    k_idx = mat2.dim() - static_cast<int64_t>(mat2_batch_idx.size()) - 2;
-    tmp_mat2_size = op_infer::array_to_small_vector(tmp_mat2.sizes());
-    tmp_mat2_size_low.insert(tmp_mat2_size_low.end(), tmp_mat2_size.begin(), tmp_mat2_size.begin() + k_idx);
-    tmp_mat2_size_low.insert(tmp_mat2_size_low.end(), {-1, mat2.size(-1)});
-    tmp_mat2 = tmp_mat2.reshape(tmp_mat2_size_low);
-    return tmp_mat2;
+c10::SmallVector<int64_t, SIZE> align_small_vector(
+    c10::SmallVector<int64_t, SIZE> svec,
+    c10::SmallVector<int64_t, SIZE> golden_svec) {
+  // svec, golden: [6,7,65], [5,6,7,65]
+  // expect: [6,7,65] -> [1,6,7,65]
+  c10::SmallVector<int64_t, SIZE> tmp_svec;
+  tmp_svec = svec;
+  int64_t size_to_fill = static_cast<int64_t>(golden_svec.size() - svec.size());
+  if (size_to_fill > 0) {
+    tmp_svec.insert(tmp_svec.begin(), size_to_fill, 1);
+  }
+  return tmp_svec;
 }
 
-c10::SmallVector<int64_t, SIZE> align_small_vector(c10::SmallVector<int64_t, SIZE> svec,
-                                                   c10::SmallVector<int64_t, SIZE> golden_svec)
-{
-    // svec, golden: [6,7,65], [5,6,7,65]
-    // expect: [6,7,65] -> [1,6,7,65]
-    c10::SmallVector<int64_t, SIZE> tmp_svec;
-    tmp_svec = svec;
-    int64_t size_to_fill = static_cast<int64_t>(golden_svec.size() - svec.size());
-    if (size_to_fill > 0) {
-        tmp_svec.insert(tmp_svec.begin(), size_to_fill, 1);
-    }
-    return tmp_svec;
+void expand_tensor(
+    at::Tensor& self,
+    at::Tensor& mat2,
+    c10::SmallVector<int64_t, SIZE>& expand_output_size) {
+  self = self.dim() == 1 ? self.view({1, self.size(0)}) : self;
+  mat2 = mat2.dim() == 1 ? mat2.view({mat2.size(0), 1}) : mat2;
+  int64_t m = self.size(PENULT_DIM);
+  int64_t k1 = self.size(-1);
+  int64_t k2 = mat2.size(PENULT_DIM);
+  int64_t n = mat2.size(-1);
+
+  std::vector<int64_t> expand_batch_portion(
+      expand_output_size.begin(), expand_output_size.end() - 2);
+  std::vector<int64_t> self_expand_size(expand_batch_portion);
+  std::vector<int64_t> mat2_expand_size(expand_batch_portion);
+
+  self_expand_size.insert(self_expand_size.end(), {m, k1});
+  mat2_expand_size.insert(mat2_expand_size.end(), {k2, n});
+
+  int64_t expand_batch_product = std::accumulate(
+      expand_batch_portion.begin(),
+      expand_batch_portion.end(),
+      1L,
+      std::multiplies<int64_t>());
+
+  std::vector<int64_t> self_bmm_view({expand_batch_product});
+  std::vector<int64_t> mat2_bmm_view({expand_batch_product});
+  self_bmm_view.insert(self_bmm_view.end(), {m, k1});
+  mat2_bmm_view.insert(mat2_bmm_view.end(), {k2, n});
+
+  self = self.expand(self_expand_size).reshape(self_bmm_view);
+  mat2 = mat2.expand(mat2_expand_size).reshape(mat2_bmm_view);
 }
 
-void expand_tensor(at::Tensor &self, at::Tensor &mat2, c10::SmallVector<int64_t, SIZE> &expand_output_size)
-{
-    self = self.dim() == 1 ? self.view({1, self.size(0)}) : self;
-    mat2 = mat2.dim() == 1 ? mat2.view({mat2.size(0), 1}) : mat2;
-    int64_t m = self.size(PENULT_DIM);
-    int64_t k1 = self.size(-1);
-    int64_t k2 = mat2.size(PENULT_DIM);
-    int64_t n = mat2.size(-1);
+at::Tensor npu_bmmV2_impl(
+    const at::Tensor& self,
+    const at::Tensor& mat2,
+    at::IntArrayRef output_sizes) {
+  auto expect_output_size = op_infer::array_to_small_vector(output_sizes);
+  auto infer_output_size = bmm_v2_output_size(self, mat2);
+  at::Tensor tmp_self = self;
+  at::Tensor tmp_mat2 = mat2;
 
-    std::vector<int64_t> expand_batch_portion(expand_output_size.begin(), expand_output_size.end() - 2);
-    std::vector<int64_t> self_expand_size(expand_batch_portion);
-    std::vector<int64_t> mat2_expand_size(expand_batch_portion);
-
-    self_expand_size.insert(self_expand_size.end(), {m, k1});
-    mat2_expand_size.insert(mat2_expand_size.end(), {k2, n});
-
-    int64_t expand_batch_product =
-        std::accumulate(expand_batch_portion.begin(), expand_batch_portion.end(), 1L, std::multiplies<int64_t>());
-
-    std::vector<int64_t> self_bmm_view({expand_batch_product});
-    std::vector<int64_t> mat2_bmm_view({expand_batch_product});
-    self_bmm_view.insert(self_bmm_view.end(), {m, k1});
-    mat2_bmm_view.insert(mat2_bmm_view.end(), {k2, n});
-
-    self = self.expand(self_expand_size).reshape(self_bmm_view);
-    mat2 = mat2.expand(mat2_expand_size).reshape(mat2_bmm_view);
-}
-
-at::Tensor npu_bmmV2_impl(const at::Tensor &self, const at::Tensor &mat2, at::IntArrayRef output_sizes)
-{
-    auto expect_output_size = op_infer::array_to_small_vector(output_sizes);
-    auto infer_output_size = bmm_v2_output_size(self, mat2);
-    at::Tensor tmp_self = self;
-    at::Tensor tmp_mat2 = mat2;
-
-    // forward propagation
-    if (expect_output_size.empty()) {
-        // special issure for dim n*n
-        if (tmp_self.dim() == tmp_mat2.dim()) {
-            return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size);
-        }
-        // avoid some accuracy error caused by transdata
-        expand_tensor(tmp_self, tmp_mat2, infer_output_size);
-        expect_output_size = infer_output_size;
-        infer_output_size = bmm_v2_output_size(tmp_self, tmp_mat2);
-
-        auto res = pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size).view(expect_output_size);
-        infer_output_size = expect_output_size;
-
-        if (self.dim() == 1) {
-            // [k][b, k, n] -> [b, 1, n] -> [b, n]
-            infer_output_size.erase(infer_output_size.end() - 2);
-            return res.view(infer_output_size);
-        } else if (mat2.dim() == 1) {
-            // [b, m, k][k] -> [b, m, 1] -> [b, m]
-            infer_output_size.erase(infer_output_size.end() - 1);
-            return res.view(infer_output_size);
-        }
-        return res;
+  // forward propagation
+  if (expect_output_size.empty()) {
+    // special issure for dim n*n
+    if (tmp_self.dim() == tmp_mat2.dim()) {
+      return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size);
     }
-
-    c10::SmallVector<int64_t, SIZE> axis_reduce;
-    c10::SmallVector<int64_t, SIZE> tmp_self_size;
-    c10::SmallVector<int64_t, SIZE> tmp_mat2_size;
-
-    c10::SmallVector<int64_t, SIZE> tmp_expect_output_size = align_small_vector(expect_output_size, infer_output_size);
-    for (int i = 0; i < static_cast<int64_t>(tmp_expect_output_size.size()); ++i) {
-        if (tmp_expect_output_size[i] != infer_output_size[i]) {
-            axis_reduce.emplace_back(i);
-        }
-    }
-
-    // no reduce_sum
-    if (axis_reduce.empty()) {
-        // special issure for dim n*n
-        if (tmp_self.dim() == tmp_mat2.dim()) {
-            return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size);
-        }
-        // avoid some accuracy error caused by transdata
-        expand_tensor(tmp_self, tmp_mat2, infer_output_size);
-        infer_output_size = bmm_v2_output_size(tmp_self, tmp_mat2);
-        return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size).view(expect_output_size);
-    }
-
-    // reduce sum without accuracy error
-    tmp_self_size = align_small_vector(op_infer::array_to_small_vector(self.sizes()), infer_output_size);
-    tmp_mat2_size = align_small_vector(op_infer::array_to_small_vector(mat2.sizes()), infer_output_size);
-    tmp_self = self.reshape(tmp_self_size);
-    tmp_mat2 = mat2.reshape(tmp_mat2_size);
-    tmp_self = reshape_tensor_self(tmp_self, tmp_expect_output_size);
-    tmp_mat2 = reshape_tensor_mat2(tmp_mat2, tmp_expect_output_size);
+    // avoid some accuracy error caused by transdata
+    expand_tensor(tmp_self, tmp_mat2, infer_output_size);
+    expect_output_size = infer_output_size;
     infer_output_size = bmm_v2_output_size(tmp_self, tmp_mat2);
+
+    auto res = pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size)
+                   .view(expect_output_size);
+    infer_output_size = expect_output_size;
+
+    if (self.dim() == 1) {
+      // [k][b, k, n] -> [b, 1, n] -> [b, n]
+      infer_output_size.erase(infer_output_size.end() - 2);
+      return res.view(infer_output_size);
+    } else if (mat2.dim() == 1) {
+      // [b, m, k][k] -> [b, m, 1] -> [b, m]
+      infer_output_size.erase(infer_output_size.end() - 1);
+      return res.view(infer_output_size);
+    }
+    return res;
+  }
+
+  c10::SmallVector<int64_t, SIZE> axis_reduce;
+  c10::SmallVector<int64_t, SIZE> tmp_self_size;
+  c10::SmallVector<int64_t, SIZE> tmp_mat2_size;
+
+  c10::SmallVector<int64_t, SIZE> tmp_expect_output_size =
+      align_small_vector(expect_output_size, infer_output_size);
+  for (int i = 0; i < static_cast<int64_t>(tmp_expect_output_size.size());
+       ++i) {
+    if (tmp_expect_output_size[i] != infer_output_size[i]) {
+      axis_reduce.emplace_back(i);
+    }
+  }
+
+  // no reduce_sum
+  if (axis_reduce.empty()) {
+    // special issure for dim n*n
+    if (tmp_self.dim() == tmp_mat2.dim()) {
+      return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size);
+    }
     // avoid some accuracy error caused by transdata
     expand_tensor(tmp_self, tmp_mat2, infer_output_size);
     infer_output_size = bmm_v2_output_size(tmp_self, tmp_mat2);
-    return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size).view(expect_output_size);
+    return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size)
+        .view(expect_output_size);
+  }
+
+  // reduce sum without accuracy error
+  tmp_self_size = align_small_vector(
+      op_infer::array_to_small_vector(self.sizes()), infer_output_size);
+  tmp_mat2_size = align_small_vector(
+      op_infer::array_to_small_vector(mat2.sizes()), infer_output_size);
+  tmp_self = self.reshape(tmp_self_size);
+  tmp_mat2 = mat2.reshape(tmp_mat2_size);
+  tmp_self = reshape_tensor_self(tmp_self, tmp_expect_output_size);
+  tmp_mat2 = reshape_tensor_mat2(tmp_mat2, tmp_expect_output_size);
+  infer_output_size = bmm_v2_output_size(tmp_self, tmp_mat2);
+  // avoid some accuracy error caused by transdata
+  expand_tensor(tmp_self, tmp_mat2, infer_output_size);
+  infer_output_size = bmm_v2_output_size(tmp_self, tmp_mat2);
+  return pure_bmm_v2(tmp_self, tmp_mat2, infer_output_size)
+      .view(expect_output_size);
 }
 } // namespace
 
-at::Tensor npu_bmmV2(const at::Tensor &self, const at::Tensor &mat2, at::IntArrayRef output_sizes)
-{
-    TORCH_CHECK(self.scalar_type() != at::ScalarType::Char && mat2.scalar_type() != at::ScalarType::Char,
-                "bmm is not support int8 dtype" + OPS_ERROR(ErrCode::TYPE));
-    return npu_bmmV2_impl(self, mat2, output_sizes);
+at::Tensor npu_bmmV2(
+    const at::Tensor& self,
+    const at::Tensor& mat2,
+    at::IntArrayRef output_sizes) {
+  TORCH_CHECK(
+      self.scalar_type() != at::ScalarType::Char &&
+          mat2.scalar_type() != at::ScalarType::Char,
+      "bmm is not support int8 dtype" + OPS_ERROR(ErrCode::TYPE));
+  return npu_bmmV2_impl(self, mat2, output_sizes);
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/DeformableConv2dKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/DeformableConv2dKernelNpu.cpp
@@ -20,218 +20,323 @@ namespace acl_op {
 using npu_preparation = at_npu::native::OpPreparation;
 
 namespace {
-std::tuple<at::Tensor, at::Tensor> deformable_conv2d_nocheck(const at::Tensor &input, const at::Tensor &weight,
-                                                             const at::Tensor &offset,
-                                                             const c10::optional<at::Tensor> &bias_opt,
-                                                             at::IntArrayRef kernel_size, at::IntArrayRef stride,
-                                                             at::IntArrayRef padding, at::IntArrayRef dilation,
-                                                             int64_t groups, int64_t deformable_groups, bool modulated)
-{
-    TORCH_CHECK(input.dim() >= 4, "input has to be more than 4D, but got Tensor of dimension ", input.dim(),
-        OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(offset.dim() >= 4, "offset has to more than 4D, but got Tensor of dimension ", offset.dim(),
-        OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(stride.size() >= 4, "stride has to contain more than 4 elements, but got ", stride.size(),
-        OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(dilation.size() >= 4, "dilation has to contain more than 4 elements, but got ", dilation.size(),
-        OPS_ERROR(ErrCode::PARAM));
-    const at::Tensor &bias = c10::value_or_else(bias_opt, [] { return at::Tensor(); });
-    at::Tensor bias_fp32 = (bias.defined() && bias.dtype() != at::kFloat) ?
-                               at_npu::native::custom_ops::npu_dtype_cast(bias, at::kFloat) :
-                               bias;
-    auto output_size = op_infer::deformable_conv2d_npu_output_size(
-        input, weight, offset, bias, kernel_size, stride, padding, dilation, groups, deformable_groups, modulated);
-    TORCH_CHECK(output_size.size() >= 4,
-        "output_size has to contain more than 4 elements, but got Tensor of dimension ", output_size.size(),
-        OPS_ERROR(ErrCode::PARAM));
-    /*
-     * DeformableOffsets and DeformableOffsetsGrad only support NHWC and don't support binary.
-     * FE will insert Transpose before DeformableOffsets and DeformableOffsetsGrad.
-     * In order to allow Transpose into binary,
-     * Transpose is called explicitly in adapter.
-     */
-    c10::SmallVector<int64_t, SIZE> nhwc_deformable_offsets_output_shape = {output_size[0], output_size[2],
-                                                                            output_size[3], output_size[1]};
-    at::Tensor nhwc_deformable_offsets_output = npu_preparation::apply_tensor_with_format(
-        nhwc_deformable_offsets_output_shape, input.options(), ACL_FORMAT_NHWC);
-    c10::SmallVector<int64_t, SIZE> in_perm = {0, 2, 3, 1};
-    at::Tensor ori_input = npu_preparation::CastBackToOriFormat(input);
-    at::Tensor ori_offset = npu_preparation::CastBackToOriFormat(offset);
-    at::Tensor nhwc_input = acl_op::npu_transpose(ori_input, in_perm, true);
-    at::Tensor nhwc_offset = acl_op::npu_transpose(ori_offset, in_perm, true);
+std::tuple<at::Tensor, at::Tensor> deformable_conv2d_nocheck(
+    const at::Tensor& input,
+    const at::Tensor& weight,
+    const at::Tensor& offset,
+    const c10::optional<at::Tensor>& bias_opt,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups,
+    int64_t deformable_groups,
+    bool modulated) {
+  TORCH_CHECK(
+      input.dim() >= 4,
+      "input has to be more than 4D, but got Tensor of dimension ",
+      input.dim(),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      offset.dim() >= 4,
+      "offset has to more than 4D, but got Tensor of dimension ",
+      offset.dim(),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      stride.size() >= 4,
+      "stride has to contain more than 4 elements, but got ",
+      stride.size(),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      dilation.size() >= 4,
+      "dilation has to contain more than 4 elements, but got ",
+      dilation.size(),
+      OPS_ERROR(ErrCode::PARAM));
+  const at::Tensor& bias =
+      c10::value_or_else(bias_opt, [] { return at::Tensor(); });
+  at::Tensor bias_fp32 = (bias.defined() && bias.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(bias, at::kFloat)
+      : bias;
+  auto output_size = op_infer::deformable_conv2d_npu_output_size(
+      input,
+      weight,
+      offset,
+      bias,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      groups,
+      deformable_groups,
+      modulated);
+  TORCH_CHECK(
+      output_size.size() >= 4,
+      "output_size has to contain more than 4 elements, but got Tensor of dimension ",
+      output_size.size(),
+      OPS_ERROR(ErrCode::PARAM));
+  /*
+   * DeformableOffsets and DeformableOffsetsGrad only support NHWC and don't
+   * support binary. FE will insert Transpose before DeformableOffsets and
+   * DeformableOffsetsGrad. In order to allow Transpose into binary, Transpose
+   * is called explicitly in adapter.
+   */
+  c10::SmallVector<int64_t, SIZE> nhwc_deformable_offsets_output_shape = {
+      output_size[0], output_size[2], output_size[3], output_size[1]};
+  at::Tensor nhwc_deformable_offsets_output =
+      npu_preparation::apply_tensor_with_format(
+          nhwc_deformable_offsets_output_shape,
+          input.options(),
+          ACL_FORMAT_NHWC);
+  c10::SmallVector<int64_t, SIZE> in_perm = {0, 2, 3, 1};
+  at::Tensor ori_input = npu_preparation::CastBackToOriFormat(input);
+  at::Tensor ori_offset = npu_preparation::CastBackToOriFormat(offset);
+  at::Tensor nhwc_input = acl_op::npu_transpose(ori_input, in_perm, true);
+  at::Tensor nhwc_offset = acl_op::npu_transpose(ori_offset, in_perm, true);
 
-    auto &nhwc_input_desc = torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_input)->npu_desc_;
-    auto &nhwc_offset_desc = torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_offset)->npu_desc_;
+  auto& nhwc_input_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_input)->npu_desc_;
+  auto& nhwc_offset_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_offset)->npu_desc_;
 
-    nhwc_input_desc.npu_format_ = ACL_FORMAT_NHWC;
-    nhwc_input_desc.origin_format_ = ACL_FORMAT_NHWC;
-    nhwc_offset_desc.npu_format_ = ACL_FORMAT_NHWC;
-    nhwc_offset_desc.origin_format_ = ACL_FORMAT_NHWC;
+  nhwc_input_desc.npu_format_ = ACL_FORMAT_NHWC;
+  nhwc_input_desc.origin_format_ = ACL_FORMAT_NHWC;
+  nhwc_offset_desc.npu_format_ = ACL_FORMAT_NHWC;
+  nhwc_offset_desc.origin_format_ = ACL_FORMAT_NHWC;
 
-    c10::SmallVector<int64_t, SIZE> nhwc_strides = {stride[0], stride[2], stride[3], stride[1]};
-    c10::SmallVector<int64_t, SIZE> nhwc_dilations = {dilation[0], dilation[2], dilation[3], dilation[1]};
-    string data_format = "NHWC";
-    at_npu::native::OpCommand cmd;
-    cmd.Name("DeformableOffsets")
-        .Input(nhwc_input, "X")
-        .Input(nhwc_offset, "offsets")
-        .Output(nhwc_deformable_offsets_output, "y")
-        .Attr("ksize", kernel_size)
-        .Attr("strides", nhwc_strides)
-        .Attr("pads", padding)
-        .Attr("dilations", nhwc_dilations)
-        .Attr("deformable_groups", deformable_groups)
-        .Attr("data_format", data_format)
-        .Attr("modulated", modulated)
-        .Run();
+  c10::SmallVector<int64_t, SIZE> nhwc_strides = {
+      stride[0], stride[2], stride[3], stride[1]};
+  c10::SmallVector<int64_t, SIZE> nhwc_dilations = {
+      dilation[0], dilation[2], dilation[3], dilation[1]};
+  string data_format = "NHWC";
+  at_npu::native::OpCommand cmd;
+  cmd.Name("DeformableOffsets")
+      .Input(nhwc_input, "X")
+      .Input(nhwc_offset, "offsets")
+      .Output(nhwc_deformable_offsets_output, "y")
+      .Attr("ksize", kernel_size)
+      .Attr("strides", nhwc_strides)
+      .Attr("pads", padding)
+      .Attr("dilations", nhwc_dilations)
+      .Attr("deformable_groups", deformable_groups)
+      .Attr("data_format", data_format)
+      .Attr("modulated", modulated)
+      .Run();
 
-    c10::SmallVector<int64_t, SIZE> out_perm = {0, 3, 1, 2};
-    nhwc_input_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_input_desc.origin_format_ = ACL_FORMAT_NCHW;
-    nhwc_offset_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_offset_desc.origin_format_ = ACL_FORMAT_NCHW;
-    auto &nhwc_deformable_offsets_output_desc =
-        torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_deformable_offsets_output)->npu_desc_;
-    nhwc_deformable_offsets_output_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_deformable_offsets_output_desc.origin_format_ = ACL_FORMAT_NCHW;
-    at::Tensor deformable_offsets_output = acl_op::npu_transpose(nhwc_deformable_offsets_output, out_perm, true);
+  c10::SmallVector<int64_t, SIZE> out_perm = {0, 3, 1, 2};
+  nhwc_input_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_input_desc.origin_format_ = ACL_FORMAT_NCHW;
+  nhwc_offset_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_offset_desc.origin_format_ = ACL_FORMAT_NCHW;
+  auto& nhwc_deformable_offsets_output_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_deformable_offsets_output)
+          ->npu_desc_;
+  nhwc_deformable_offsets_output_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_deformable_offsets_output_desc.origin_format_ = ACL_FORMAT_NCHW;
+  at::Tensor deformable_offsets_output =
+      acl_op::npu_transpose(nhwc_deformable_offsets_output, out_perm, true);
 
-    c10::SmallVector<int64_t, SIZE> conv2d_stride = op_infer::array_to_small_vector(kernel_size);
-    c10::SmallVector<int64_t, SIZE> conv2d_padding = {0, 0, 0, 0};
-    c10::SmallVector<int64_t, SIZE> conv2d_dilation = {1, 1};
-    at::Tensor conv2d_output = acl_op::npu_conv2d(deformable_offsets_output, weight, bias_fp32, conv2d_stride,
-                                                  conv2d_padding, conv2d_dilation, groups);
+  c10::SmallVector<int64_t, SIZE> conv2d_stride =
+      op_infer::array_to_small_vector(kernel_size);
+  c10::SmallVector<int64_t, SIZE> conv2d_padding = {0, 0, 0, 0};
+  c10::SmallVector<int64_t, SIZE> conv2d_dilation = {1, 1};
+  at::Tensor conv2d_output = acl_op::npu_conv2d(
+      deformable_offsets_output,
+      weight,
+      bias_fp32,
+      conv2d_stride,
+      conv2d_padding,
+      conv2d_dilation,
+      groups);
 
-    return std::tie(conv2d_output, deformable_offsets_output);
+  return std::tie(conv2d_output, deformable_offsets_output);
 }
 } // namespace
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_deformable_conv2dbk(
-    const at::Tensor &input_ori, const at::Tensor &grad_output_ori, const at::Tensor &offset_out_ori,
-    const at::Tensor &weight_ori, const at::Tensor &offset_ori, at::IntArrayRef kernel_size, at::IntArrayRef stride,
-    at::IntArrayRef padding, at::IntArrayRef dilation, int64_t groups, int64_t deformable_groups, bool modulated)
-{
-    TORCH_CHECK(input_ori.dim() >= 4, "input_ori has to be more than 4D, but got Tensor of dimension ",
-        input_ori.dim(), OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(offset_ori.dim() >= 4, "offset_ori has to more than 4D, but got Tensor of dimension ",
-        offset_ori.dim(), OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(stride.size() >= 4, "stride has to contain more than 4 elements, but got ", stride.size(),
-        OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(dilation.size() >= 4, "dilation has to contain more than 4 elements, but got ", dilation.size(),
-        OPS_ERROR(ErrCode::PARAM));
-    at::Tensor input = (input_ori.dtype() != at::kFloat) ?
-                           at_npu::native::custom_ops::npu_dtype_cast(input_ori, at::kFloat) :
-                           input_ori;
-    at::Tensor grad_output = (grad_output_ori.dtype() != at::kFloat) ?
-                                 at_npu::native::custom_ops::npu_dtype_cast(grad_output_ori, at::kFloat) :
-                                 grad_output_ori;
-    at::Tensor offset_out = (offset_out_ori.dtype() != at::kFloat) ?
-                                at_npu::native::custom_ops::npu_dtype_cast(offset_out_ori, at::kFloat) :
-                                offset_out_ori;
-    at::Tensor weight = (weight_ori.dtype() != at::kFloat) ?
-                            at_npu::native::custom_ops::npu_dtype_cast(weight_ori, at::kFloat) :
-                            weight_ori;
-    at::Tensor offset = (offset_ori.dtype() != at::kFloat) ?
-                            at_npu::native::custom_ops::npu_dtype_cast(offset_ori, at::kFloat) :
-                            offset_ori;
-    // deformable_conv2d_backward includes conv2d_backward and DeformableOffsetsGrad
-    c10::SmallVector<int64_t, SIZE> conv2d_stride = op_infer::array_to_small_vector(kernel_size);
-    c10::SmallVector<int64_t, SIZE> conv2d_padding = {0, 0, 0, 0};
-    c10::SmallVector<int64_t, SIZE> conv2d_dilation = {1, 1};
-    auto conv2d_backward_output = acl_op::npu_conv2d_backward(
-        offset_out, grad_output, weight, conv2d_stride, conv2d_padding, conv2d_dilation, groups, {true, true, true});
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+npu_deformable_conv2dbk(
+    const at::Tensor& input_ori,
+    const at::Tensor& grad_output_ori,
+    const at::Tensor& offset_out_ori,
+    const at::Tensor& weight_ori,
+    const at::Tensor& offset_ori,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups,
+    int64_t deformable_groups,
+    bool modulated) {
+  TORCH_CHECK(
+      input_ori.dim() >= 4,
+      "input_ori has to be more than 4D, but got Tensor of dimension ",
+      input_ori.dim(),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      offset_ori.dim() >= 4,
+      "offset_ori has to more than 4D, but got Tensor of dimension ",
+      offset_ori.dim(),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      stride.size() >= 4,
+      "stride has to contain more than 4 elements, but got ",
+      stride.size(),
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      dilation.size() >= 4,
+      "dilation has to contain more than 4 elements, but got ",
+      dilation.size(),
+      OPS_ERROR(ErrCode::PARAM));
+  at::Tensor input = (input_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(input_ori, at::kFloat)
+      : input_ori;
+  at::Tensor grad_output = (grad_output_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(grad_output_ori, at::kFloat)
+      : grad_output_ori;
+  at::Tensor offset_out = (offset_out_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(offset_out_ori, at::kFloat)
+      : offset_out_ori;
+  at::Tensor weight = (weight_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(weight_ori, at::kFloat)
+      : weight_ori;
+  at::Tensor offset = (offset_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(offset_ori, at::kFloat)
+      : offset_ori;
+  // deformable_conv2d_backward includes conv2d_backward and
+  // DeformableOffsetsGrad
+  c10::SmallVector<int64_t, SIZE> conv2d_stride =
+      op_infer::array_to_small_vector(kernel_size);
+  c10::SmallVector<int64_t, SIZE> conv2d_padding = {0, 0, 0, 0};
+  c10::SmallVector<int64_t, SIZE> conv2d_dilation = {1, 1};
+  auto conv2d_backward_output = acl_op::npu_conv2d_backward(
+      offset_out,
+      grad_output,
+      weight,
+      conv2d_stride,
+      conv2d_padding,
+      conv2d_dilation,
+      groups,
+      {true, true, true});
 
-    // DeformableOffsetsGrad's input 'grad' is the output[0] of conv2d_backward
-    at::Tensor deformable_offsets_backward_input = std::get<0>(conv2d_backward_output);
-    at::Tensor grad_weight = std::get<1>(conv2d_backward_output);
-    at::Tensor grad_bias = std::get<2>(conv2d_backward_output);
+  // DeformableOffsetsGrad's input 'grad' is the output[0] of conv2d_backward
+  at::Tensor deformable_offsets_backward_input =
+      std::get<0>(conv2d_backward_output);
+  at::Tensor grad_weight = std::get<1>(conv2d_backward_output);
+  at::Tensor grad_bias = std::get<2>(conv2d_backward_output);
 
-    c10::SmallVector<int64_t, SIZE> in_perm = {0, 2, 3, 1};
-    auto nhwc_grad_input_shape = op_infer::transpose_npu_output_size(input, in_perm);
-    auto nhwc_grad_offset_shape = op_infer::transpose_npu_output_size(offset, in_perm);
-    at::Tensor nhwc_grad_input =
-        npu_preparation::apply_tensor_with_format(input, nhwc_grad_input_shape, ACL_FORMAT_NHWC);
-    at::Tensor nhwc_grad_offset =
-        npu_preparation::apply_tensor_with_format(offset, nhwc_grad_offset_shape, ACL_FORMAT_NHWC);
+  c10::SmallVector<int64_t, SIZE> in_perm = {0, 2, 3, 1};
+  auto nhwc_grad_input_shape =
+      op_infer::transpose_npu_output_size(input, in_perm);
+  auto nhwc_grad_offset_shape =
+      op_infer::transpose_npu_output_size(offset, in_perm);
+  at::Tensor nhwc_grad_input = npu_preparation::apply_tensor_with_format(
+      input, nhwc_grad_input_shape, ACL_FORMAT_NHWC);
+  at::Tensor nhwc_grad_offset = npu_preparation::apply_tensor_with_format(
+      offset, nhwc_grad_offset_shape, ACL_FORMAT_NHWC);
 
-    auto trans_shape = op_infer::transpose_npu_output_size(deformable_offsets_backward_input, in_perm);
+  auto trans_shape = op_infer::transpose_npu_output_size(
+      deformable_offsets_backward_input, in_perm);
 
-    at::Tensor ori_deformable_offsets_backward_input =
-        npu_preparation::CastBackToOriFormat(deformable_offsets_backward_input);
-    at::Tensor ori_input = npu_preparation::CastBackToOriFormat(input);
-    at::Tensor ori_offset = npu_preparation::CastBackToOriFormat(offset);
+  at::Tensor ori_deformable_offsets_backward_input =
+      npu_preparation::CastBackToOriFormat(deformable_offsets_backward_input);
+  at::Tensor ori_input = npu_preparation::CastBackToOriFormat(input);
+  at::Tensor ori_offset = npu_preparation::CastBackToOriFormat(offset);
 
-    at::Tensor nhwc_deformable_offsets_backward_input =
-        acl_op::npu_transpose(ori_deformable_offsets_backward_input, in_perm, true);
-    at::Tensor nhwc_input = acl_op::npu_transpose(ori_input, in_perm, true);
-    at::Tensor nhwc_offset = acl_op::npu_transpose(ori_offset, in_perm, true);
+  at::Tensor nhwc_deformable_offsets_backward_input = acl_op::npu_transpose(
+      ori_deformable_offsets_backward_input, in_perm, true);
+  at::Tensor nhwc_input = acl_op::npu_transpose(ori_input, in_perm, true);
+  at::Tensor nhwc_offset = acl_op::npu_transpose(ori_offset, in_perm, true);
 
-    auto &nhwc_deformable_offsets_backward_input_desc =
-        torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_deformable_offsets_backward_input)->npu_desc_;
-    auto &nhwc_input_desc = torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_input)->npu_desc_;
-    auto &nhwc_offset_desc = torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_offset)->npu_desc_;
+  auto& nhwc_deformable_offsets_backward_input_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(
+          nhwc_deformable_offsets_backward_input)
+          ->npu_desc_;
+  auto& nhwc_input_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_input)->npu_desc_;
+  auto& nhwc_offset_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_offset)->npu_desc_;
 
-    nhwc_deformable_offsets_backward_input_desc.npu_format_ = ACL_FORMAT_NHWC;
-    nhwc_deformable_offsets_backward_input_desc.origin_format_ = ACL_FORMAT_NHWC;
-    nhwc_input_desc.npu_format_ = ACL_FORMAT_NHWC;
-    nhwc_input_desc.origin_format_ = ACL_FORMAT_NHWC;
-    nhwc_offset_desc.npu_format_ = ACL_FORMAT_NHWC;
-    nhwc_offset_desc.origin_format_ = ACL_FORMAT_NHWC;
+  nhwc_deformable_offsets_backward_input_desc.npu_format_ = ACL_FORMAT_NHWC;
+  nhwc_deformable_offsets_backward_input_desc.origin_format_ = ACL_FORMAT_NHWC;
+  nhwc_input_desc.npu_format_ = ACL_FORMAT_NHWC;
+  nhwc_input_desc.origin_format_ = ACL_FORMAT_NHWC;
+  nhwc_offset_desc.npu_format_ = ACL_FORMAT_NHWC;
+  nhwc_offset_desc.origin_format_ = ACL_FORMAT_NHWC;
 
-    c10::SmallVector<int64_t, SIZE> nhwc_strides = {stride[0], stride[2], stride[3], stride[1]};
-    c10::SmallVector<int64_t, SIZE> nhwc_dilations = {dilation[0], dilation[2], dilation[3], dilation[1]};
-    string data_format = "NHWC";
-    at_npu::native::OpCommand cmd;
-    cmd.Name("DeformableOffsetsGrad")
-        .Input(nhwc_deformable_offsets_backward_input, "grad")
-        .Input(nhwc_input, "X")
-        .Input(nhwc_offset, "offsets")
-        .Output(nhwc_grad_input, "grad_X")
-        .Output(nhwc_grad_offset, "grad_offsets")
-        .Attr("strides", nhwc_strides)
-        .Attr("pads", padding)
-        .Attr("ksize", kernel_size)
-        .Attr("dilations", nhwc_dilations)
-        .Attr("data_format", data_format)
-        .Attr("deformable_groups", deformable_groups)
-        .Attr("modulated", modulated)
-        .Run();
-    c10::SmallVector<int64_t, SIZE> out_perm = {0, 3, 1, 2};
-    nhwc_deformable_offsets_backward_input_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_deformable_offsets_backward_input_desc.origin_format_ = ACL_FORMAT_NCHW;
-    nhwc_input_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_input_desc.origin_format_ = ACL_FORMAT_NCHW;
-    nhwc_offset_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_offset_desc.origin_format_ = ACL_FORMAT_NCHW;
-    auto &nhwc_grad_input_desc = torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_grad_input)->npu_desc_;
-    auto &nhwc_grad_offset_desc = torch_backend::NPUBridge::GetNpuStorageImpl(nhwc_grad_offset)->npu_desc_;
-    nhwc_grad_input_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_grad_input_desc.origin_format_ = ACL_FORMAT_NCHW;
-    nhwc_grad_offset_desc.npu_format_ = ACL_FORMAT_NCHW;
-    nhwc_grad_offset_desc.origin_format_ = ACL_FORMAT_NCHW;
-    at::Tensor grad_input = acl_op::npu_transpose(nhwc_grad_input, out_perm, true);
-    at::Tensor grad_offset = acl_op::npu_transpose(nhwc_grad_offset, out_perm, true);
+  c10::SmallVector<int64_t, SIZE> nhwc_strides = {
+      stride[0], stride[2], stride[3], stride[1]};
+  c10::SmallVector<int64_t, SIZE> nhwc_dilations = {
+      dilation[0], dilation[2], dilation[3], dilation[1]};
+  string data_format = "NHWC";
+  at_npu::native::OpCommand cmd;
+  cmd.Name("DeformableOffsetsGrad")
+      .Input(nhwc_deformable_offsets_backward_input, "grad")
+      .Input(nhwc_input, "X")
+      .Input(nhwc_offset, "offsets")
+      .Output(nhwc_grad_input, "grad_X")
+      .Output(nhwc_grad_offset, "grad_offsets")
+      .Attr("strides", nhwc_strides)
+      .Attr("pads", padding)
+      .Attr("ksize", kernel_size)
+      .Attr("dilations", nhwc_dilations)
+      .Attr("data_format", data_format)
+      .Attr("deformable_groups", deformable_groups)
+      .Attr("modulated", modulated)
+      .Run();
+  c10::SmallVector<int64_t, SIZE> out_perm = {0, 3, 1, 2};
+  nhwc_deformable_offsets_backward_input_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_deformable_offsets_backward_input_desc.origin_format_ = ACL_FORMAT_NCHW;
+  nhwc_input_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_input_desc.origin_format_ = ACL_FORMAT_NCHW;
+  nhwc_offset_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_offset_desc.origin_format_ = ACL_FORMAT_NCHW;
+  auto& nhwc_grad_input_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_grad_input)->npu_desc_;
+  auto& nhwc_grad_offset_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(nhwc_grad_offset)->npu_desc_;
+  nhwc_grad_input_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_grad_input_desc.origin_format_ = ACL_FORMAT_NCHW;
+  nhwc_grad_offset_desc.npu_format_ = ACL_FORMAT_NCHW;
+  nhwc_grad_offset_desc.origin_format_ = ACL_FORMAT_NCHW;
+  at::Tensor grad_input =
+      acl_op::npu_transpose(nhwc_grad_input, out_perm, true);
+  at::Tensor grad_offset =
+      acl_op::npu_transpose(nhwc_grad_offset, out_perm, true);
 
-    return std::tie(grad_input, grad_weight, grad_offset, grad_bias);
+  return std::tie(grad_input, grad_weight, grad_offset, grad_bias);
 }
 
-std::tuple<at::Tensor, at::Tensor> npu_deformable_conv2d(const at::Tensor &input_ori, const at::Tensor &weight_ori,
-                                                         const at::Tensor &offset_ori,
-                                                         const c10::optional<at::Tensor> &bias_opt,
-                                                         at::IntArrayRef kernel_size, at::IntArrayRef stride,
-                                                         at::IntArrayRef padding, at::IntArrayRef dilation,
-                                                         int64_t groups, int64_t deformable_groups, bool modulated)
-{
-    at::Tensor input = (input_ori.dtype() != at::kFloat) ?
-                           at_npu::native::custom_ops::npu_dtype_cast(input_ori, at::kFloat) :
-                           input_ori;
-    at::Tensor weight = (weight_ori.dtype() != at::kFloat) ?
-                            at_npu::native::custom_ops::npu_dtype_cast(weight_ori, at::kFloat) :
-                            weight_ori;
-    at::Tensor offset = (offset_ori.dtype() != at::kFloat) ?
-                            at_npu::native::custom_ops::npu_dtype_cast(offset_ori, at::kFloat) :
-                            offset_ori;
-    return deformable_conv2d_nocheck(input, weight, offset, bias_opt, kernel_size, stride, padding, dilation, groups,
-                                     deformable_groups, modulated);
+std::tuple<at::Tensor, at::Tensor> npu_deformable_conv2d(
+    const at::Tensor& input_ori,
+    const at::Tensor& weight_ori,
+    const at::Tensor& offset_ori,
+    const c10::optional<at::Tensor>& bias_opt,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    int64_t groups,
+    int64_t deformable_groups,
+    bool modulated) {
+  at::Tensor input = (input_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(input_ori, at::kFloat)
+      : input_ori;
+  at::Tensor weight = (weight_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(weight_ori, at::kFloat)
+      : weight_ori;
+  at::Tensor offset = (offset_ori.dtype() != at::kFloat)
+      ? at_npu::native::custom_ops::npu_dtype_cast(offset_ori, at::kFloat)
+      : offset_ori;
+  return deformable_conv2d_nocheck(
+      input,
+      weight,
+      offset,
+      bias_opt,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      groups,
+      deformable_groups,
+      modulated);
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/DropoutKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/DropoutKernelNpu.cpp
@@ -37,7 +37,10 @@ at::Tensor& dropout_do_mask(
   cmd.Name("DropOutDoMask")
       .Input(self)
       .Input(mask)
-      .Input(prob, self.scalar_type(), npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(
+          prob,
+          self.scalar_type(),
+          npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
       .Output(result)
       .Run();
   return result;
@@ -53,7 +56,10 @@ std::tuple<at::Tensor, at::Tensor> dropout_do_mask_npu(
   cmd.Name("DropOutDoMask")
       .Input(self)
       .Input(mask)
-      .Input(prob, self.scalar_type(), npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(
+          prob,
+          self.scalar_type(),
+          npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
       .Output(result)
       .Run();
   return std::tie(result, mask);
@@ -61,16 +67,20 @@ std::tuple<at::Tensor, at::Tensor> dropout_do_mask_npu(
 
 at::Tensor dropout_gen_mask(const at::Tensor& self, at::Scalar prob) {
   bool is_not_jit_compile = at_npu::native::env::CheckJitDisable();
-  auto desc_ = torch_backend::NPUBridge::GetNpuStorageImpl(self)->get_npu_desc();
-  int64_t numels = is_not_jit_compile ? c10::multiply_integers(desc_.storage_sizes_) : self.numel();
+  auto desc_ = c10::backend::NPUBridge::GetNpuStorageImpl(self)->get_npu_desc();
+  int64_t numels = is_not_jit_compile
+      ? c10::multiply_integers(desc_.storage_sizes_)
+      : self.numel();
 
-  uint64_t length = (static_cast<uint64_t>(numels) + LENGTH_DATA_ALIGN - 1) / LENGTH_DATA_ALIGN * LENGTH_DATA_ALIGN;
+  uint64_t length = (static_cast<uint64_t>(numels) + LENGTH_DATA_ALIGN - 1) /
+      LENGTH_DATA_ALIGN * LENGTH_DATA_ALIGN;
   at::Tensor mask = npu_preparation::apply_tensor_with_format(
       {length / LENGTH_BOLCK_ALIGN},
       self.options().dtype(at::kByte),
       ACL_FORMAT_ND);
 
-  at::IntArrayRef self_shape = is_not_jit_compile ? desc_.storage_sizes_ : self.sizes();
+  at::IntArrayRef self_shape =
+      is_not_jit_compile ? desc_.storage_sizes_ : self.sizes();
 
   at_npu::native::OpCommand cmd;
   // DropOutGenMask use seed and seed1 to generator a seed, like this:
@@ -79,7 +89,9 @@ at::Tensor dropout_gen_mask(const at::Tensor& self, at::Scalar prob) {
   // so, we set seed1 = 0 to ensure the seed which user set is equal to the seed
   // used by the operator DropOutGenMask
   const auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto pair = at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(INCREMENT);
+  auto pair =
+      at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(
+          INCREMENT);
   // At present, the default value of random number may be very large,
   // which will cause overflow in graph mode, so we set seed = 0 to avoid it.
   const int64_t seed = static_cast<int64_t>(pair.first);
@@ -89,10 +101,16 @@ at::Tensor dropout_gen_mask(const at::Tensor& self, at::Scalar prob) {
   const int64_t seed1 = 0;
   cmd.Name("StatelessDropOutGenMask")
       .Input(self_shape)
-      .Input(prob, self.scalar_type(), npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(
+          prob,
+          self.scalar_type(),
+          npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
       .Input(at::Scalar(seed), at::ScalarType::Int)
       .Input(at::Scalar(seed1), at::ScalarType::Int)
-      .Input(offset_list, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(
+          offset_list,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
       .Output(mask)
       .Run();
   return mask;
@@ -106,7 +124,8 @@ std::tuple<at::Tensor, at::Tensor> dropout_v1_out_nocheck(
   TORCH_CHECK(
       p >= 0 && p <= 1,
       "dropout probability has to be between 0 and 1, but got ",
-      p, OPS_ERROR(ErrCode::VALUE));
+      p,
+      OPS_ERROR(ErrCode::VALUE));
   TORCH_CHECK(
       at::isFloatingType(self_cp.scalar_type()),
       "dropout only supports floating-point dtypes" + OPS_ERROR(ErrCode::TYPE));
@@ -129,30 +148,32 @@ std::tuple<at::Tensor, at::Tensor> _npu_dropout(
 }
 
 at::Tensor npu_dropout_gen_mask(
-    at::IntArrayRef size, double p,
+    at::IntArrayRef size,
+    double p,
     c10::optional<at::ScalarType> dtype_opt,
     c10::optional<c10::Layout> layout_opt,
     c10::optional<c10::Device> device_opt,
     c10::optional<bool> pin_memory_opt) {
-  c10::TensorOptions options = c10::TensorOptions().dtype(dtype_opt)
-      .device(device_opt)
-      .layout(layout_opt)
-      .pinned_memory(pin_memory_opt);
+  c10::TensorOptions options = c10::TensorOptions()
+                                   .dtype(dtype_opt)
+                                   .device(device_opt)
+                                   .layout(layout_opt)
+                                   .pinned_memory(pin_memory_opt);
 
   at::Scalar prob = at::Scalar(1. - p);
   int64_t numels = c10::multiply_integers(size);
 
   uint64_t length = (static_cast<uint64_t>(numels) + 128 - 1) / 128 * 128;
   at::Tensor mask = npu_preparation::apply_tensor_with_format(
-      at::IntArrayRef{length / 8},
-      options.dtype(at::kByte),
-      ACL_FORMAT_ND);
+      at::IntArrayRef{length / 8}, options.dtype(at::kByte), ACL_FORMAT_ND);
 
   at_npu::native::OpCommand cmd;
   // If either seed or seed1 are set to be non-zero, the random number generator
   // is seeded by the given seed. Otherwise, it is seeded by a random seed.
   const auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto pair = at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(10);
+  auto pair =
+      at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(
+          10);
   // At present, the default value of random number may be very large,
   // which will cause overflow in graph mode, so we set seed = 0 to avoid it.
   const int64_t seed = static_cast<int64_t>(pair.first);
@@ -162,10 +183,16 @@ at::Tensor npu_dropout_gen_mask(
   const int64_t seed1 = 0;
   cmd.Name("StatelessDropOutGenMask")
       .Input(size)
-      .Input(prob, c10::typeMetaToScalarType(options.dtype()), npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(
+          prob,
+          c10::typeMetaToScalarType(options.dtype()),
+          npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
       .Input(at::Scalar(seed), at::ScalarType::Int)
       .Input(at::Scalar(seed1), at::ScalarType::Int)
-      .Input(offset_list, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(
+          offset_list,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
       .Output(mask)
       .Run();
   return mask;
@@ -177,7 +204,8 @@ at::Tensor npu_dropout_backward(
     double scale) {
   TORCH_CHECK(
       at::isFloatingType(grad_output.scalar_type()),
-      "dropoutbackward only supports floating-point dtypes" + OPS_ERROR(ErrCode::TYPE));
+      "dropoutbackward only supports floating-point dtypes" +
+          OPS_ERROR(ErrCode::TYPE));
   TORCH_CHECK(
       mask.scalar_type() == at::ScalarType::Byte,
       "mask should be torch.uint8 dtype" + OPS_ERROR(ErrCode::TYPE));
@@ -188,7 +216,10 @@ at::Tensor npu_dropout_backward(
   cmd.Name("DropOutDoMask")
       .Input(grad_output)
       .Input(mask)
-      .Input(at::Scalar(retain), grad_output.scalar_type(), npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(
+          at::Scalar(retain),
+          grad_output.scalar_type(),
+          npu_compile_type::MEMORY_HOST_COMPILE_DEPENDENT)
       .Output(result)
       .Run();
 

--- a/npu/aten/ops/base/aclops/DropoutKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/DropoutKernelNpu.cpp
@@ -88,10 +88,9 @@ at::Tensor dropout_gen_mask(const at::Tensor& self, at::Scalar prob) {
   // 127~64   63~0
   // so, we set seed1 = 0 to ensure the seed which user set is equal to the seed
   // used by the operator DropOutGenMask
-  const auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto pair =
-      at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(
-          INCREMENT);
+  const auto gen = c10::backend::detail::getDefaultNPUGenerator();
+  auto pair = at::check_generator<c10::backend::NPUGeneratorImpl>(gen)
+                  ->philox_engine_inputs(INCREMENT);
   // At present, the default value of random number may be very large,
   // which will cause overflow in graph mode, so we set seed = 0 to avoid it.
   const int64_t seed = static_cast<int64_t>(pair.first);
@@ -170,10 +169,9 @@ at::Tensor npu_dropout_gen_mask(
   at_npu::native::OpCommand cmd;
   // If either seed or seed1 are set to be non-zero, the random number generator
   // is seeded by the given seed. Otherwise, it is seeded by a random seed.
-  const auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto pair =
-      at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(
-          10);
+  const auto gen = c10::backend::detail::getDefaultNPUGenerator();
+  auto pair = at::check_generator<c10::backend::NPUGeneratorImpl>(gen)
+                  ->philox_engine_inputs(10);
   // At present, the default value of random number may be very large,
   // which will cause overflow in graph mode, so we set seed = 0 to avoid it.
   const int64_t seed = static_cast<int64_t>(pair.first);

--- a/npu/aten/ops/base/aclops/FusedAttentionScoreKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/FusedAttentionScoreKernelNpu.cpp
@@ -46,7 +46,7 @@ at::Tensor dropout_gen_mask_nocheck(
     const at::Scalar& prob) {
   at::Tensor mask = npu_preparation::apply_tensor_with_format(
       {self.numel()}, self.options().dtype(at::kByte), ACL_FORMAT_ND);
-  const auto gen = at_npu::detail::getDefaultNPUGenerator();
+  const auto gen = c10::backend::detail::getDefaultNPUGenerator();
   const int64_t seed = static_cast<int64_t>(gen.current_seed());
   const int64_t seed2 = 0;
   at_npu::native::OpCommand cmd;

--- a/npu/aten/ops/base/aclops/FusedAttentionScoreKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/FusedAttentionScoreKernelNpu.cpp
@@ -219,7 +219,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_fused_attention_score_fwd(
   at::Tensor softmax_output =
       npu_preparation::apply_tensor(query_layer, std::get<1>(output_sizes));
   at::Tensor drop_mask;
-  auto original_stream = c10::npu::getCurrentNPUStream();
+  auto original_stream = c10::backend::getCurrentNPUStream();
   drop_mask = dropout_gen_mask_nocheck(softmax_output, at::Scalar(keep_prob));
   npu_fused_attention_score_nocheck(
       attention_score,

--- a/npu/aten/ops/base/aclops/MaxPool2dWithIndicesBackwardKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/MaxPool2dWithIndicesBackwardKernelNpu.cpp
@@ -28,168 +28,227 @@ using npu_preparation = at_npu::native::OpPreparation;
 using npu_utils = at_npu::native::NpuUtils;
 
 namespace {
-at::Tensor &max_pool2d_with_indices_backward_out_nocheck(at::Tensor &grad_input, const at::Tensor &grad_output,
-                                                         const at::Tensor &self, at::IntArrayRef kernel_size,
-                                                         at::IntArrayRef stride, at::IntArrayRef padding,
-                                                         at::IntArrayRef dilation, bool ceil_mode,
-                                                         const at::Tensor &indices)
-{
-    at::Tensor self_cp = self;
-    at::Tensor grad_output_cp = grad_output;
-    at::Tensor indices_cp = indices;
-    if (self.dim() == 3) {
-        self_cp = self.unsqueeze(0);
-        grad_output_cp = grad_output.unsqueeze(0);
-        indices_cp = indices.unsqueeze(0);
-        grad_input.unsqueeze_(0);
+at::Tensor& max_pool2d_with_indices_backward_out_nocheck(
+    at::Tensor& grad_input,
+    const at::Tensor& grad_output,
+    const at::Tensor& self,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    bool ceil_mode,
+    const at::Tensor& indices) {
+  at::Tensor self_cp = self;
+  at::Tensor grad_output_cp = grad_output;
+  at::Tensor indices_cp = indices;
+  if (self.dim() == 3) {
+    self_cp = self.unsqueeze(0);
+    grad_output_cp = grad_output.unsqueeze(0);
+    indices_cp = indices.unsqueeze(0);
+    grad_input.unsqueeze_(0);
+  }
+  int64_t stride_H = 1;
+  int64_t stride_W = 1;
+  if (stride.empty()) {
+    stride_H = kernel_size[0];
+    stride_W = kernel_size[1];
+  } else {
+    stride_H = stride[0];
+    stride_W = stride[1];
+  }
+
+  c10::SmallVector<int64_t, N> kernel_size_new = {
+      1, kernel_size[0], kernel_size[1], 1};
+  c10::SmallVector<int64_t, N> strides_size = {1, stride_H, stride_W, 1};
+  c10::SmallVector<int64_t, N> paddings = {1, padding[0], padding[1], 1};
+  c10::SmallVector<int64_t, N> dilations = {1, dilation[0], dilation[1], 1};
+  at_npu::native::OpCommand cmd;
+
+  if (indices.dtype() == at::kChar) {
+    /* Here to fix the situation when the foward is op_api.
+    ** The indices of op_api foward, has continuous storage memory, and dtype is
+    *int8, format is NCHW, shape is 4D.
+    ** To avoid FE insert transdata node, and damage the storage memory,
+    *modifing indices's format to NC1HWC0.
+    ** And modify the dtype to short to align with argmax of op parameter.
+    */
+    at::SmallVector<int64_t, N> shape;
+    for (int i = 0; i < indices.dim(); i++) {
+      shape.emplace_back(
+          (i == 3) ? indices.size(i) / INDICES_TYPE_CONVERT / BLOCKSIZE
+                   : indices.size(i));
     }
-    int64_t stride_H = 1;
-    int64_t stride_W = 1;
-    if (stride.empty()) {
-        stride_H = kernel_size[0];
-        stride_W = kernel_size[1];
-    } else {
-        stride_H = stride[0];
-        stride_W = stride[1];
-    }
+    shape.emplace_back(BLOCKSIZE);
 
-    c10::SmallVector<int64_t, N> kernel_size_new = {1, kernel_size[0], kernel_size[1], 1};
-    c10::SmallVector<int64_t, N> strides_size = {1, stride_H, stride_W, 1};
-    c10::SmallVector<int64_t, N> paddings = {1, padding[0], padding[1], 1};
-    c10::SmallVector<int64_t, N> dilations = {1, dilation[0], dilation[1], 1};
-    at_npu::native::OpCommand cmd;
+    at::Tensor indices_para = indices.view(at::kShort);
+    c10::backend::NPUStorageDesc& desc =
+        c10::backend::NPUBridge::GetNpuStorageImpl(indices_para)->npu_desc_;
+    desc.npu_format_ = ACL_FORMAT_NC1HWC0;
+    desc.storage_sizes_ = shape;
+    desc.data_type_ = at::ScalarType::Short;
+    desc.origin_format_ = ACL_FORMAT_NCHW;
+    desc.base_sizes_ = indices_para.sizes();
+    desc.base_strides_ = indices_para.strides();
 
-    if (indices.dtype() == at::kChar) {
-        /* Here to fix the situation when the foward is op_api.
-        ** The indices of op_api foward, has continuous storage memory, and dtype is int8, format is NCHW, shape is 4D.
-        ** To avoid FE insert transdata node, and damage the storage memory, modifing indices's format to NC1HWC0.
-        ** And modify the dtype to short to align with argmax of op parameter.
-        */
-        at::SmallVector<int64_t, N> shape;
-        for (int i = 0; i < indices.dim(); i++) {
-            shape.emplace_back((i == 3) ? indices.size(i) / INDICES_TYPE_CONVERT / BLOCKSIZE : indices.size(i));
-        }
-        shape.emplace_back(BLOCKSIZE);
+    cmd.Name("MaxPoolGradWithArgmaxV1")
+        .Input(self, "x")
+        .Input(grad_output, "grad")
+        .Input(indices_para, "argmax", c10::nullopt, "uint16")
+        .Output(grad_input, "y")
+        .Attr("ksize", kernel_size_new)
+        .Attr("strides", strides_size)
+        .Attr("pads", paddings)
+        .Attr("dilations", dilations)
+        .Attr("ceil_mode", ceil_mode)
+        .Run();
+  } else {
+    cmd.Name("MaxPoolGradWithArgmaxV1")
+        .Input(self, "x")
+        .Input(grad_output, "grad")
+        .Input(indices, "argmax", c10::nullopt, "uint16")
+        .Output(grad_input, "y")
+        .Attr("ksize", kernel_size_new)
+        .Attr("strides", strides_size)
+        .Attr("pads", paddings)
+        .Attr("dilations", dilations)
+        .Attr("ceil_mode", ceil_mode)
+        .Run();
+  }
 
-        at::Tensor indices_para = indices.view(at::kShort);
-        torch_backend::NPUStorageDesc &desc = torch_backend::NPUBridge::GetNpuStorageImpl(indices_para)->npu_desc_;
-        desc.npu_format_ = ACL_FORMAT_NC1HWC0;
-        desc.storage_sizes_ = shape;
-        desc.data_type_ = at::ScalarType::Short;
-        desc.origin_format_ = ACL_FORMAT_NCHW;
-        desc.base_sizes_ = indices_para.sizes();
-        desc.base_strides_ = indices_para.strides();
-
-        cmd.Name("MaxPoolGradWithArgmaxV1")
-            .Input(self, "x")
-            .Input(grad_output, "grad")
-            .Input(indices_para, "argmax", c10::nullopt, "uint16")
-            .Output(grad_input, "y")
-            .Attr("ksize", kernel_size_new)
-            .Attr("strides", strides_size)
-            .Attr("pads", paddings)
-            .Attr("dilations", dilations)
-            .Attr("ceil_mode", ceil_mode)
-            .Run();
-    } else {
-        cmd.Name("MaxPoolGradWithArgmaxV1")
-            .Input(self, "x")
-            .Input(grad_output, "grad")
-            .Input(indices, "argmax", c10::nullopt, "uint16")
-            .Output(grad_input, "y")
-            .Attr("ksize", kernel_size_new)
-            .Attr("strides", strides_size)
-            .Attr("pads", paddings)
-            .Attr("dilations", dilations)
-            .Attr("ceil_mode", ceil_mode)
-            .Run();
-    }
-
-    if (self.dim() == 3) {
-        grad_input.squeeze_(0);
-    }
-    return grad_input;
+  if (self.dim() == 3) {
+    grad_input.squeeze_(0);
+  }
+  return grad_input;
 }
 
-void max_pool2d_with_indices_backward_parameter_check(const at::Tensor &self, at::IntArrayRef kernel_size,
-                                                      at::IntArrayRef stride, at::IntArrayRef padding,
-                                                      at::IntArrayRef dilation)
-{
-    TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 2,
-        "max_pool2d: kernel_size must either be a single int, or a tuple of two ints"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 2,
-        "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(padding.size() == 1 || padding.size() == 2,
-        "max_pool2d: padding must be either be a single int, or a tuple of two ints"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(dilation.size() == 1 || dilation.size() == 2,
-        "max_pool2d: dilation must be either a single int, or a tuple of two ints"
-        + OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK((self.ndimension() == 3 || self.ndimension() == 4),
-        "non-empty 3D or 4D (batch mode) tensor expected for input"
-        + OPS_ERROR(ErrCode::PARAM));
+void max_pool2d_with_indices_backward_parameter_check(
+    const at::Tensor& self,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation) {
+  TORCH_CHECK(
+      kernel_size.size() == 1 || kernel_size.size() == 2,
+      "max_pool2d: kernel_size must either be a single int, or a tuple of two ints" +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      stride.size() == 0 || stride.size() == 1 || stride.size() == 2,
+      "max_pool2d: stride must either be omitted, a single int, or a tuple of two ints" +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      padding.size() == 1 || padding.size() == 2,
+      "max_pool2d: padding must be either be a single int, or a tuple of two ints" +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      dilation.size() == 1 || dilation.size() == 2,
+      "max_pool2d: dilation must be either a single int, or a tuple of two ints" +
+          OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      (self.ndimension() == 3 || self.ndimension() == 4),
+      "non-empty 3D or 4D (batch mode) tensor expected for input" +
+          OPS_ERROR(ErrCode::PARAM));
 }
 } // namespace
 
-at::Tensor &max_pool2d_with_indices_backward_out(const at::Tensor &grad_output, const at::Tensor &self,
-                                                 at::IntArrayRef kernel_size, at::IntArrayRef stride,
-                                                 at::IntArrayRef padding, at::IntArrayRef dilation, bool ceil_mode,
-                                                 const at::Tensor &indices, at::Tensor &grad_input)
-{
-    max_pool2d_with_indices_backward_parameter_check(self, kernel_size, stride, padding, dilation);
+at::Tensor& max_pool2d_with_indices_backward_out(
+    const at::Tensor& grad_output,
+    const at::Tensor& self,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    bool ceil_mode,
+    const at::Tensor& indices,
+    at::Tensor& grad_input) {
+  max_pool2d_with_indices_backward_parameter_check(
+      self, kernel_size, stride, padding, dilation);
 
-    npu_preparation::CheckOut({self, grad_output, indices}, grad_input, self);
-    if (!npu_utils::check_match(&grad_input)) {
-        at::Tensor contig_grad_input = npu_utils::format_contiguous(grad_input);
-        max_pool2d_with_indices_backward_out_nocheck(contig_grad_input, grad_output, self, kernel_size, stride, padding,
-                                                     dilation, ceil_mode, indices);
-        npu_utils::format_fresh_view(grad_input, contig_grad_input);
-    } else {
-        max_pool2d_with_indices_backward_out_nocheck(grad_input, grad_output, self, kernel_size, stride, padding,
-                                                     dilation, ceil_mode, indices);
-    }
-    return grad_input;
+  npu_preparation::CheckOut({self, grad_output, indices}, grad_input, self);
+  if (!npu_utils::check_match(&grad_input)) {
+    at::Tensor contig_grad_input = npu_utils::format_contiguous(grad_input);
+    max_pool2d_with_indices_backward_out_nocheck(
+        contig_grad_input,
+        grad_output,
+        self,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        indices);
+    npu_utils::format_fresh_view(grad_input, contig_grad_input);
+  } else {
+    max_pool2d_with_indices_backward_out_nocheck(
+        grad_input,
+        grad_output,
+        self,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        indices);
+  }
+  return grad_input;
 }
 
-at::Tensor max_pool2d_with_indices_backward(const at::Tensor &grad_output_var, const at::Tensor &self,
-                                            at::IntArrayRef kernel_size, at::IntArrayRef stride,
-                                            at::IntArrayRef padding, at::IntArrayRef dilation, bool ceil_mode,
-                                            const at::Tensor &indices)
-{
-    max_pool2d_with_indices_backward_parameter_check(self, kernel_size, stride, padding, dilation);
+at::Tensor max_pool2d_with_indices_backward(
+    const at::Tensor& grad_output_var,
+    const at::Tensor& self,
+    at::IntArrayRef kernel_size,
+    at::IntArrayRef stride,
+    at::IntArrayRef padding,
+    at::IntArrayRef dilation,
+    bool ceil_mode,
+    const at::Tensor& indices) {
+  max_pool2d_with_indices_backward_parameter_check(
+      self, kernel_size, stride, padding, dilation);
 
-    const int k_H = at::native::safe_downcast<int, int64_t>(kernel_size[0]);
-    const int k_W = kernel_size.size() == 1 ? k_H : at::native::safe_downcast<int, int64_t>(kernel_size[1]);
-    c10::SmallVector<int64_t, SIZE> kernel_sizes = {k_H, k_W};
-    at::IntArrayRef kernel_sizess = at::IntArrayRef(kernel_sizes);
+  const int k_H = at::native::safe_downcast<int, int64_t>(kernel_size[0]);
+  const int k_W = kernel_size.size() == 1
+      ? k_H
+      : at::native::safe_downcast<int, int64_t>(kernel_size[1]);
+  c10::SmallVector<int64_t, SIZE> kernel_sizes = {k_H, k_W};
+  at::IntArrayRef kernel_sizess = at::IntArrayRef(kernel_sizes);
 
-    // NB: stride default is not expressible as an integer constant, so we accept
-    // empty stride for this case
-    const int d_H = stride.empty() ? k_H : at::native::safe_downcast<int, int64_t>(stride[0]);
-    const int d_W = stride.empty()     ? k_W :
-                    stride.size() == 1 ? d_H :
-                                         at::native::safe_downcast<int, int64_t>(stride[1]);
-    c10::SmallVector<int64_t, SIZE> strides = {d_H, d_W};
-    at::IntArrayRef stridess = at::IntArrayRef(strides);
+  // NB: stride default is not expressible as an integer constant, so we accept
+  // empty stride for this case
+  const int d_H =
+      stride.empty() ? k_H : at::native::safe_downcast<int, int64_t>(stride[0]);
+  const int d_W = stride.empty() ? k_W
+      : stride.size() == 1       ? d_H
+                           : at::native::safe_downcast<int, int64_t>(stride[1]);
+  c10::SmallVector<int64_t, SIZE> strides = {d_H, d_W};
+  at::IntArrayRef stridess = at::IntArrayRef(strides);
 
-    const int pad_H = at::native::safe_downcast<int, int64_t>(padding[0]);
-    const int pad_W = padding.size() == 1 ? pad_H : at::native::safe_downcast<int, int64_t>(padding[1]);
-    c10::SmallVector<int64_t, SIZE> paddings = {pad_H, pad_W};
-    at::IntArrayRef padss = at::IntArrayRef(paddings);
+  const int pad_H = at::native::safe_downcast<int, int64_t>(padding[0]);
+  const int pad_W = padding.size() == 1
+      ? pad_H
+      : at::native::safe_downcast<int, int64_t>(padding[1]);
+  c10::SmallVector<int64_t, SIZE> paddings = {pad_H, pad_W};
+  at::IntArrayRef padss = at::IntArrayRef(paddings);
 
-    const int dilation_H = at::native::safe_downcast<int, int64_t>(dilation[0]);
-    const int dilation_W = dilation.size() == 1 ? dilation_H : at::native::safe_downcast<int, int64_t>(dilation[1]);
-    c10::SmallVector<int64_t, SIZE> dilations = {dilation_H, dilation_W};
-    at::IntArrayRef dilationss = at::IntArrayRef(dilations);
+  const int dilation_H = at::native::safe_downcast<int, int64_t>(dilation[0]);
+  const int dilation_W = dilation.size() == 1
+      ? dilation_H
+      : at::native::safe_downcast<int, int64_t>(dilation[1]);
+  c10::SmallVector<int64_t, SIZE> dilations = {dilation_H, dilation_W};
+  at::IntArrayRef dilationss = at::IntArrayRef(dilations);
 
-    at::Tensor grad_input = npu_preparation::apply_tensor(self);
+  at::Tensor grad_input = npu_preparation::apply_tensor(self);
 
-    max_pool2d_with_indices_backward_out_nocheck(grad_input, grad_output_var, self, kernel_sizess, stridess, padss,
-                                                 dilationss, ceil_mode, indices);
+  max_pool2d_with_indices_backward_out_nocheck(
+      grad_input,
+      grad_output_var,
+      self,
+      kernel_sizess,
+      stridess,
+      padss,
+      dilationss,
+      ceil_mode,
+      indices);
 
-    return grad_input;
+  return grad_input;
 }
 
 } // namespace acl_op

--- a/npu/aten/ops/base/aclops/MmKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/MmKernelNpu.cpp
@@ -55,7 +55,7 @@ bool is_transpose_last_two_dims_flex(const at::Tensor& tensor) {
 bool is_transpose_last_two_dims_strict(
     const at::Tensor& tensor,
     bool is_transpose_flex) {
-  auto base_sizes = torch_backend::NPUBridge::GetNpuStorageImpl(tensor)
+  auto base_sizes = c10::backend::NPUBridge::GetNpuStorageImpl(tensor)
                         ->get_npu_desc()
                         .base_sizes_;
   if (is_transpose_flex &&
@@ -223,9 +223,9 @@ at::Tensor& mm_out_npu_nocheck(
     const at::Tensor& self,
     const at::Tensor& mat2) {
   const auto self_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
   const auto mat2_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_;
   bool is_self_t_flex = is_transpose_last_two_dims_flex(self);
   bool is_mat2_t_flex = is_transpose_last_two_dims_flex(mat2);
   bool is_self_t_strict =
@@ -267,10 +267,10 @@ at::Tensor& mm_out_npu_nocheck(
   // Recover storage desc of view-transpose tensors, i.e. the inverse process of
   // set_transposed_npu_desc
   if (is_self_t_flex && (!is_self_t_strict)) {
-    torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_ = self_desc;
+    c10::backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_ = self_desc;
   }
   if (is_mat2_t_flex && (!is_mat2_t_strict)) {
-    torch_backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
+    c10::backend::NPUBridge::GetNpuStorageImpl(mat2)->npu_desc_ = mat2_desc;
   }
 
   return result;

--- a/npu/aten/ops/base/aclops/TrilKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/TrilKernelNpu.cpp
@@ -21,22 +21,21 @@ using npu_preparation = at_npu::native::OpPreparation;
 using npu_utils = at_npu::native::NpuUtils;
 
 namespace {
-at::Tensor& tril_out_nocheck(at::Tensor& result, const at::Tensor& self, int64_t diagonal) {
+at::Tensor& tril_out_nocheck(
+    at::Tensor& result,
+    const at::Tensor& self,
+    int64_t diagonal) {
   at_npu::native::OpCommand cmd;
-  cmd.Name("Tril")
-      .Input(self)
-      .Output(result)
-      .Attr("diagonal", diagonal)
-      .Run();
+  cmd.Name("Tril").Input(self).Output(result).Attr("diagonal", diagonal).Run();
   return result;
 }
 } // namespace
 
-at::Tensor& tril_out(const at::Tensor& self, int64_t diagonal, at::Tensor& result) {
-  npu_preparation::CheckOut(
-      {self},
-      result,
-      self);
+at::Tensor& tril_out(
+    const at::Tensor& self,
+    int64_t diagonal,
+    at::Tensor& result) {
+  npu_preparation::CheckOut({self}, result, self);
 
   if (!npu_utils::check_match(&result)) {
     at::Tensor contiguous_result = npu_utils::format_contiguous(result);
@@ -50,19 +49,24 @@ at::Tensor& tril_out(const at::Tensor& self, int64_t diagonal, at::Tensor& resul
 }
 
 at::Tensor tril(const at::Tensor& self, int64_t diagonal) {
-    auto is_last_two_dims = [&self]() {
-        auto self_storage = torch_backend::NPUBridge::GetNpuStorageImpl(self)->get_npu_desc().storage_sizes_;
-        if (self_storage.size() <= 1) {
-          return false;
-        }
+  auto is_last_two_dims = [&self]() {
+    auto self_storage = c10::backend::NPUBridge::GetNpuStorageImpl(self)
+                            ->get_npu_desc()
+                            .storage_sizes_;
+    if (self_storage.size() <= 1) {
+      return false;
+    }
 
-        return true;
-    };
-    TORCH_CHECK(is_last_two_dims(), "tril require tensor should be last two dims" + OPS_ERROR(ErrCode::PARAM));
-    at::Tensor result = npu_preparation::apply_tensor(self);
-    tril_out_nocheck(result, self, diagonal);
+    return true;
+  };
+  TORCH_CHECK(
+      is_last_two_dims(),
+      "tril require tensor should be last two dims" +
+          OPS_ERROR(ErrCode::PARAM));
+  at::Tensor result = npu_preparation::apply_tensor(self);
+  tril_out_nocheck(result, self, diagonal);
 
-    return result;
+  return result;
 }
 
 at::Tensor& tril_(at::Tensor& self, int64_t diagonal) {

--- a/npu/aten/ops/base/aclops/UniformKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/UniformKernelNpu.cpp
@@ -30,7 +30,8 @@ at::Tensor& uniform_out_npu(
     double from,
     double to,
     c10::optional<at::Generator> gen_) {
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen_, at_npu::detail::getDefaultNPUGenerator());
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen_, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
@@ -39,9 +40,20 @@ at::Tensor& uniform_out_npu(
   int64_t alg = 1;
   at_npu::native::OpCommand cmd;
   cmd.Name("StatelessRandomUniformV2")
-      .Input(self.sizes(), at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-      .Input(seed_list, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT, (string)"uint64")
-      .Input(offset_list, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT, (string)"uint64")
+      .Input(
+          self.sizes(),
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Input(
+          seed_list,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT,
+          (string) "uint64")
+      .Input(
+          offset_list,
+          at::kLong,
+          npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT,
+          (string) "uint64")
       .Input(at::Scalar(alg), at::ScalarType::Int)
       .Output(result)
       .Attr("dtype", self.scalar_type())
@@ -53,7 +65,11 @@ at::Tensor& uniform_out_npu(
 }
 } // namespace
 
-at::Tensor& uniform_(at::Tensor& self, double from, double to, c10::optional<at::Generator> gen_) {
+at::Tensor& uniform_(
+    at::Tensor& self,
+    double from,
+    double to,
+    c10::optional<at::Generator> gen_) {
   if (!npu_utils::check_match(&self)) {
     at::Tensor contiguous_self = npu_utils::format_contiguous(self);
     uniform_out_npu(contiguous_self, contiguous_self, from, to, gen_);

--- a/npu/aten/ops/base/aclops/ViewcopyKernelNpu.cpp
+++ b/npu/aten/ops/base/aclops/ViewcopyKernelNpu.cpp
@@ -24,100 +24,129 @@ namespace {
 // format are base format (the format of src and dst are all nchw now)
 // dtype are same
 // so the view_value and ReflushDescBySelf are base on the hypothesis above.
-bool AicoreValid(at::Tensor &self, const at::Tensor &src)
-{
-    const auto &dst_storage_sizes = torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_.storage_sizes_;
-    auto self_size = self.sizes();
-    auto self_stride = self.strides();
-    auto dst_storage_size_len = dst_storage_sizes.size();
-    auto self_size_len = self_size.size();
+bool AicoreValid(at::Tensor& self, const at::Tensor& src) {
+  const auto& dst_storage_sizes =
+      c10::backend::NPUBridge::GetNpuStorageImpl(self)
+          ->npu_desc_.storage_sizes_;
+  auto self_size = self.sizes();
+  auto self_stride = self.strides();
+  auto dst_storage_size_len = dst_storage_sizes.size();
+  auto self_size_len = self_size.size();
 
-    // count the difference between dst_storage and dst_size.
-    auto diff = dst_storage_size_len - self_size_len;
-    if (diff < 0 || diff > 1) {
+  // count the difference between dst_storage and dst_size.
+  auto diff = dst_storage_size_len - self_size_len;
+  if (diff < 0 || diff > 1) {
+    return false;
+  }
+
+  // record the index of the difference.
+  auto diff_index = self_size_len;
+  for (uint64_t i = 0; i < self_size_len; i++) {
+    if (dst_storage_sizes[i] != self_size[i]) {
+      ++diff;
+      if (diff > 1) {
         return false;
+      }
+      // differece should be 1.
+      diff_index = i;
     }
+  }
 
-    // record the index of the difference.
-    auto diff_index = self_size_len;
-    for (uint64_t i = 0; i < self_size_len; i++) {
-        if (dst_storage_sizes[i] != self_size[i]) {
-            ++diff;
-            if (diff > 1) {
-                return false;
-            }
-            // differece should be 1.
-            diff_index = i;
-        }
+  // if diff or diff_index equals 0, no need viewcopy.
+  if (diff == 0 || diff_index == 0) {
+    return false;
+  }
+
+  const auto& dst_base_stride =
+      c10::backend::NPUBridge::GetNpuStorageImpl(self)
+          ->npu_desc_.base_strides_;
+  // dst_base_stride should be equal to dst_storage_stride except for diff_index
+  if (self_stride.size() > dst_base_stride.size()) {
+    return false;
+  }
+
+  for (uint64_t i = 0; i < self_stride.size(); i++) {
+    if (dst_base_stride[i] != self_stride[i] && i != diff_index) {
+      return false;
     }
+  }
 
-    // if diff or diff_index equals 0, no need viewcopy.
-    if (diff == 0 || diff_index == 0) {
-        return false;
-    }
+  // dtype cannot be double and dst_size has to be equal with src_size.
+  if (self.dtype() == at::ScalarType::Double || self_size != src.sizes()) {
+    return false;
+  }
 
-    const auto &dst_base_stride = torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_.base_strides_;
-    // dst_base_stride should be equal to dst_storage_stride except for diff_index
-    if (self_stride.size() > dst_base_stride.size()) {
-        return false;
-    }
-
-    for (uint64_t i = 0; i < self_stride.size(); i++) {
-        if (dst_base_stride[i] != self_stride[i] && i != diff_index) {
-            return false;
-        }
-    }
-
-    // dtype cannot be double and dst_size has to be equal with src_size.
-    if (self.dtype() == at::ScalarType::Double || self_size != src.sizes()) {
-        return false;
-    }
-
-    return true;
+  return true;
 }
 } // namespace
 
-at::Tensor &npu_view_copy(at::Tensor &self, const at::Tensor &src, bool non_blocking)
-{
-    auto self_size = self.sizes();
-    auto self_stride = self.strides();
-    auto src_size = src.sizes();
-    auto src_stride = src.strides();
+at::Tensor& npu_view_copy(
+    at::Tensor& self,
+    const at::Tensor& src,
+    bool non_blocking) {
+  auto self_size = self.sizes();
+  auto self_stride = self.strides();
+  auto src_size = src.sizes();
+  auto src_stride = src.strides();
 
-    at_npu::native::OpCommand cmd;
-    if (AicoreValid(self, src)) {
-        at::Tensor contiguous_src(src);
-        if (!npu_utils::check_match(&contiguous_src)) {
-            contiguous_src = npu_utils::format_contiguous(contiguous_src);
-        }
-        src_stride = contiguous_src.strides();
-
-        cmd.Name("ViewCopy")
-            .InputWithoutContiguous(self)
-            .Input(self_size, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(self_stride, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(at::Scalar(0), at::kLong)
-            .InputWithoutContiguous(contiguous_src)
-            .Input(src_size, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(src_stride, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(at::Scalar(0), at::kLong)
-            .Output(self)
-            .Run();
-    } else {
-        cmd.Name("ViewCopy")
-            .InputWithoutContiguous(self)
-            .Input(self_size, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(self_stride, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(at::Scalar(0), at::kLong)
-            .InputWithoutContiguous(src)
-            .Input(src_size, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(src_stride, at::kLong, npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
-            .Input(at::Scalar(0), at::kLong)
-            .Output(self)
-            .Attr("_exclude_engines", (string) "AiCore")
-            .Run();
+  at_npu::native::OpCommand cmd;
+  if (AicoreValid(self, src)) {
+    at::Tensor contiguous_src(src);
+    if (!npu_utils::check_match(&contiguous_src)) {
+      contiguous_src = npu_utils::format_contiguous(contiguous_src);
     }
+    src_stride = contiguous_src.strides();
 
-    return self;
+    cmd.Name("ViewCopy")
+        .InputWithoutContiguous(self)
+        .Input(
+            self_size,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(
+            self_stride,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(at::Scalar(0), at::kLong)
+        .InputWithoutContiguous(contiguous_src)
+        .Input(
+            src_size,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(
+            src_stride,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(at::Scalar(0), at::kLong)
+        .Output(self)
+        .Run();
+  } else {
+    cmd.Name("ViewCopy")
+        .InputWithoutContiguous(self)
+        .Input(
+            self_size,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(
+            self_stride,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(at::Scalar(0), at::kLong)
+        .InputWithoutContiguous(src)
+        .Input(
+            src_size,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(
+            src_stride,
+            at::kLong,
+            npu_compile_type::MEMORY_HOST_COMPILE_INDEPENDENT)
+        .Input(at::Scalar(0), at::kLong)
+        .Output(self)
+        .Attr("_exclude_engines", (string) "AiCore")
+        .Run();
+  }
+
+  return self;
 }
 } // namespace acl_op

--- a/npu/aten/ops/base/opapi/AmpForeachNonFiniteCheckAndUnscaleKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/AmpForeachNonFiniteCheckAndUnscaleKernelNpuOpApi.cpp
@@ -47,7 +47,7 @@ static bool amp_foreach_non_finite_check(at::TensorList& scaled_grads) {
   uint64_t buff_size = 64;
   void* host_mem_out = nullptr;
   void* device_mem_out = nullptr;
-  aclrtStream aclStream = c10::npu::getCurrentNPUStream().stream();
+  aclrtStream aclStream = c10::backend::getCurrentNPUStream().stream();
 
   aclError err = aclrtMallocHost((void**)&host_mem_out, buff_size);
   NON_FINITE_CHECK_RESULT_ESTIMATE(

--- a/npu/aten/ops/base/opapi/BernoulliKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/BernoulliKernelNpuOpApi.cpp
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <climits>
 #include <ATen/NamedTensorUtils.h>
+#include <climits>
 #include "npu/aten/AclOpsInterface.h"
 #include "npu/aten/OpApiInterface.h"
 #include "npu/aten/utils/op_api_common.h"
@@ -25,9 +25,13 @@ static const uint64_t PHILOX_DEFAULT_NUM = 10;
 
 using npu_preparation = at_npu::native::OpPreparation;
 
-at::Tensor& bernoulli_(at::Tensor& self, double p, c10::optional<at::Generator> gen) {
+at::Tensor& bernoulli_(
+    at::Tensor& self,
+    double p,
+    c10::optional<at::Generator> gen) {
   DO_COMPATIBILITY(aclnnInplaceBernoulli, acl_op::bernoulli_(self, p, gen));
-  auto gen_ = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen, at_npu::detail::getDefaultNPUGenerator());
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen_->philox_engine_inputs(PHILOX_DEFAULT_NUM);
   const uint64_t seed = pair.first;
   const uint64_t offset = pair.second;
@@ -37,9 +41,14 @@ at::Tensor& bernoulli_(at::Tensor& self, double p, c10::optional<at::Generator> 
   return self;
 }
 
-at::Tensor& bernoulli_(at::Tensor& self, const at::Tensor& p, c10::optional<at::Generator> gen) {
-  DO_COMPATIBILITY(aclnnInplaceBernoulliTensor, acl_op::bernoulli_(self, p, gen));
-  auto gen_ = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen, at_npu::detail::getDefaultNPUGenerator());
+at::Tensor& bernoulli_(
+    at::Tensor& self,
+    const at::Tensor& p,
+    c10::optional<at::Generator> gen) {
+  DO_COMPATIBILITY(
+      aclnnInplaceBernoulliTensor, acl_op::bernoulli_(self, p, gen));
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen_->philox_engine_inputs(PHILOX_DEFAULT_NUM);
   const uint64_t seed = pair.first;
   const uint64_t offset = pair.second;
@@ -53,15 +62,23 @@ at::Tensor bernoulli(const at::Tensor& self, c10::optional<at::Generator> gen) {
   return op_api::bernoulli_(self_copy, self, gen);
 }
 
-at::Tensor bernoulli(const at::Tensor& self, double p, c10::optional<at::Generator> gen) {
+at::Tensor bernoulli(
+    const at::Tensor& self,
+    double p,
+    c10::optional<at::Generator> gen) {
   DO_COMPATIBILITY(aclnnInplaceBernoulli, acl_op::bernoulli(self, p, gen));
-  return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT).bernoulli_(p, gen);
+  return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT)
+      .bernoulli_(p, gen);
 }
 
-at::Tensor& bernoulli_out(const at::Tensor& self, c10::optional<at::Generator> gen, at::Tensor& result) {
-  DO_COMPATIBILITY(aclnnInplaceBernoulliTensor, acl_op::bernoulli_out(self, gen, result));
+at::Tensor& bernoulli_out(
+    const at::Tensor& self,
+    c10::optional<at::Generator> gen,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(
+      aclnnInplaceBernoulliTensor, acl_op::bernoulli_out(self, gen, result));
   result.resize_(self.sizes()).bernoulli_(self, gen);
   at::namedinference::propagate_names(result, self);
   return result;
 }
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/base/opapi/MultiHeadAttentionV2KernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/MultiHeadAttentionV2KernelNpuOpApi.cpp
@@ -14,108 +14,134 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "npu/framework/utils/RandomOpAdapter.h"
 #include "csrc/aten/generated/CustomFunctions.h"
 #include "npu/aten/OpApiInterface.h"
 #include "npu/aten/utils/op_api_common.h"
+#include "npu/framework/utils/RandomOpAdapter.h"
 
 namespace op_api {
 using namespace at_npu::native;
 
-enum class DropOutStatus {
-    DROPOUT_NORMAL = 0,
-    DROPOUT_NONE,
-    DROPOUT_ALL
-};
+enum class DropOutStatus { DROPOUT_NORMAL = 0, DROPOUT_NONE, DROPOUT_ALL };
 
 namespace {
-DropOutStatus get_status(double keep_prob)
-{
-    if (keep_prob == 0) {
-        return DropOutStatus::DROPOUT_ALL;
-    }
-    if (keep_prob == 1.) {
-        return DropOutStatus::DROPOUT_NONE;
-    }
-    return DropOutStatus::DROPOUT_NORMAL;
+DropOutStatus get_status(double keep_prob) {
+  if (keep_prob == 0) {
+    return DropOutStatus::DROPOUT_ALL;
+  }
+  if (keep_prob == 1.) {
+    return DropOutStatus::DROPOUT_NONE;
+  }
+  return DropOutStatus::DROPOUT_NORMAL;
 }
 
-at::Tensor tensor_format_trans(const at::Tensor &at_tensor)
-{
-    if (at_tensor.defined()) {
-        TORCH_CHECK(torch_backend::utils::is_npu(at_tensor), "only npu tensor is supported", OPS_ERROR(ErrCode::PARAM));
-        return custom_ops::npu_format_cast(at_tensor, ACL_FORMAT_ND);
-    }
-    return at_tensor;
+at::Tensor tensor_format_trans(const at::Tensor& at_tensor) {
+  if (at_tensor.defined()) {
+    TORCH_CHECK(
+        torch_backend::utils::is_npu(at_tensor),
+        "only npu tensor is supported",
+        OPS_ERROR(ErrCode::PARAM));
+    return custom_ops::npu_format_cast(at_tensor, ACL_FORMAT_ND);
+  }
+  return at_tensor;
 }
 
-at::Tensor gen_mask_impl(const at::Tensor &self, const at::Scalar &keep_prob, const at::Scalar &seed,
-    const int64_t offset, const int64_t numels)
-{
-    int64_t length = (numels + 256 - 1) / 256 * 256 / 8;
-    c10::TensorOptions options = self.options();
-    at::Tensor mask = OpPreparation::apply_tensor_without_format(at::IntArrayRef{length + 32}, options.dtype(at::kByte));
-    at::SmallVector<int64_t, ::N> offsetList = {0, offset};
-    const int64_t seed1 = 0;
-    OpCommand cmd;
-    cmd.Name("StatelessDropOutGenMask")
-        .Input(at::IntArrayRef{numels})
-        .Input(keep_prob, self.scalar_type(), CompileType::MEMORY_HOST_COMPILE_DEPENDENT)
-        .Input(seed, at::ScalarType::Int)
-        .Input(at::Scalar(seed1), at::ScalarType::Int)
-        .Input(offsetList, at::kLong, CompileType::MEMORY_HOST_COMPILE_INDEPENDENT)
-        .Output(mask)
-        .Run();
-    return mask;
+at::Tensor gen_mask_impl(
+    const at::Tensor& self,
+    const at::Scalar& keep_prob,
+    const at::Scalar& seed,
+    const int64_t offset,
+    const int64_t numels) {
+  int64_t length = (numels + 256 - 1) / 256 * 256 / 8;
+  c10::TensorOptions options = self.options();
+  at::Tensor mask = OpPreparation::apply_tensor_without_format(
+      at::IntArrayRef{length + 32}, options.dtype(at::kByte));
+  at::SmallVector<int64_t, ::N> offsetList = {0, offset};
+  const int64_t seed1 = 0;
+  OpCommand cmd;
+  cmd.Name("StatelessDropOutGenMask")
+      .Input(at::IntArrayRef{numels})
+      .Input(
+          keep_prob,
+          self.scalar_type(),
+          CompileType::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(seed, at::ScalarType::Int)
+      .Input(at::Scalar(seed1), at::ScalarType::Int)
+      .Input(
+          offsetList, at::kLong, CompileType::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Output(mask)
+      .Run();
+  return mask;
 }
 
-at::Tensor gen_mask_dispatch(const at::Tensor &self, const at::Scalar &keep_prob, const at::Scalar &seed,
-    const int64_t offset, const int64_t numels, const bool gen_mask_parallel, const bool sync)
-{
-    at::Tensor mask;
+at::Tensor gen_mask_dispatch(
+    const at::Tensor& self,
+    const at::Scalar& keep_prob,
+    const at::Scalar& seed,
+    const int64_t offset,
+    const int64_t numels,
+    const bool gen_mask_parallel,
+    const bool sync) {
+  at::Tensor mask;
 
-    mask = gen_mask_impl(self, keep_prob, seed, offset, numels);
-    return mask;
+  mask = gen_mask_impl(self, keep_prob, seed, offset, numels);
+  return mask;
 }
 
-at::Tensor gen_mask(const at::Tensor &self, double keep_prob,
-    int64_t head_num, std::string input_layout, bool gen_mask_parallel, bool sync,
-    int64_t &seed, int64_t &offset, int64_t &numels)
-{
-    at::Tensor drop_mask;
-    if (input_layout == "BSH") {
-        numels = self.size(0) * head_num * self.size(1) * self.size(1); // [B,N,S,S]
-    } else if (input_layout == "SBH") {
-        numels = self.size(1) * head_num * self.size(0) * self.size(0); // [B,N,S,S]
-    } else if (input_layout == "BNSD") {
-        numels = self.size(0) * self.size(1) * self.size(2) * self.size(2); // [B,N,S,S]
-    }
-    int64_t length = (numels + 256 - 1) / 256 * 256 / 8;
-    length += 32;
-    if (get_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
-        const auto gen = at_npu::detail::getDefaultNPUGenerator();
-        auto pair = at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(10);
-        seed = static_cast<int64_t>(pair.first);
-        offset = static_cast<int64_t>(pair.second);
-        drop_mask = gen_mask_dispatch(self, at::Scalar(keep_prob), at::Scalar(seed),
-            offset, numels, gen_mask_parallel, sync);
-    } else if (get_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
-        drop_mask = at::zeros(at::IntArrayRef{length}, self.options().dtype(at::kByte));
-    }
-    return drop_mask;
+at::Tensor gen_mask(
+    const at::Tensor& self,
+    double keep_prob,
+    int64_t head_num,
+    std::string input_layout,
+    bool gen_mask_parallel,
+    bool sync,
+    int64_t& seed,
+    int64_t& offset,
+    int64_t& numels) {
+  at::Tensor drop_mask;
+  if (input_layout == "BSH") {
+    numels = self.size(0) * head_num * self.size(1) * self.size(1); // [B,N,S,S]
+  } else if (input_layout == "SBH") {
+    numels = self.size(1) * head_num * self.size(0) * self.size(0); // [B,N,S,S]
+  } else if (input_layout == "BNSD") {
+    numels =
+        self.size(0) * self.size(1) * self.size(2) * self.size(2); // [B,N,S,S]
+  }
+  int64_t length = (numels + 256 - 1) / 256 * 256 / 8;
+  length += 32;
+  if (get_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
+    const auto gen = c10::backend::detail::getDefaultNPUGenerator();
+    auto pair = at::check_generator<c10::backend::NPUGeneratorImpl>(gen)
+                    ->philox_engine_inputs(10);
+    seed = static_cast<int64_t>(pair.first);
+    offset = static_cast<int64_t>(pair.second);
+    drop_mask = gen_mask_dispatch(
+        self,
+        at::Scalar(keep_prob),
+        at::Scalar(seed),
+        offset,
+        numels,
+        gen_mask_parallel,
+        sync);
+  } else if (get_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
+    drop_mask =
+        at::zeros(at::IntArrayRef{length}, self.options().dtype(at::kByte));
+  }
+  return drop_mask;
 }
 } // namespace
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_multi_head_attention_v2_backward(
-    const at::Tensor &attention_score_grad,
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const at::Tensor &softmax_log_max_sum,
-    const at::Tensor &attention_score,
-    const c10::optional<at::Tensor> &atten_mask,
-    const c10::optional<at::Tensor> &alibi_mask,
-    const c10::optional<at::Tensor> &drop_mask,
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+npu_multi_head_attention_v2_backward(
+    const at::Tensor& attention_score_grad,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& softmax_log_max_sum,
+    const at::Tensor& attention_score,
+    const c10::optional<at::Tensor>& atten_mask,
+    const c10::optional<at::Tensor>& alibi_mask,
+    const c10::optional<at::Tensor>& drop_mask,
     double scale_value,
     int64_t head_num,
     const std::string input_layout,
@@ -123,51 +149,66 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_multi_head_attention_v2_backw
     int64_t pre_tokens,
     int64_t next_tokens,
     bool gen_mask_parallel,
-    bool sync)
-{
-    const at::Tensor &drop_mask_const = drop_mask.value_or(at::Tensor());
-    at::Tensor format_drop_mask = tensor_format_trans(drop_mask_const);
+    bool sync) {
+  const at::Tensor& drop_mask_const = drop_mask.value_or(at::Tensor());
+  at::Tensor format_drop_mask = tensor_format_trans(drop_mask_const);
 
-    at::Tensor format_attention_score_grad = tensor_format_trans(attention_score_grad);
-    at::Tensor format_query = tensor_format_trans(query);
-    at::Tensor format_key = tensor_format_trans(key);
-    at::Tensor format_value = tensor_format_trans(value);
-    at::Tensor format_softmax_log_max_sum = tensor_format_trans(softmax_log_max_sum);
-    at::Tensor format_attention_score = tensor_format_trans(attention_score);
+  at::Tensor format_attention_score_grad =
+      tensor_format_trans(attention_score_grad);
+  at::Tensor format_query = tensor_format_trans(query);
+  at::Tensor format_key = tensor_format_trans(key);
+  at::Tensor format_value = tensor_format_trans(value);
+  at::Tensor format_softmax_log_max_sum =
+      tensor_format_trans(softmax_log_max_sum);
+  at::Tensor format_attention_score = tensor_format_trans(attention_score);
 
-    const at::Tensor &atten_mask_const = atten_mask.value_or(at::Tensor());
-    at::Tensor format_atten_mask = tensor_format_trans(atten_mask_const);
-    const at::Tensor &alibi_mask_const = alibi_mask.value_or(at::Tensor());
-    at::Tensor format_alibi_mask = tensor_format_trans(alibi_mask_const);
+  const at::Tensor& atten_mask_const = atten_mask.value_or(at::Tensor());
+  at::Tensor format_atten_mask = tensor_format_trans(atten_mask_const);
+  const at::Tensor& alibi_mask_const = alibi_mask.value_or(at::Tensor());
+  at::Tensor format_alibi_mask = tensor_format_trans(alibi_mask_const);
 
-    at::Tensor query_grad;
-    at::Tensor key_grad;
-    at::Tensor value_grad;
+  at::Tensor query_grad;
+  at::Tensor key_grad;
+  at::Tensor value_grad;
 
-    query_grad = OpPreparation::apply_tensor_without_format(format_query);
-    key_grad = OpPreparation::apply_tensor_without_format(format_key);
-    value_grad = OpPreparation::apply_tensor_without_format(format_value);
+  query_grad = OpPreparation::apply_tensor_without_format(format_query);
+  key_grad = OpPreparation::apply_tensor_without_format(format_key);
+  value_grad = OpPreparation::apply_tensor_without_format(format_value);
 
-    char* input_layout_ptr = const_cast<char *>(input_layout.c_str());
-    EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnnAscendFlashAttentionGrad,
-                                 format_query, format_key, format_value,
-                                 format_softmax_log_max_sum, format_attention_score, format_attention_score_grad,
-                                 format_atten_mask, format_alibi_mask, format_drop_mask,
-                                 scale_value, head_num, input_layout_ptr, keep_prob, pre_tokens, next_tokens,
-                                 query_grad, key_grad, value_grad);
+  char* input_layout_ptr = const_cast<char*>(input_layout.c_str());
+  EXEC_NPU_NO_FORMAT_CHECK_CMD(
+      aclnnAscendFlashAttentionGrad,
+      format_query,
+      format_key,
+      format_value,
+      format_softmax_log_max_sum,
+      format_attention_score,
+      format_attention_score_grad,
+      format_atten_mask,
+      format_alibi_mask,
+      format_drop_mask,
+      scale_value,
+      head_num,
+      input_layout_ptr,
+      keep_prob,
+      pre_tokens,
+      next_tokens,
+      query_grad,
+      key_grad,
+      value_grad);
 
-    return std::make_tuple(query_grad, key_grad, value_grad);
+  return std::make_tuple(query_grad, key_grad, value_grad);
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_multi_head_attention_v2_grad(
-    const at::Tensor &attention_score_grad,
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const at::Tensor &softmax_log_max_sum,
-    const at::Tensor &attention_score,
-    const c10::optional<at::Tensor> &atten_mask,
-    const c10::optional<at::Tensor> &alibi_mask,
+    const at::Tensor& attention_score_grad,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& softmax_log_max_sum,
+    const at::Tensor& attention_score,
+    const c10::optional<at::Tensor>& atten_mask,
+    const c10::optional<at::Tensor>& alibi_mask,
     double scale,
     int64_t head_num,
     c10::string_view input_layout,
@@ -178,40 +219,67 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_multi_head_attention_v2_grad(
     int64_t offset,
     int64_t numels,
     bool gen_mask_parallel,
-    bool sync)
-{
-    TORCH_CHECK(keep_prob >= 0 && keep_prob <= 1,
-        "The keep_prob value must be in range of [0, 1], but got ", keep_prob, OPS_ERROR(ErrCode::VALUE));
+    bool sync) {
+  TORCH_CHECK(
+      keep_prob >= 0 && keep_prob <= 1,
+      "The keep_prob value must be in range of [0, 1], but got ",
+      keep_prob,
+      OPS_ERROR(ErrCode::VALUE));
 
-    std::string input_layout_str = std::string(input_layout);
-    TORCH_CHECK(input_layout_str == "BSH" || input_layout_str == "SBH" || input_layout_str == "BNSD",
-        "The input_layout should be BSH/SBH/BNSD(case-insensitive), but got ", input_layout, OPS_ERROR(ErrCode::PARAM));
+  std::string input_layout_str = std::string(input_layout);
+  TORCH_CHECK(
+      input_layout_str == "BSH" || input_layout_str == "SBH" ||
+          input_layout_str == "BNSD",
+      "The input_layout should be BSH/SBH/BNSD(case-insensitive), but got ",
+      input_layout,
+      OPS_ERROR(ErrCode::PARAM));
 
-    int64_t length = (numels + 256 - 1) / 256 * 256 / 8;
-    length += 32;
-    at::Tensor drop_mask;
-    if (get_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
-        drop_mask = gen_mask_dispatch(query, at::Scalar(keep_prob), at::Scalar(seed), offset, numels,
-                                      gen_mask_parallel, sync);
-    } else if (get_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
-        drop_mask = at::zeros(at::IntArrayRef{length}, query.options().dtype(at::kByte));
-    }
+  int64_t length = (numels + 256 - 1) / 256 * 256 / 8;
+  length += 32;
+  at::Tensor drop_mask;
+  if (get_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
+    drop_mask = gen_mask_dispatch(
+        query,
+        at::Scalar(keep_prob),
+        at::Scalar(seed),
+        offset,
+        numels,
+        gen_mask_parallel,
+        sync);
+  } else if (get_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
+    drop_mask =
+        at::zeros(at::IntArrayRef{length}, query.options().dtype(at::kByte));
+  }
 
-    auto results = npu_multi_head_attention_v2_backward(attention_score_grad, query, key, value,
-                                                        softmax_log_max_sum, attention_score,
-                                                        atten_mask, alibi_mask, drop_mask,
-                                                        scale, head_num, input_layout_str, keep_prob,
-                                                        pre_tokens, next_tokens, gen_mask_parallel, sync);
+  auto results = npu_multi_head_attention_v2_backward(
+      attention_score_grad,
+      query,
+      key,
+      value,
+      softmax_log_max_sum,
+      attention_score,
+      atten_mask,
+      alibi_mask,
+      drop_mask,
+      scale,
+      head_num,
+      input_layout_str,
+      keep_prob,
+      pre_tokens,
+      next_tokens,
+      gen_mask_parallel,
+      sync);
 
-    return results;
+  return results;
 }
 
-std::tuple<at::Tensor, at::Tensor, int64_t, int64_t, int64_t> npu_multi_head_attention_v2(
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const c10::optional<at::Tensor> &atten_mask_opt,
-    const c10::optional<at::Tensor> &alibi_mask_opt,
+std::tuple<at::Tensor, at::Tensor, int64_t, int64_t, int64_t>
+npu_multi_head_attention_v2(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const c10::optional<at::Tensor>& atten_mask_opt,
+    const c10::optional<at::Tensor>& alibi_mask_opt,
     double scale,
     int64_t head_num,
     c10::string_view input_layout,
@@ -219,54 +287,82 @@ std::tuple<at::Tensor, at::Tensor, int64_t, int64_t, int64_t> npu_multi_head_att
     int64_t pre_tokens,
     int64_t next_tokens,
     bool gen_mask_parallel,
-    bool sync)
-{
-    const at::Tensor &atten_mask = atten_mask_opt.value_or(at::Tensor());
-    const at::Tensor &alibi_mask = alibi_mask_opt.value_or(at::Tensor());
+    bool sync) {
+  const at::Tensor& atten_mask = atten_mask_opt.value_or(at::Tensor());
+  const at::Tensor& alibi_mask = alibi_mask_opt.value_or(at::Tensor());
 
-    TORCH_CHECK(keep_prob >= 0 && keep_prob <= 1,
-        "The keep_prob value must be in range of [0, 1], but got ", keep_prob, OPS_ERROR(ErrCode::VALUE));
+  TORCH_CHECK(
+      keep_prob >= 0 && keep_prob <= 1,
+      "The keep_prob value must be in range of [0, 1], but got ",
+      keep_prob,
+      OPS_ERROR(ErrCode::VALUE));
 
-    std::string input_layout_str = std::string(input_layout);
-    TORCH_CHECK(input_layout_str == "BSH" || input_layout_str == "SBH" || input_layout_str == "BNSD",
-        "The input_layout should be BSH/SBH/BNSD(case-insensitive), but got ", input_layout, OPS_ERROR(ErrCode::PARAM));
-    char* input_layout_ptr = const_cast<char *>(input_layout_str.c_str());
+  std::string input_layout_str = std::string(input_layout);
+  TORCH_CHECK(
+      input_layout_str == "BSH" || input_layout_str == "SBH" ||
+          input_layout_str == "BNSD",
+      "The input_layout should be BSH/SBH/BNSD(case-insensitive), but got ",
+      input_layout,
+      OPS_ERROR(ErrCode::PARAM));
+  char* input_layout_ptr = const_cast<char*>(input_layout_str.c_str());
 
-    int64_t seed;
-    int64_t offset;
-    int64_t numels;
+  int64_t seed;
+  int64_t offset;
+  int64_t numels;
 
-    at::Tensor drop_mask = gen_mask(query, keep_prob, head_num, input_layout_str,
-                                    gen_mask_parallel, sync, seed, offset, numels);
+  at::Tensor drop_mask = gen_mask(
+      query,
+      keep_prob,
+      head_num,
+      input_layout_str,
+      gen_mask_parallel,
+      sync,
+      seed,
+      offset,
+      numels);
 
-    at::Tensor format_drop_mask = tensor_format_trans(drop_mask);
-    at::Tensor format_query = tensor_format_trans(query);
-    at::Tensor format_key = tensor_format_trans(key);
-    at::Tensor format_value = tensor_format_trans(value);
-    at::Tensor format_atten_mask = tensor_format_trans(atten_mask);
-    at::Tensor format_alibi_mask = tensor_format_trans(alibi_mask);
+  at::Tensor format_drop_mask = tensor_format_trans(drop_mask);
+  at::Tensor format_query = tensor_format_trans(query);
+  at::Tensor format_key = tensor_format_trans(key);
+  at::Tensor format_value = tensor_format_trans(value);
+  at::Tensor format_atten_mask = tensor_format_trans(atten_mask);
+  at::Tensor format_alibi_mask = tensor_format_trans(alibi_mask);
 
-    int64_t B = 0;
-    int64_t S = 0;
-    if (input_layout == "BSH") {
-        B = query.size(0);
-        S = query.size(1);
-    } else if (input_layout == "SBH") {
-        B = query.size(1);
-        S = query.size(0);
-    } else if (input_layout == "BNSD") {
-        B = query.size(0);
-        S = query.size(2);
-    }
-    at::Tensor softmax_log_max_sum = OpPreparation::apply_tensor_without_format({B, head_num, S},
-                                                                                query.options().dtype(at::kFloat));
-    at::Tensor attention_score = OpPreparation::apply_tensor_without_format(query);
+  int64_t B = 0;
+  int64_t S = 0;
+  if (input_layout == "BSH") {
+    B = query.size(0);
+    S = query.size(1);
+  } else if (input_layout == "SBH") {
+    B = query.size(1);
+    S = query.size(0);
+  } else if (input_layout == "BNSD") {
+    B = query.size(0);
+    S = query.size(2);
+  }
+  at::Tensor softmax_log_max_sum = OpPreparation::apply_tensor_without_format(
+      {B, head_num, S}, query.options().dtype(at::kFloat));
+  at::Tensor attention_score =
+      OpPreparation::apply_tensor_without_format(query);
 
-    EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnnAscendFlashAttention,
-                                 format_query, format_key, format_value, format_atten_mask, format_alibi_mask,
-                                 format_drop_mask, scale, head_num, input_layout_ptr, keep_prob, pre_tokens,
-                                 next_tokens, softmax_log_max_sum, attention_score);
+  EXEC_NPU_NO_FORMAT_CHECK_CMD(
+      aclnnAscendFlashAttention,
+      format_query,
+      format_key,
+      format_value,
+      format_atten_mask,
+      format_alibi_mask,
+      format_drop_mask,
+      scale,
+      head_num,
+      input_layout_ptr,
+      keep_prob,
+      pre_tokens,
+      next_tokens,
+      softmax_log_max_sum,
+      attention_score);
 
-    return std::make_tuple(attention_score, softmax_log_max_sum, seed, offset, numels);
+  return std::make_tuple(
+      attention_score, softmax_log_max_sum, seed, offset, numels);
 }
 } // namespace op_api

--- a/npu/aten/ops/base/opapi/NativeDropoutKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/NativeDropoutKernelNpuOpApi.cpp
@@ -36,7 +36,7 @@ std::tuple<at::Tensor, at::Tensor> _npu_dropout(
       at_npu::native::OpPreparation::apply_tensor_without_format(self);
   at::Tensor mask;
 
-  auto original_stream = c10::npu::getCurrentNPUStream();
+  auto original_stream = c10::backend::getCurrentNPUStream();
   mask = at_npu::native::OpPreparation::apply_tensor_without_format(
       {length}, self.options().dtype(at::kByte));
   at::IntArrayRef shapeArray(self.sizes());

--- a/npu/aten/ops/base/opapi/NativeDropoutKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/NativeDropoutKernelNpuOpApi.cpp
@@ -46,10 +46,9 @@ std::tuple<at::Tensor, at::Tensor> _npu_dropout(
   // 127~64   63~0
   // so, we set seed1 = 0 to ensure the seed which user set is equal to the seed
   // used by the operator DropOutGenMask
-  const auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto pair =
-      at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(
-          10);
+  const auto gen = c10::backend::detail::getDefaultNPUGenerator();
+  auto pair = at::check_generator<c10::backend::NPUGeneratorImpl>(gen)
+                  ->philox_engine_inputs(10);
   // At present, the default value of random number may be very large,
   // which will cause overflow in graph mode, so we set seed = 0 to avoid it.
   const uint64_t seed = pair.first;

--- a/npu/aten/ops/base/opapi/NormalKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/NormalKernelNpuOpApi.cpp
@@ -22,30 +22,44 @@
 namespace op_api {
 using npu_preparation = at_npu::native::OpPreparation;
 
-at::Tensor& normal_(at::Tensor& self, double mean, double std, c10::optional<at::Generator> generator)
-{
-    DO_COMPATIBILITY(aclnnInplaceNormal, acl_op::normal_(self, mean, std, generator));
-    TORCH_CHECK(std >= 0.0, "normal_ expects std >= 0.0, but found std=", std, OPS_ERROR(ErrCode::VALUE));
-    npu_preparation::check_tensor({}, self, self, self.sizes());
-    auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                      at_npu::detail::getDefaultNPUGenerator());
-    auto pair = gen->philox_engine_inputs(10);
-    const int64_t seed = static_cast<int64_t>(pair.first);
-    const int64_t offset = static_cast<int64_t>(pair.second);
-    float mean_cast = static_cast<float>(mean);
-    float rstd_cast = static_cast<float>(std);
-    EXEC_NPU_CMD(aclnnInplaceNormal, self, mean_cast, rstd_cast, seed, offset);
-    return self;
+at::Tensor& normal_(
+    at::Tensor& self,
+    double mean,
+    double std,
+    c10::optional<at::Generator> generator) {
+  DO_COMPATIBILITY(
+      aclnnInplaceNormal, acl_op::normal_(self, mean, std, generator));
+  TORCH_CHECK(
+      std >= 0.0,
+      "normal_ expects std >= 0.0, but found std=",
+      std,
+      OPS_ERROR(ErrCode::VALUE));
+  npu_preparation::check_tensor({}, self, self, self.sizes());
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
+  auto pair = gen->philox_engine_inputs(10);
+  const int64_t seed = static_cast<int64_t>(pair.first);
+  const int64_t offset = static_cast<int64_t>(pair.second);
+  float mean_cast = static_cast<float>(mean);
+  float rstd_cast = static_cast<float>(std);
+  EXEC_NPU_CMD(aclnnInplaceNormal, self, mean_cast, rstd_cast, seed, offset);
+  return self;
 }
 
 /* TensorTensor */
-at::Tensor& normal_out(const at::Tensor &mean, const at::Tensor &std, c10::optional<at::Generator> generator,
-                       at::Tensor &result) {
-  DO_COMPATIBILITY(aclnnNormalTensorTensor, acl_op::normal_out(mean, std, generator, result));
-  at::SmallVector<int64_t, SIZE> output_size = op_infer::broadcast_ops_npu_output_size(mean, std);
+at::Tensor& normal_out(
+    const at::Tensor& mean,
+    const at::Tensor& std,
+    c10::optional<at::Generator> generator,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(
+      aclnnNormalTensorTensor,
+      acl_op::normal_out(mean, std, generator, result));
+  at::SmallVector<int64_t, SIZE> output_size =
+      op_infer::broadcast_ops_npu_output_size(mean, std);
   npu_preparation::check_tensor({mean, std}, result, result, output_size);
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                    at_npu::detail::getDefaultNPUGenerator());
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
@@ -53,12 +67,18 @@ at::Tensor& normal_out(const at::Tensor &mean, const at::Tensor &std, c10::optio
   return result;
 }
 
-at::Tensor normal(const at::Tensor &mean, const at::Tensor &std, c10::optional<at::Generator> generator) {
-  DO_COMPATIBILITY(aclnnNormalTensorTensor, acl_op::normal(mean, std, generator));
-  at::SmallVector<int64_t, SIZE> output_size = op_infer::broadcast_ops_npu_output_size(mean, std);
-  at::Tensor result = npu_preparation::apply_tensor_without_format(mean, output_size);
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                    at_npu::detail::getDefaultNPUGenerator());
+at::Tensor normal(
+    const at::Tensor& mean,
+    const at::Tensor& std,
+    c10::optional<at::Generator> generator) {
+  DO_COMPATIBILITY(
+      aclnnNormalTensorTensor, acl_op::normal(mean, std, generator));
+  at::SmallVector<int64_t, SIZE> output_size =
+      op_infer::broadcast_ops_npu_output_size(mean, std);
+  at::Tensor result =
+      npu_preparation::apply_tensor_without_format(mean, output_size);
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
@@ -67,44 +87,62 @@ at::Tensor normal(const at::Tensor &mean, const at::Tensor &std, c10::optional<a
 }
 
 /* TensorFloat */
-at::Tensor& normal_out(const at::Tensor &mean, double std, c10::optional<at::Generator> generator,
-                       at::Tensor &result)
-{
-    DO_COMPATIBILITY(aclnnNormalTensorFloat, acl_op::normal_out(mean, std, generator, result));
-    TORCH_CHECK(std >= 0.0, "normal_ expects std >= 0.0, but found std=", std, OPS_ERROR(ErrCode::VALUE));
-    npu_preparation::check_tensor({mean}, result, result);
-    auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                      at_npu::detail::getDefaultNPUGenerator());
-    auto pair = gen->philox_engine_inputs(10);
-    const int64_t seed = static_cast<int64_t>(pair.first);
-    const int64_t offset = static_cast<int64_t>(pair.second);
-    float rstd_cast = static_cast<float>(std);
-    EXEC_NPU_CMD(aclnnNormalTensorFloat, mean, rstd_cast, seed, offset, result);
-    return result;
+at::Tensor& normal_out(
+    const at::Tensor& mean,
+    double std,
+    c10::optional<at::Generator> generator,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(
+      aclnnNormalTensorFloat, acl_op::normal_out(mean, std, generator, result));
+  TORCH_CHECK(
+      std >= 0.0,
+      "normal_ expects std >= 0.0, but found std=",
+      std,
+      OPS_ERROR(ErrCode::VALUE));
+  npu_preparation::check_tensor({mean}, result, result);
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
+  auto pair = gen->philox_engine_inputs(10);
+  const int64_t seed = static_cast<int64_t>(pair.first);
+  const int64_t offset = static_cast<int64_t>(pair.second);
+  float rstd_cast = static_cast<float>(std);
+  EXEC_NPU_CMD(aclnnNormalTensorFloat, mean, rstd_cast, seed, offset, result);
+  return result;
 }
 
-at::Tensor normal(const at::Tensor &mean, double std, c10::optional<at::Generator> generator)
-{
-    DO_COMPATIBILITY(aclnnNormalTensorFloat, acl_op::normal(mean, std, generator));
-    TORCH_CHECK(std >= 0.0, "normal_ expects std >= 0.0, but found std=", std, OPS_ERROR(ErrCode::VALUE));
-    at::Tensor result = npu_preparation::apply_tensor_without_format(mean);
-    auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                      at_npu::detail::getDefaultNPUGenerator());
-    auto pair = gen->philox_engine_inputs(10);
-    const int64_t seed = static_cast<int64_t>(pair.first);
-    const int64_t offset = static_cast<int64_t>(pair.second);
-    float rstd_cast = static_cast<float>(std);
-    EXEC_NPU_CMD(aclnnNormalTensorFloat, mean, rstd_cast, seed, offset, result);
-    return result;
+at::Tensor normal(
+    const at::Tensor& mean,
+    double std,
+    c10::optional<at::Generator> generator) {
+  DO_COMPATIBILITY(
+      aclnnNormalTensorFloat, acl_op::normal(mean, std, generator));
+  TORCH_CHECK(
+      std >= 0.0,
+      "normal_ expects std >= 0.0, but found std=",
+      std,
+      OPS_ERROR(ErrCode::VALUE));
+  at::Tensor result = npu_preparation::apply_tensor_without_format(mean);
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
+  auto pair = gen->philox_engine_inputs(10);
+  const int64_t seed = static_cast<int64_t>(pair.first);
+  const int64_t offset = static_cast<int64_t>(pair.second);
+  float rstd_cast = static_cast<float>(std);
+  EXEC_NPU_CMD(aclnnNormalTensorFloat, mean, rstd_cast, seed, offset, result);
+  return result;
 }
 
 /* FloatTensor */
-at::Tensor& normal_out(double mean, const at::Tensor &std, c10::optional<at::Generator> generator,
-                       at::Tensor &result) {
-  DO_COMPATIBILITY(aclnnNormalFloatTensor, acl_op::normal_out(mean, std, generator, result));
+at::Tensor& normal_out(
+    double mean,
+    const at::Tensor& std,
+    c10::optional<at::Generator> generator,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(
+      aclnnNormalFloatTensor, acl_op::normal_out(mean, std, generator, result));
   npu_preparation::check_tensor({std}, result, result);
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                    at_npu::detail::getDefaultNPUGenerator());
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
@@ -113,11 +151,15 @@ at::Tensor& normal_out(double mean, const at::Tensor &std, c10::optional<at::Gen
   return result;
 }
 
-at::Tensor normal(double mean, const at::Tensor &std, c10::optional<at::Generator> generator) {
-  DO_COMPATIBILITY(aclnnNormalFloatTensor, acl_op::normal(mean, std, generator));
+at::Tensor normal(
+    double mean,
+    const at::Tensor& std,
+    c10::optional<at::Generator> generator) {
+  DO_COMPATIBILITY(
+      aclnnNormalFloatTensor, acl_op::normal(mean, std, generator));
   at::Tensor result = npu_preparation::apply_tensor_without_format(std);
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                    at_npu::detail::getDefaultNPUGenerator());
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
@@ -127,46 +169,70 @@ at::Tensor normal(double mean, const at::Tensor &std, c10::optional<at::Generato
 }
 
 /* FloatFloat */
-at::Tensor& normal_out(double mean, double std, at::IntArrayRef size,
-                       c10::optional<at::Generator> generator, at::Tensor &result)
-{
-    DO_COMPATIBILITY(aclnnNormalFloatFloat, acl_op::normal_out(mean, std, size, generator, result));
-    TORCH_CHECK(std >= 0.0, "normal_ expects std >= 0.0, but found std=", std, OPS_ERROR(ErrCode::VALUE));
-    npu_preparation::check_tensor({}, result, result, size);
-    auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                      at_npu::detail::getDefaultNPUGenerator());
-    auto pair = gen->philox_engine_inputs(10);
-    const int64_t seed = static_cast<int64_t>(pair.first);
-    const int64_t offset = static_cast<int64_t>(pair.second);
-    float mean_cast = static_cast<float>(mean);
-    float rstd_cast = static_cast<float>(std);
-    EXEC_NPU_CMD(aclnnNormalFloatFloat, mean_cast, rstd_cast, seed, offset, result);
-    return result;
-}
-
-at::Tensor normal(double mean, double std,
-                  at::IntArrayRef size,
-                  c10::optional<at::Generator> generator,
-                  c10::optional<at::ScalarType> dtype_opt,
-                  c10::optional<c10::Layout> layout_opt,
-                  c10::optional<c10::Device> device_opt,
-                  c10::optional<bool> pin_memory_opt) {
-  DO_COMPATIBILITY(aclnnNormalFloatFloat, acl_op::normal(mean, std, size, generator, dtype_opt,
-                                                                     layout_opt, device_opt, pin_memory_opt));
-  c10::TensorOptions option = c10::TensorOptions().dtype(dtype_opt)
-                                                  .device(device_opt)
-                                                  .layout(layout_opt)
-                                                  .pinned_memory(pin_memory_opt);
-  at::Tensor result = npu_preparation::apply_tensor_without_format(size, option);
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator,
-                                                                    at_npu::detail::getDefaultNPUGenerator());
+at::Tensor& normal_out(
+    double mean,
+    double std,
+    at::IntArrayRef size,
+    c10::optional<at::Generator> generator,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(
+      aclnnNormalFloatFloat,
+      acl_op::normal_out(mean, std, size, generator, result));
+  TORCH_CHECK(
+      std >= 0.0,
+      "normal_ expects std >= 0.0, but found std=",
+      std,
+      OPS_ERROR(ErrCode::VALUE));
+  npu_preparation::check_tensor({}, result, result, size);
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
   float mean_cast = static_cast<float>(mean);
   float rstd_cast = static_cast<float>(std);
-  EXEC_NPU_CMD(aclnnNormalFloatFloat, mean_cast, rstd_cast, seed, offset, result);
+  EXEC_NPU_CMD(
+      aclnnNormalFloatFloat, mean_cast, rstd_cast, seed, offset, result);
   return result;
 }
 
-}  // namespace op_api
+at::Tensor normal(
+    double mean,
+    double std,
+    at::IntArrayRef size,
+    c10::optional<at::Generator> generator,
+    c10::optional<at::ScalarType> dtype_opt,
+    c10::optional<c10::Layout> layout_opt,
+    c10::optional<c10::Device> device_opt,
+    c10::optional<bool> pin_memory_opt) {
+  DO_COMPATIBILITY(
+      aclnnNormalFloatFloat,
+      acl_op::normal(
+          mean,
+          std,
+          size,
+          generator,
+          dtype_opt,
+          layout_opt,
+          device_opt,
+          pin_memory_opt));
+  c10::TensorOptions option = c10::TensorOptions()
+                                  .dtype(dtype_opt)
+                                  .device(device_opt)
+                                  .layout(layout_opt)
+                                  .pinned_memory(pin_memory_opt);
+  at::Tensor result =
+      npu_preparation::apply_tensor_without_format(size, option);
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
+  auto pair = gen->philox_engine_inputs(10);
+  const int64_t seed = static_cast<int64_t>(pair.first);
+  const int64_t offset = static_cast<int64_t>(pair.second);
+  float mean_cast = static_cast<float>(mean);
+  float rstd_cast = static_cast<float>(std);
+  EXEC_NPU_CMD(
+      aclnnNormalFloatFloat, mean_cast, rstd_cast, seed, offset, result);
+  return result;
+}
+
+} // namespace op_api

--- a/npu/aten/ops/base/opapi/RReluWithNoiseKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/RReluWithNoiseKernelNpuOpApi.cpp
@@ -27,17 +27,27 @@ at::Tensor rrelu_with_noise(
     const at::Scalar& lower,
     const at::Scalar& upper,
     bool training,
-    c10::optional<at::Generator> generator)
-{
-  DO_COMPATIBILITY(aclnnRReluWithNoise, acl_op::rrelu_with_noise(self, noise, lower, upper, training, generator));
+    c10::optional<at::Generator> generator) {
+  DO_COMPATIBILITY(
+      aclnnRReluWithNoise,
+      acl_op::rrelu_with_noise(self, noise, lower, upper, training, generator));
   at::Tensor result = npu_preparation::apply_tensor_without_format(self);
-  auto gen_ =
-    at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator, at_npu::detail::getDefaultNPUGenerator());
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen_->philox_engine_inputs(1 << 28);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
 
-  EXEC_NPU_CMD(aclnnRReluWithNoise, self, noise, lower, upper, training, seed, offset, result);
+  EXEC_NPU_CMD(
+      aclnnRReluWithNoise,
+      self,
+      noise,
+      lower,
+      upper,
+      training,
+      seed,
+      offset,
+      result);
 
   return result;
 }
@@ -48,16 +58,25 @@ at::Tensor& rrelu_with_noise_(
     const at::Scalar& lower,
     const at::Scalar& upper,
     bool training,
-    c10::optional<at::Generator> generator)
-{
-  DO_COMPATIBILITY(aclnnInplaceRReluWithNoise,
-                   acl_op::rrelu_with_noise_(self, noise, lower, upper, training, generator));
-  auto gen_ =
-    at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator, at_npu::detail::getDefaultNPUGenerator());
+    c10::optional<at::Generator> generator) {
+  DO_COMPATIBILITY(
+      aclnnInplaceRReluWithNoise,
+      acl_op::rrelu_with_noise_(
+          self, noise, lower, upper, training, generator));
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen_->philox_engine_inputs(1 << 28);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
-  EXEC_NPU_CMD(aclnnInplaceRReluWithNoise, self, noise, lower, upper, training, seed, offset);
+  EXEC_NPU_CMD(
+      aclnnInplaceRReluWithNoise,
+      self,
+      noise,
+      lower,
+      upper,
+      training,
+      seed,
+      offset);
 
   return self;
 }
@@ -69,22 +88,29 @@ at::Tensor& rrelu_with_noise_out(
     const at::Scalar& upper,
     bool training,
     c10::optional<at::Generator> generator,
-    at::Tensor& output)
-{
-  DO_COMPATIBILITY(aclnnRReluWithNoise,
-                   acl_op::rrelu_with_noise_out(self, noise, lower, upper, training, generator, output));
-  npu_preparation::check_tensor(
-      {self, noise},
-      output,
-      self);
-  auto gen_ =
-    at::get_generator_or_default<at_npu::NPUGeneratorImpl>(generator, at_npu::detail::getDefaultNPUGenerator());
+    at::Tensor& output) {
+  DO_COMPATIBILITY(
+      aclnnRReluWithNoise,
+      acl_op::rrelu_with_noise_out(
+          self, noise, lower, upper, training, generator, output));
+  npu_preparation::check_tensor({self, noise}, output, self);
+  auto gen_ = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      generator, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen_->philox_engine_inputs(1 << 28);
   const int64_t seed = static_cast<int64_t>(pair.first);
   const int64_t offset = static_cast<int64_t>(pair.second);
-  EXEC_NPU_CMD(aclnnRReluWithNoise, self, noise, lower, upper, training, seed, offset, output);
+  EXEC_NPU_CMD(
+      aclnnRReluWithNoise,
+      self,
+      noise,
+      lower,
+      upper,
+      training,
+      seed,
+      offset,
+      output);
 
   return output;
 }
 
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/base/opapi/RandomKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/RandomKernelNpuOpApi.cpp
@@ -16,8 +16,8 @@
 
 #include "npu/aten/AclOpsInterface.h"
 #include "npu/aten/OpApiInterface.h"
-#include "npu/framework/utils/RandomOpAdapter.h"
 #include "npu/aten/utils/op_api_common.h"
+#include "npu/framework/utils/RandomOpAdapter.h"
 
 namespace op_api {
 
@@ -28,43 +28,57 @@ const int64_t RANDOM_HALF_MAX = 1LL << 11;
 const int64_t RANDOM_FLOAT_MAX = 1LL << 24;
 const int64_t RANDOM_BFLOAT16_MAX = 1LL << 8;
 
-}  // namespace
+} // namespace
 static std::map<at::ScalarType, int64_t> DTYPE_MAX_VALUE_MAP = {
-  {at::kHalf, RANDOM_HALF_MAX + 1},
-  {at::kFloat, RANDOM_FLOAT_MAX + 1},
-  {at::kDouble, RANDOM_DOUBLE_MAX + 1},
-  {at::kInt, std::numeric_limits<int>::max()},
-  {at::kShort, std::numeric_limits<int16_t>::max()},
-  {at::kChar, std::numeric_limits<int8_t>::max()},
-  {at::kByte, std::numeric_limits<uint8_t>::max()},
-  {at::kLong, std::numeric_limits<long>::max()},
-  {at::kBFloat16, RANDOM_BFLOAT16_MAX + 1},
-  {at::kBool, 1}
-};
+    {at::kHalf, RANDOM_HALF_MAX + 1},
+    {at::kFloat, RANDOM_FLOAT_MAX + 1},
+    {at::kDouble, RANDOM_DOUBLE_MAX + 1},
+    {at::kInt, std::numeric_limits<int>::max()},
+    {at::kShort, std::numeric_limits<int16_t>::max()},
+    {at::kChar, std::numeric_limits<int8_t>::max()},
+    {at::kByte, std::numeric_limits<uint8_t>::max()},
+    {at::kLong, std::numeric_limits<long>::max()},
+    {at::kBFloat16, RANDOM_BFLOAT16_MAX + 1},
+    {at::kBool, 1}};
 
-int64_t get_dtype_max_value(at::ScalarType dtype)
-{
-    auto iter = DTYPE_MAX_VALUE_MAP.find(dtype);
-    TORCH_CHECK(iter != DTYPE_MAX_VALUE_MAP.end(), "self scalar_type:", dtype, "is not surpported.", OPS_ERROR(ErrCode::TYPE));
-    return iter->second;
+int64_t get_dtype_max_value(at::ScalarType dtype) {
+  auto iter = DTYPE_MAX_VALUE_MAP.find(dtype);
+  TORCH_CHECK(
+      iter != DTYPE_MAX_VALUE_MAP.end(),
+      "self scalar_type:",
+      dtype,
+      "is not surpported.",
+      OPS_ERROR(ErrCode::TYPE));
+  return iter->second;
 }
 
-at::Tensor& random_op_api_(at::Tensor& self, int64_t from, int64_t to, c10::optional<at::Generator> gen_) {
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen_, at_npu::detail::getDefaultNPUGenerator());
+at::Tensor& random_op_api_(
+    at::Tensor& self,
+    int64_t from,
+    int64_t to,
+    c10::optional<at::Generator> gen_) {
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen_, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   EXEC_NPU_CMD(aclnnInplaceRandom, self, from, to, pair.first, pair.second);
   return self;
 }
 
-at::Tensor& random_(at::Tensor& self, int64_t from, c10::optional<int64_t> to,
-                                             c10::optional<at::Generator> gen_) {
+at::Tensor& random_(
+    at::Tensor& self,
+    int64_t from,
+    c10::optional<int64_t> to,
+    c10::optional<at::Generator> gen_) {
   DO_COMPATIBILITY(aclnnInplaceRandom, acl_op::random_(self, from, to, gen_));
   int64_t to_ = to.value_or(get_dtype_max_value(self.scalar_type()));
   random_op_api_(self, from, to_, gen_);
   return self;
 }
 
-at::Tensor& random_(at::Tensor& self, int64_t to, c10::optional<at::Generator> gen_) {
+at::Tensor& random_(
+    at::Tensor& self,
+    int64_t to,
+    c10::optional<at::Generator> gen_) {
   DO_COMPATIBILITY(aclnnInplaceRandom, acl_op::random_(self, to, gen_));
   int64_t from = 0;
   random_op_api_(self, from, to, gen_);
@@ -79,4 +93,4 @@ at::Tensor& random_(at::Tensor& self, c10::optional<at::Generator> gen_) {
   return self;
 }
 
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/base/opapi/RandpermKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/RandpermKernelNpuOpApi.cpp
@@ -16,56 +16,81 @@
 
 #include "npu/aten/AclOpsInterface.h"
 #include "npu/aten/OpApiInterface.h"
-#include "npu/framework/utils/RandomOpAdapter.h"
 #include "npu/aten/utils/op_api_common.h"
+#include "npu/framework/utils/RandomOpAdapter.h"
 
 namespace op_api {
 
-at::Tensor& randperm_op_api(int64_t n, c10::optional<at::Generator> gen_, at::Tensor& result) {
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen_, at_npu::detail::getDefaultNPUGenerator());
+at::Tensor& randperm_op_api(
+    int64_t n,
+    c10::optional<at::Generator> gen_,
+    at::Tensor& result) {
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen_, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   EXEC_NPU_CMD(aclnnRandperm, n, pair.first, pair.second, result);
   return result;
 }
 
-at::Tensor& randperm_out(int64_t n, c10::optional<at::Generator> generator, at::Tensor& result)
-{
-    DO_COMPATIBILITY(aclnnRandperm, acl_op::randperm_out(n, generator, result));
-    TORCH_CHECK(n >= 0, "n must be non-negative, got", n, OPS_ERROR(ErrCode::VALUE));
-    at_npu::native::OpPreparation::check_tensor({}, result, result, {n});
-    randperm_op_api(n, generator, result);
-    return result;
+at::Tensor& randperm_out(
+    int64_t n,
+    c10::optional<at::Generator> generator,
+    at::Tensor& result) {
+  DO_COMPATIBILITY(aclnnRandperm, acl_op::randperm_out(n, generator, result));
+  TORCH_CHECK(
+      n >= 0, "n must be non-negative, got", n, OPS_ERROR(ErrCode::VALUE));
+  at_npu::native::OpPreparation::check_tensor({}, result, result, {n});
+  randperm_op_api(n, generator, result);
+  return result;
 }
 
 at::Tensor& randperm_out(int64_t n, at::Tensor& result) {
   DO_COMPATIBILITY(aclnnRandperm, acl_op::randperm_out(n, result));
   at_npu::native::OpPreparation::check_tensor({}, result, result, {n});
-  c10::optional<at::Generator> generator = static_cast<c10::optional<at::Generator>>(c10::nullopt);
+  c10::optional<at::Generator> generator =
+      static_cast<c10::optional<at::Generator>>(c10::nullopt);
   randperm_op_api(n, generator, result);
   return result;
 }
 
-at::Tensor randperm(int64_t n, c10::optional<at::Generator> generator,
-                    c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout,
-                    c10::optional<at::Device> device, c10::optional<bool> pin_memory)
-{
-    DO_COMPATIBILITY(aclnnRandperm, acl_op::randperm(n, generator, dtype, layout, device, pin_memory));
-    TORCH_CHECK(n >= 0, "n must be non-negative, got", n, OPS_ERROR(ErrCode::VALUE));
-    at::TensorOptions options;
-    options = options.dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
+at::Tensor randperm(
+    int64_t n,
+    c10::optional<at::Generator> generator,
+    c10::optional<at::ScalarType> dtype,
+    c10::optional<at::Layout> layout,
+    c10::optional<at::Device> device,
+    c10::optional<bool> pin_memory) {
+  DO_COMPATIBILITY(
+      aclnnRandperm,
+      acl_op::randperm(n, generator, dtype, layout, device, pin_memory));
+  TORCH_CHECK(
+      n >= 0, "n must be non-negative, got", n, OPS_ERROR(ErrCode::VALUE));
+  at::TensorOptions options;
+  options = options.dtype(dtype).layout(layout).device(device).pinned_memory(
+      pin_memory);
 
-    at::Tensor result = at_npu::native::OpPreparation::apply_tensor_without_format({n}, options);
+  at::Tensor result =
+      at_npu::native::OpPreparation::apply_tensor_without_format({n}, options);
 
-    randperm_op_api(n, generator, result);
-    return result;
+  randperm_op_api(n, generator, result);
+  return result;
 }
 
-at::Tensor randperm(int64_t n, c10::optional<at::ScalarType> dtype,
-                    c10::optional<at::Layout> layout, c10::optional<at::Device> device,
-                    c10::optional<bool> pin_memory) {
-  DO_COMPATIBILITY(aclnnRandperm, acl_op::randperm(n, dtype, layout, device, pin_memory));
-  return op_api::randperm(n, static_cast<c10::optional<at::Generator>>(c10::nullopt), dtype, layout,
-                          device, pin_memory);
+at::Tensor randperm(
+    int64_t n,
+    c10::optional<at::ScalarType> dtype,
+    c10::optional<at::Layout> layout,
+    c10::optional<at::Device> device,
+    c10::optional<bool> pin_memory) {
+  DO_COMPATIBILITY(
+      aclnnRandperm, acl_op::randperm(n, dtype, layout, device, pin_memory));
+  return op_api::randperm(
+      n,
+      static_cast<c10::optional<at::Generator>>(c10::nullopt),
+      dtype,
+      layout,
+      device,
+      pin_memory);
 }
 
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/base/opapi/UniformKernelNpuOpApi.cpp
+++ b/npu/aten/ops/base/opapi/UniformKernelNpuOpApi.cpp
@@ -13,18 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "npu/aten/AclOpsInterface.h"
 #include "npu/aten/OpApiInterface.h"
 #include "npu/aten/utils/op_api_common.h"
-#include "npu/aten/AclOpsInterface.h"
 #include "npu/framework/utils/RandomOpAdapter.h"
 
 namespace op_api {
 using npu_preparation = at_npu::native::OpPreparation;
 
-at::Tensor& uniform_(at::Tensor& self, double from, double to,
-                     c10::optional<at::Generator> gen_) {
+at::Tensor& uniform_(
+    at::Tensor& self,
+    double from,
+    double to,
+    c10::optional<at::Generator> gen_) {
   DO_COMPATIBILITY(aclnnInplaceUniform, acl_op::uniform_(self, from, to, gen_));
-  auto gen = at::get_generator_or_default<at_npu::NPUGeneratorImpl>(gen_, at_npu::detail::getDefaultNPUGenerator());
+  auto gen = at::get_generator_or_default<c10::backend::NPUGeneratorImpl>(
+      gen_, c10::backend::detail::getDefaultNPUGenerator());
   auto pair = gen->philox_engine_inputs(10);
   int64_t seed = static_cast<int64_t>(pair.first);
   int64_t offset = static_cast<int64_t>(pair.second);
@@ -32,4 +36,4 @@ at::Tensor& uniform_(at::Tensor& self, double from, double to,
   return self;
 }
 
-}  // namespace op_api
+} // namespace op_api

--- a/npu/aten/ops/latest/op_api/CopyKernelOpApi.cpp
+++ b/npu/aten/ops/latest/op_api/CopyKernelOpApi.cpp
@@ -35,7 +35,7 @@ void copy_between_host_and_device_opapi(
     aclrtMemcpyKind kind,
     bool non_blocking) {
   int64_t nbytes = dst.numel() * dst.element_size();
-  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
+  c10::backend::NPUStream stream = c10::backend::getCurrentNPUStream();
 
   if (non_blocking) {
     auto ret = CalcuOpUtil::LaunchAsyncCopyTaskWithModeSwitch(
@@ -185,8 +185,8 @@ void copy_d2d_baseformat_opapi(
           dst.device().index());
     }
     guard.reset_device(dst.device());
-    c10::npu::NPUStream dst_stream =
-        c10::npu::getCurrentNPUStream(dst.device().index());
+    c10::backend::NPUStream dst_stream =
+        c10::backend::getCurrentNPUStream(dst.device().index());
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(dst_stream, -1));
     guard.reset_device(src.device());
   } else {
@@ -196,7 +196,7 @@ void copy_d2d_baseformat_opapi(
   }
   EXEC_NPU_CMD(aclnnInplaceCopy, dst, src);
   if (dst.device().index() != src.device().index()) {
-    c10::npu::NPUStream copy_stream = c10::npu::getCurrentNPUStream();
+    c10::backend::NPUStream copy_stream = c10::backend::getCurrentNPUStream();
     NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(copy_stream, -1));
   }
 }

--- a/npu/aten/ops/latest/op_api/FlashAttentionKernelNpuOpApi.cpp
+++ b/npu/aten/ops/latest/op_api/FlashAttentionKernelNpuOpApi.cpp
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "npu/framework/utils/RandomOpAdapter.h"
 #include "csrc/aten/generated/CustomFunctions.h"
 #include "npu/aten/OpApiInterface.h"
 #include "npu/aten/utils/op_api_common.h"
+#include "npu/framework/utils/RandomOpAdapter.h"
 
 namespace op_api {
 const static int FLASH_THRESHOLD = 512;
@@ -24,138 +24,181 @@ const static int64_t SOFTMAXMAX_LAST_DIMSHAPE = 8;
 using namespace at_npu::native;
 using npu_preparation = at_npu::native::OpPreparation;
 
-enum class DropOutStatus {
-    DROPOUT_NORMAL = 0,
-    DROPOUT_NONE,
-    DROPOUT_ALL
-};
+enum class DropOutStatus { DROPOUT_NORMAL = 0, DROPOUT_NONE, DROPOUT_ALL };
 
 enum class SparseMode {
-    NO_MASK = 0,
-    ALL_MASK,
-    LEFT_UP_CAUSAL,
-    RIGHT_DOWN_CAUSAL,
-    BAND,
-    PREFIX,
-    PREFIX_COMPRESS,
-    RIGHT_DOWN_CAUSAL_BAND,
-    BAND_LEFT_UP_CAUSAL
+  NO_MASK = 0,
+  ALL_MASK,
+  LEFT_UP_CAUSAL,
+  RIGHT_DOWN_CAUSAL,
+  BAND,
+  PREFIX,
+  PREFIX_COMPRESS,
+  RIGHT_DOWN_CAUSAL_BAND,
+  BAND_LEFT_UP_CAUSAL
 };
 
 namespace {
-DropOutStatus get_dropout_status(double keep_prob)
-{
-    if (keep_prob == 0) {
-        return DropOutStatus::DROPOUT_ALL;
-    }
-    if (keep_prob == 1.) {
-        return DropOutStatus::DROPOUT_NONE;
-    }
-    return DropOutStatus::DROPOUT_NORMAL;
+DropOutStatus get_dropout_status(double keep_prob) {
+  if (keep_prob == 0) {
+    return DropOutStatus::DROPOUT_ALL;
+  }
+  if (keep_prob == 1.) {
+    return DropOutStatus::DROPOUT_NONE;
+  }
+  return DropOutStatus::DROPOUT_NORMAL;
 }
 
-at::Tensor format_trans(const at::Tensor &at_tensor)
-{
-    if (at_tensor.defined()) {
-        TORCH_CHECK(torch_backend::utils::is_npu(at_tensor), "only npu tensor is supported" + OPS_ERROR(ErrCode::NOT_SUPPORT));
-        return custom_ops::npu_format_cast(at_tensor, ACL_FORMAT_ND);
-    }
-    return at_tensor;
+at::Tensor format_trans(const at::Tensor& at_tensor) {
+  if (at_tensor.defined()) {
+    TORCH_CHECK(
+        torch_backend::utils::is_npu(at_tensor),
+        "only npu tensor is supported" + OPS_ERROR(ErrCode::NOT_SUPPORT));
+    return custom_ops::npu_format_cast(at_tensor, ACL_FORMAT_ND);
+  }
+  return at_tensor;
 }
 
-at::Tensor& stateless_dropout_gen_mask_aclop(const at::Tensor &query, double keep_prob, int64_t seed,
-    const int64_t offset, const int64_t numels, at::Tensor& mask)
-{
-    int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
-    c10::TensorOptions options = query.options();
-    at::SmallVector<int64_t, ::N> offsetList = {0, offset};
-    const int64_t seed1 = 0;
-    at_npu::native::OpCommand cmd;
-    cmd.Name("StatelessDropOutGenMask")
-        .Input(at::IntArrayRef{numels})
-        .Input(at::Scalar(keep_prob), query.scalar_type(),  at_npu::native::CompileType::MEMORY_HOST_COMPILE_DEPENDENT)
-        .Input(at::Scalar(seed), at::ScalarType::Int)
-        .Input(at::Scalar(seed1), at::ScalarType::Int)
-        .Input(offsetList, at::kLong,  at_npu::native::CompileType::MEMORY_HOST_COMPILE_INDEPENDENT)
-        .Output(mask)
-        .Run();
-    return mask;
+at::Tensor& stateless_dropout_gen_mask_aclop(
+    const at::Tensor& query,
+    double keep_prob,
+    int64_t seed,
+    const int64_t offset,
+    const int64_t numels,
+    at::Tensor& mask) {
+  int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
+  c10::TensorOptions options = query.options();
+  at::SmallVector<int64_t, ::N> offsetList = {0, offset};
+  const int64_t seed1 = 0;
+  at_npu::native::OpCommand cmd;
+  cmd.Name("StatelessDropOutGenMask")
+      .Input(at::IntArrayRef{numels})
+      .Input(
+          at::Scalar(keep_prob),
+          query.scalar_type(),
+          at_npu::native::CompileType::MEMORY_HOST_COMPILE_DEPENDENT)
+      .Input(at::Scalar(seed), at::ScalarType::Int)
+      .Input(at::Scalar(seed1), at::ScalarType::Int)
+      .Input(
+          offsetList,
+          at::kLong,
+          at_npu::native::CompileType::MEMORY_HOST_COMPILE_INDEPENDENT)
+      .Output(mask)
+      .Run();
+  return mask;
 }
 
-at::Tensor dropout_gen_mask_impl(const at::Tensor &query, double keep_prob, int64_t seed,
-    const int64_t offset, const int64_t numels)
-{
-    int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
-    c10::TensorOptions options = query.options();
-    at::Tensor mask = OpPreparation::apply_tensor_without_format(at::IntArrayRef{length}, options.dtype(at::kByte));
-    c10::SmallVector<int64_t, SIZE> shapeSize = {numels};
-    at::IntArrayRef shapeArray = at::IntArrayRef(shapeSize);
-    double prob;
-    at::Scalar probScalar;
-    if (query.scalar_type() == at::kHalf) {
-        probScalar = at::Scalar(at::Half(1.0)- at::Half(keep_prob));
-    } else {
-        probScalar = at::Scalar(at::BFloat16(1.0)- at::BFloat16(keep_prob));
-    }
-    prob = probScalar.toDouble();
-    aclDataType probDataType = at_npu::native::OpPreparation::convert_to_acl_data_type(query.scalar_type());
-    DO_COMPATIBILITY(aclnnDropoutGenMaskV2, stateless_dropout_gen_mask_aclop(query, keep_prob, seed, offset, numels, mask));
-    EXEC_NPU_CMD(aclnnDropoutGenMaskV2, shapeArray, prob, seed, offset, probDataType, mask);
-    return mask;
+at::Tensor dropout_gen_mask_impl(
+    const at::Tensor& query,
+    double keep_prob,
+    int64_t seed,
+    const int64_t offset,
+    const int64_t numels) {
+  int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
+  c10::TensorOptions options = query.options();
+  at::Tensor mask = OpPreparation::apply_tensor_without_format(
+      at::IntArrayRef{length}, options.dtype(at::kByte));
+  c10::SmallVector<int64_t, SIZE> shapeSize = {numels};
+  at::IntArrayRef shapeArray = at::IntArrayRef(shapeSize);
+  double prob;
+  at::Scalar probScalar;
+  if (query.scalar_type() == at::kHalf) {
+    probScalar = at::Scalar(at::Half(1.0) - at::Half(keep_prob));
+  } else {
+    probScalar = at::Scalar(at::BFloat16(1.0) - at::BFloat16(keep_prob));
+  }
+  prob = probScalar.toDouble();
+  aclDataType probDataType =
+      at_npu::native::OpPreparation::convert_to_acl_data_type(
+          query.scalar_type());
+  DO_COMPATIBILITY(
+      aclnnDropoutGenMaskV2,
+      stateless_dropout_gen_mask_aclop(
+          query, keep_prob, seed, offset, numels, mask));
+  EXEC_NPU_CMD(
+      aclnnDropoutGenMaskV2,
+      shapeArray,
+      prob,
+      seed,
+      offset,
+      probDataType,
+      mask);
+  return mask;
 }
 
-at::Tensor dropout_gen_mask_dispatch(const at::Tensor &query, double keep_prob, int64_t seed,
-    const int64_t offset, const int64_t numels, const bool gen_mask_parallel, const bool sync)
-{
-    at::Tensor mask;
+at::Tensor dropout_gen_mask_dispatch(
+    const at::Tensor& query,
+    double keep_prob,
+    int64_t seed,
+    const int64_t offset,
+    const int64_t numels,
+    const bool gen_mask_parallel,
+    const bool sync) {
+  at::Tensor mask;
 
-    mask = dropout_gen_mask_impl(query, keep_prob, seed, offset, numels);
-    return mask;
+  mask = dropout_gen_mask_impl(query, keep_prob, seed, offset, numels);
+  return mask;
 }
-} // namespace _
+} // namespace
 
-at::Tensor dropout_gen_mask(const at::Tensor &query, const at::Tensor &key, double keep_prob, int64_t head_num, std::string input_layout,
-    bool gen_mask_parallel, bool sync, int64_t &seed, int64_t &offset, int64_t &numels)
-{
-    at::Tensor drop_mask;
-    if (input_layout == "BSH") {
-        numels = query.size(0) * head_num * query.size(1) * key.size(1); // [B,N,S,S]
-    } else if (input_layout == "SBH") {
-        numels = query.size(1) * head_num * query.size(0) * key.size(0); // [B,N,S,S]
-    } else if (input_layout == "BNSD") {
-        numels = query.size(0) * query.size(1) * query.size(2) * key.size(2); // [B,N,S,S]
-    } else if (input_layout == "BSND") {
-        numels = query.size(0) * query.size(2) * query.size(1) * key.size(1); // [B,N,S,S]
-    }
-    int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
-    length += 32;
-    if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
-        const auto gen = at_npu::detail::getDefaultNPUGenerator();
-        auto pair = at::check_generator<at_npu::NPUGeneratorImpl>(gen)->philox_engine_inputs(10);
-        seed = static_cast<int64_t>(pair.first);
-        offset = static_cast<int64_t>(pair.second);
-        drop_mask = dropout_gen_mask_dispatch(query, keep_prob, seed, offset, numels, gen_mask_parallel, sync);
-    } else if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
-        drop_mask = at::zeros(at::IntArrayRef{length}, query.options().dtype(at::kByte));
-    }
-    return drop_mask;
+at::Tensor dropout_gen_mask(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    double keep_prob,
+    int64_t head_num,
+    std::string input_layout,
+    bool gen_mask_parallel,
+    bool sync,
+    int64_t& seed,
+    int64_t& offset,
+    int64_t& numels) {
+  at::Tensor drop_mask;
+  if (input_layout == "BSH") {
+    numels =
+        query.size(0) * head_num * query.size(1) * key.size(1); // [B,N,S,S]
+  } else if (input_layout == "SBH") {
+    numels =
+        query.size(1) * head_num * query.size(0) * key.size(0); // [B,N,S,S]
+  } else if (input_layout == "BNSD") {
+    numels = query.size(0) * query.size(1) * query.size(2) *
+        key.size(2); // [B,N,S,S]
+  } else if (input_layout == "BSND") {
+    numels = query.size(0) * query.size(2) * query.size(1) *
+        key.size(1); // [B,N,S,S]
+  }
+  int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
+  length += 32;
+  if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
+    const auto gen = c10::backend::detail::getDefaultNPUGenerator();
+    auto pair = at::check_generator<c10::backend::NPUGeneratorImpl>(gen)
+                    ->philox_engine_inputs(10);
+    seed = static_cast<int64_t>(pair.first);
+    offset = static_cast<int64_t>(pair.second);
+    drop_mask = dropout_gen_mask_dispatch(
+        query, keep_prob, seed, offset, numels, gen_mask_parallel, sync);
+  } else if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
+    drop_mask =
+        at::zeros(at::IntArrayRef{length}, query.options().dtype(at::kByte));
+  }
+  return drop_mask;
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_fusion_attention_backward(
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const at::Tensor &dy,
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+npu_fusion_attention_backward(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& dy,
     int64_t head_num,
     const std::string input_layout,
-    const c10::optional<at::Tensor> &pse,
-    const c10::optional<at::Tensor> &drop_mask,
-    const c10::optional<at::Tensor> &padding_mask,
-    const c10::optional<at::Tensor> &atten_mask,
-    const c10::optional<at::Tensor> &softmax_max,
-    const c10::optional<at::Tensor> &softmax_sum,
-    const c10::optional<at::Tensor> &softmax_in,
-    const c10::optional<at::Tensor> &attention_in,
+    const c10::optional<at::Tensor>& pse,
+    const c10::optional<at::Tensor>& drop_mask,
+    const c10::optional<at::Tensor>& padding_mask,
+    const c10::optional<at::Tensor>& atten_mask,
+    const c10::optional<at::Tensor>& softmax_max,
+    const c10::optional<at::Tensor>& softmax_sum,
+    const c10::optional<at::Tensor>& softmax_in,
+    const c10::optional<at::Tensor>& attention_in,
     double scale_value,
     double keep_prob,
     int64_t pre_tockens,
@@ -164,83 +207,128 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_fusion_attention_
     c10::OptionalIntArrayRef prefix,
     c10::OptionalIntArrayRef actual_seq_qlen,
     c10::OptionalIntArrayRef actual_seq_kvlen,
-    int64_t sparse_mode)
-{
-    double scale = scale_value;
+    int64_t sparse_mode) {
+  double scale = scale_value;
 
-    const at::Tensor &pse_const = pse.value_or(at::Tensor());
-    const at::Tensor &drop_mask_const = drop_mask.value_or(at::Tensor());
-    const at::Tensor &padding_mask_const = padding_mask.value_or(at::Tensor());
-    const at::Tensor &atten_mask_const = atten_mask.value_or(at::Tensor());
-    const at::Tensor &softmax_max_const = softmax_max.value_or(at::Tensor());
-    const at::Tensor &softmax_sum_const = softmax_sum.value_or(at::Tensor());
-    const at::Tensor &softmax_const = softmax_in.value_or(at::Tensor());
-    const at::Tensor &attention_const = attention_in.value_or(at::Tensor());
-    auto prefixN = prefix.value_or(at::IntArrayRef{});
-    auto ac_seq_qlen = actual_seq_qlen.value_or(at::IntArrayRef{});
-    auto ac_seq_kvlen = actual_seq_kvlen.value_or(at::IntArrayRef{});
+  const at::Tensor& pse_const = pse.value_or(at::Tensor());
+  const at::Tensor& drop_mask_const = drop_mask.value_or(at::Tensor());
+  const at::Tensor& padding_mask_const = padding_mask.value_or(at::Tensor());
+  const at::Tensor& atten_mask_const = atten_mask.value_or(at::Tensor());
+  const at::Tensor& softmax_max_const = softmax_max.value_or(at::Tensor());
+  const at::Tensor& softmax_sum_const = softmax_sum.value_or(at::Tensor());
+  const at::Tensor& softmax_const = softmax_in.value_or(at::Tensor());
+  const at::Tensor& attention_const = attention_in.value_or(at::Tensor());
+  auto prefixN = prefix.value_or(at::IntArrayRef{});
+  auto ac_seq_qlen = actual_seq_qlen.value_or(at::IntArrayRef{});
+  auto ac_seq_kvlen = actual_seq_kvlen.value_or(at::IntArrayRef{});
 
-    at::Tensor format_query = format_trans(query);
-    at::Tensor format_key = format_trans(key);
-    at::Tensor format_value = format_trans(value);
-    at::Tensor format_dy = format_trans(dy);
+  at::Tensor format_query = format_trans(query);
+  at::Tensor format_key = format_trans(key);
+  at::Tensor format_value = format_trans(value);
+  at::Tensor format_dy = format_trans(dy);
 
-    at::Tensor format_pse = format_trans(pse_const);
-    at::Tensor format_drop_mask = format_trans(drop_mask_const);
-    at::Tensor format_padding_mask = format_trans(padding_mask_const);
-    at::Tensor format_atten_mask = format_trans(atten_mask_const);
-    at::Tensor format_softmax_max = format_trans(softmax_max_const);
-    at::Tensor format_softmax_sum = format_trans(softmax_sum_const);
-    at::Tensor format_softmax = format_trans(softmax_const);
-    at::Tensor format_attention = format_trans(attention_const);
-    at::Tensor dq = OpPreparation::apply_tensor_without_format(format_query);
-    at::Tensor dk = OpPreparation::apply_tensor_without_format(format_key);
-    at::Tensor dv = OpPreparation::apply_tensor_without_format(format_value);
-    char* input_layout_ptr = const_cast<char *>(input_layout.c_str());
-    at::Tensor dpse;
-    if (format_pse.defined()) {
-        dpse = OpPreparation::apply_tensor_without_format(format_pse);
-    } else {
-        dpse = at::empty({0}, query.options());
-    }
+  at::Tensor format_pse = format_trans(pse_const);
+  at::Tensor format_drop_mask = format_trans(drop_mask_const);
+  at::Tensor format_padding_mask = format_trans(padding_mask_const);
+  at::Tensor format_atten_mask = format_trans(atten_mask_const);
+  at::Tensor format_softmax_max = format_trans(softmax_max_const);
+  at::Tensor format_softmax_sum = format_trans(softmax_sum_const);
+  at::Tensor format_softmax = format_trans(softmax_const);
+  at::Tensor format_attention = format_trans(attention_const);
+  at::Tensor dq = OpPreparation::apply_tensor_without_format(format_query);
+  at::Tensor dk = OpPreparation::apply_tensor_without_format(format_key);
+  at::Tensor dv = OpPreparation::apply_tensor_without_format(format_value);
+  char* input_layout_ptr = const_cast<char*>(input_layout.c_str());
+  at::Tensor dpse;
+  if (format_pse.defined()) {
+    dpse = OpPreparation::apply_tensor_without_format(format_pse);
+  } else {
+    dpse = at::empty({0}, query.options());
+  }
 
-    if (!ac_seq_qlen.empty() && !ac_seq_kvlen.empty()) {
-        EXEC_NPU_CMD(
-            aclnnFlashAttentionUnpaddingScoreGrad, format_query, format_key, format_value, format_dy,
-            format_pse, format_drop_mask, format_padding_mask, format_atten_mask, format_softmax_max,
-            format_softmax_sum, format_softmax, format_attention, prefixN, ac_seq_qlen, ac_seq_kvlen,
-            scale_value, keep_prob, pre_tockens, next_tockens, head_num, input_layout_ptr, inner_precise, sparse_mode,
-            dq, dk, dv, dpse);
-    } else {
-        EXEC_NPU_CMD(
-            aclnnFlashAttentionScoreGrad, format_query, format_key, format_value, format_dy,
-            format_pse, format_drop_mask, format_padding_mask, format_atten_mask, format_softmax_max,
-            format_softmax_sum, format_softmax, format_attention, prefixN, scale_value, keep_prob,
-            pre_tockens, next_tockens, head_num, input_layout_ptr, inner_precise, sparse_mode, dq, dk, dv, dpse);
-    }
+  if (!ac_seq_qlen.empty() && !ac_seq_kvlen.empty()) {
+    EXEC_NPU_CMD(
+        aclnnFlashAttentionUnpaddingScoreGrad,
+        format_query,
+        format_key,
+        format_value,
+        format_dy,
+        format_pse,
+        format_drop_mask,
+        format_padding_mask,
+        format_atten_mask,
+        format_softmax_max,
+        format_softmax_sum,
+        format_softmax,
+        format_attention,
+        prefixN,
+        ac_seq_qlen,
+        ac_seq_kvlen,
+        scale_value,
+        keep_prob,
+        pre_tockens,
+        next_tockens,
+        head_num,
+        input_layout_ptr,
+        inner_precise,
+        sparse_mode,
+        dq,
+        dk,
+        dv,
+        dpse);
+  } else {
+    EXEC_NPU_CMD(
+        aclnnFlashAttentionScoreGrad,
+        format_query,
+        format_key,
+        format_value,
+        format_dy,
+        format_pse,
+        format_drop_mask,
+        format_padding_mask,
+        format_atten_mask,
+        format_softmax_max,
+        format_softmax_sum,
+        format_softmax,
+        format_attention,
+        prefixN,
+        scale_value,
+        keep_prob,
+        pre_tockens,
+        next_tockens,
+        head_num,
+        input_layout_ptr,
+        inner_precise,
+        sparse_mode,
+        dq,
+        dk,
+        dv,
+        dpse);
+  }
 
-    if (!format_pse.defined()) {
-        at::Tensor dpse_required;
-        dpse = dpse_required;
-    }
+  if (!format_pse.defined()) {
+    at::Tensor dpse_required;
+    dpse = dpse_required;
+  }
 
-    return std::make_tuple(dq, dk, dv, dpse);
+  return std::make_tuple(dq, dk, dv, dpse);
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_fusion_attention_grad(
-    const at::Tensor &query,
-    const at::Tensor &key,
-    const at::Tensor &value,
-    const at::Tensor &dy,
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+npu_fusion_attention_grad(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& dy,
     int64_t head_num,
     c10::string_view input_layout,
-    const c10::optional<at::Tensor> &pse,
-    const c10::optional<at::Tensor> &padding_mask,
-    const c10::optional<at::Tensor> &atten_mask,
-    const c10::optional<at::Tensor> &softmax_max,
-    const c10::optional<at::Tensor> &softmax_sum,
-    const c10::optional<at::Tensor> &softmax_in,
-    const c10::optional<at::Tensor> &attention_in,
+    const c10::optional<at::Tensor>& pse,
+    const c10::optional<at::Tensor>& padding_mask,
+    const c10::optional<at::Tensor>& atten_mask,
+    const c10::optional<at::Tensor>& softmax_max,
+    const c10::optional<at::Tensor>& softmax_sum,
+    const c10::optional<at::Tensor>& softmax_in,
+    const c10::optional<at::Tensor>& attention_in,
     double scale_value,
     double keep_prob,
     int64_t pre_tockens,
@@ -254,254 +342,458 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> npu_fusion_attention_
     c10::OptionalIntArrayRef actual_seq_kvlen,
     int64_t sparse_mode,
     bool gen_mask_parallel,
-    bool sync)
-{
-    TORCH_CHECK(query.dim() == 3 || query.dim() == 4, "The shapes of the input query should be 3 or 4 dimensional, but got ",
-        query.dim(), "-dimensional", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(key.dim() == 3 || key.dim() == 4, "The shapes of the input key should be 3 or 4 dimensional, but got ",
-        key.dim(), "-dimensional", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(value.dim() == 3 || value.dim() == 4, "The shapes of the input value should be 3 or 4 dimensional, but got ",
-        value.dim(), "-dimensional", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(dy.dim() == 3 || dy.dim() == 4, "The shapes of the input dy should be 3 or 4 dimensional, but got ", dy.dim(), "-dimensional",
+    bool sync) {
+  TORCH_CHECK(
+      query.dim() == 3 || query.dim() == 4,
+      "The shapes of the input query should be 3 or 4 dimensional, but got ",
+      query.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      key.dim() == 3 || key.dim() == 4,
+      "The shapes of the input key should be 3 or 4 dimensional, but got ",
+      key.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      value.dim() == 3 || value.dim() == 4,
+      "The shapes of the input value should be 3 or 4 dimensional, but got ",
+      value.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      dy.dim() == 3 || dy.dim() == 4,
+      "The shapes of the input dy should be 3 or 4 dimensional, but got ",
+      dy.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      keep_prob >= 0 && keep_prob <= 1,
+      "The keep_prob value must be in range of [0, 1], but got ",
+      keep_prob,
+      OPS_ERROR(ErrCode::PARAM));
+  std::string input_layout_str = std::string(input_layout);
+  if (input_layout_str == "TND") {
+    TORCH_CHECK(
+        (sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
+         sparse_mode < static_cast<int64_t>(SparseMode::PREFIX)) ||
+            (sparse_mode > static_cast<int64_t>(SparseMode::PREFIX) &&
+             sparse_mode <=
+                 static_cast<int64_t>(SparseMode::BAND_LEFT_UP_CAUSAL)),
+        "The sparse_mode value must be in range of [0,5) or (5,8], but got ",
+        sparse_mode,
         OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(keep_prob >= 0 && keep_prob <= 1, "The keep_prob value must be in range of [0, 1], but got ", keep_prob,
+  } else {
+    TORCH_CHECK(
+        sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
+            sparse_mode <= static_cast<int64_t>(SparseMode::PREFIX_COMPRESS),
+        "The sparse_mode value must be in range of [0,6], but got ",
+        sparse_mode,
         OPS_ERROR(ErrCode::PARAM));
-    std::string input_layout_str = std::string(input_layout);
-    if (input_layout_str == "TND") {
-        TORCH_CHECK((sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
-                    sparse_mode < static_cast<int64_t>(SparseMode::PREFIX)) ||
-                    (sparse_mode > static_cast<int64_t>(SparseMode::PREFIX) &&
-                    sparse_mode <= static_cast<int64_t>(SparseMode::BAND_LEFT_UP_CAUSAL)),
-                    "The sparse_mode value must be in range of [0,5) or (5,8], but got ",
-                    sparse_mode, OPS_ERROR(ErrCode::PARAM));
-    } else {
-        TORCH_CHECK(sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
-                    sparse_mode <= static_cast<int64_t>(SparseMode::PREFIX_COMPRESS),
-                    "The sparse_mode value must be in range of [0,6], but got ",
-                    sparse_mode, OPS_ERROR(ErrCode::PARAM));
-    }
-    for (auto &c : input_layout_str) {
-        c = toupper(c);
-    }
-    TORCH_CHECK(input_layout_str == "BSH" || input_layout_str == "SBH" || input_layout_str == "BNSD" ||
-        input_layout_str == "BSND" || input_layout_str == "TND",
-        "The input_layout should be BSH/SBH/BNSD/BSND/TND(case-insensitive), but got ", input_layout, OPS_ERROR(ErrCode::PARAM));
+  }
+  for (auto& c : input_layout_str) {
+    c = toupper(c);
+  }
+  TORCH_CHECK(
+      input_layout_str == "BSH" || input_layout_str == "SBH" ||
+          input_layout_str == "BNSD" || input_layout_str == "BSND" ||
+          input_layout_str == "TND",
+      "The input_layout should be BSH/SBH/BNSD/BSND/TND(case-insensitive), but got ",
+      input_layout,
+      OPS_ERROR(ErrCode::PARAM));
 
-    int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
-    length += 32;
-    at::Tensor drop_mask;
-    if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
-        drop_mask = dropout_gen_mask_dispatch(query, keep_prob, seed, offset, numels, gen_mask_parallel, sync);
-    } else if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
-        drop_mask = at::zeros(at::IntArrayRef{length}, query.options().dtype(at::kByte));
-    }
-    auto result = npu_fusion_attention_backward(query,
-        key, value, dy, head_num, input_layout_str, pse, drop_mask, padding_mask, atten_mask,
-        softmax_max, softmax_sum, softmax_in, attention_in, scale_value, keep_prob, pre_tockens,
-        next_tockens, inner_precise, prefix, actual_seq_qlen, actual_seq_kvlen, sparse_mode);
-    return result;
+  int64_t length = (numels + 128 - 1) / 128 * 128 / 8;
+  length += 32;
+  at::Tensor drop_mask;
+  if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_NORMAL) {
+    drop_mask = dropout_gen_mask_dispatch(
+        query, keep_prob, seed, offset, numels, gen_mask_parallel, sync);
+  } else if (get_dropout_status(keep_prob) == DropOutStatus::DROPOUT_ALL) {
+    drop_mask =
+        at::zeros(at::IntArrayRef{length}, query.options().dtype(at::kByte));
+  }
+  auto result = npu_fusion_attention_backward(
+      query,
+      key,
+      value,
+      dy,
+      head_num,
+      input_layout_str,
+      pse,
+      drop_mask,
+      padding_mask,
+      atten_mask,
+      softmax_max,
+      softmax_sum,
+      softmax_in,
+      attention_in,
+      scale_value,
+      keep_prob,
+      pre_tockens,
+      next_tockens,
+      inner_precise,
+      prefix,
+      actual_seq_qlen,
+      actual_seq_kvlen,
+      sparse_mode);
+  return result;
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, int64_t, int64_t, int64_t> npu_fusion_attention(
-    const at::Tensor &query, const at::Tensor &key,
-    const at::Tensor &value, int64_t head_num, c10::string_view input_layout,
-    const c10::optional<at::Tensor> &pse_opt, const c10::optional<at::Tensor> &padding_mask_opt,
-    const c10::optional<at::Tensor> &atten_mask_opt,
-    double scale, double keep_prob, int64_t pre_tockens, int64_t next_tockens, int64_t inner_precise,
-    c10::OptionalIntArrayRef prefix_opt, c10::OptionalIntArrayRef actual_seq_qlen,
-    c10::OptionalIntArrayRef actual_seq_kvlen, int64_t sparse_mode, bool gen_mask_parallel, bool sync)
-{
-    const at::Tensor &pse = pse_opt.value_or(at::Tensor());
-    const at::Tensor &padding_mask = padding_mask_opt.value_or(at::Tensor());
-    const at::Tensor &atten_mask = atten_mask_opt.value_or(at::Tensor());
-    auto prefixN = prefix_opt.value_or(at::IntArrayRef{});
-    auto ac_seq_qlen = actual_seq_qlen.value_or(at::IntArrayRef{});
-    auto ac_seq_kvlen = actual_seq_kvlen.value_or(at::IntArrayRef{});
+std::tuple<
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    at::Tensor,
+    int64_t,
+    int64_t,
+    int64_t>
+npu_fusion_attention(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    int64_t head_num,
+    c10::string_view input_layout,
+    const c10::optional<at::Tensor>& pse_opt,
+    const c10::optional<at::Tensor>& padding_mask_opt,
+    const c10::optional<at::Tensor>& atten_mask_opt,
+    double scale,
+    double keep_prob,
+    int64_t pre_tockens,
+    int64_t next_tockens,
+    int64_t inner_precise,
+    c10::OptionalIntArrayRef prefix_opt,
+    c10::OptionalIntArrayRef actual_seq_qlen,
+    c10::OptionalIntArrayRef actual_seq_kvlen,
+    int64_t sparse_mode,
+    bool gen_mask_parallel,
+    bool sync) {
+  const at::Tensor& pse = pse_opt.value_or(at::Tensor());
+  const at::Tensor& padding_mask = padding_mask_opt.value_or(at::Tensor());
+  const at::Tensor& atten_mask = atten_mask_opt.value_or(at::Tensor());
+  auto prefixN = prefix_opt.value_or(at::IntArrayRef{});
+  auto ac_seq_qlen = actual_seq_qlen.value_or(at::IntArrayRef{});
+  auto ac_seq_kvlen = actual_seq_kvlen.value_or(at::IntArrayRef{});
 
-    TORCH_CHECK(query.dim() == 3 || query.dim() == 4, "The shapes of the input query should be 3 or 4 dimensional, but got ",
-        query.dim(), "-dimensional", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(key.dim() == 3 || key.dim() == 4, "The shapes of the input key should be 3 or 4 dimensional, but got ", key.dim(),
-        "-dimensional", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(value.dim() == 3 || value.dim() == 4, "The shapes of the input value should be 3 or 4 dimensional, but got ",
-        value.dim(), "-dimensional", OPS_ERROR(ErrCode::PARAM));
-    TORCH_CHECK(keep_prob >= 0 && keep_prob <= 1, "The keep_prob value must be in range of [0, 1], but got ", keep_prob,
+  TORCH_CHECK(
+      query.dim() == 3 || query.dim() == 4,
+      "The shapes of the input query should be 3 or 4 dimensional, but got ",
+      query.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      key.dim() == 3 || key.dim() == 4,
+      "The shapes of the input key should be 3 or 4 dimensional, but got ",
+      key.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      value.dim() == 3 || value.dim() == 4,
+      "The shapes of the input value should be 3 or 4 dimensional, but got ",
+      value.dim(),
+      "-dimensional",
+      OPS_ERROR(ErrCode::PARAM));
+  TORCH_CHECK(
+      keep_prob >= 0 && keep_prob <= 1,
+      "The keep_prob value must be in range of [0, 1], but got ",
+      keep_prob,
+      OPS_ERROR(ErrCode::PARAM));
+  std::string input_layout_str = std::string(input_layout);
+  if (input_layout_str == "TND") {
+    TORCH_CHECK(
+        (sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
+         sparse_mode < static_cast<int64_t>(SparseMode::PREFIX)) ||
+            (sparse_mode > static_cast<int64_t>(SparseMode::PREFIX) &&
+             sparse_mode <=
+                 static_cast<int64_t>(SparseMode::BAND_LEFT_UP_CAUSAL)),
+        "The sparse_mode value must be in range of [0,5) or (5,8], but got ",
+        sparse_mode,
         OPS_ERROR(ErrCode::PARAM));
-    std::string input_layout_str = std::string(input_layout);
-    if (input_layout_str == "TND") {
-        TORCH_CHECK((sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
-                    sparse_mode < static_cast<int64_t>(SparseMode::PREFIX)) ||
-                    (sparse_mode > static_cast<int64_t>(SparseMode::PREFIX) &&
-                    sparse_mode <= static_cast<int64_t>(SparseMode::BAND_LEFT_UP_CAUSAL)),
-                    "The sparse_mode value must be in range of [0,5) or (5,8], but got ",
-                    sparse_mode, OPS_ERROR(ErrCode::PARAM));
-    } else {
-        TORCH_CHECK(sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
-                    sparse_mode <= static_cast<int64_t>(SparseMode::PREFIX_COMPRESS),
-                    "The sparse_mode value must be in range of [0,6], but got ",
-                    sparse_mode, OPS_ERROR(ErrCode::PARAM));
+  } else {
+    TORCH_CHECK(
+        sparse_mode >= static_cast<int64_t>(SparseMode::NO_MASK) &&
+            sparse_mode <= static_cast<int64_t>(SparseMode::PREFIX_COMPRESS),
+        "The sparse_mode value must be in range of [0,6], but got ",
+        sparse_mode,
+        OPS_ERROR(ErrCode::PARAM));
+  }
+  for (auto& c : input_layout_str) {
+    c = toupper(c);
+  }
+  TORCH_CHECK(
+      input_layout_str == "BSH" || input_layout_str == "SBH" ||
+          input_layout_str == "BNSD" || input_layout_str == "BSND" ||
+          input_layout_str == "TND",
+      "The input_layout should be BSH/SBH/BNSD/BSND/TND(case-insensitive), but got ",
+      input_layout,
+      OPS_ERROR(ErrCode::PARAM));
+
+  int64_t B = 0;
+  int64_t S0 = 0; // S for query
+  int64_t S1 = 0; // S for key & value
+  int64_t N = 0;
+  int64_t D = 0;
+  int64_t H = 0;
+  int64_t T = 0;
+
+  if (input_layout_str == "BSH") {
+    B = query.size(0);
+    S0 = query.size(1);
+    S1 = key.size(1);
+    H = query.size(2);
+  } else if (input_layout_str == "SBH") {
+    B = query.size(1);
+    S0 = query.size(0);
+    S1 = key.size(0);
+    H = query.size(2);
+  } else if (input_layout_str == "BNSD") {
+    B = query.size(0);
+    N = query.size(1);
+    S0 = query.size(2);
+    S1 = key.size(2);
+    D = query.size(3);
+  } else if (input_layout_str == "BSND") {
+    B = query.size(0);
+    N = query.size(2);
+    S0 = query.size(1);
+    S1 = key.size(1);
+    D = query.size(3);
+  } else if (input_layout_str == "TND") {
+    T = query.size(0);
+    N = query.size(1);
+    D = query.size(2);
+  }
+
+  double scale_value = scale;
+
+  at::Tensor format_query = format_trans(query);
+  at::Tensor attention_score =
+      OpPreparation::apply_tensor_without_format(format_query);
+  at::Tensor format_key = format_trans(key);
+  at::Tensor format_value = format_trans(value);
+
+  at::Tensor format_pse = format_trans(pse);
+  at::Tensor format_padding_mask = format_trans(padding_mask);
+  at::Tensor format_atten_mask = format_trans(atten_mask);
+
+  int64_t seed;
+  int64_t offset;
+  int64_t numels;
+  if (input_layout_str == "TND" && ac_seq_qlen.size() == ac_seq_kvlen.size()) {
+    numels = N;
+    int64_t accum = ac_seq_qlen[0] * ac_seq_kvlen[0];
+    for (size_t i = 1; i < ac_seq_qlen.size(); i++) {
+      accum +=
+          ((ac_seq_qlen[i] - ac_seq_qlen[i - 1]) *
+           (ac_seq_kvlen[i] - ac_seq_kvlen[i - 1]));
     }
-    for (auto &c : input_layout_str) {
-        c = toupper(c);
-    }
-    TORCH_CHECK(input_layout_str == "BSH" || input_layout_str == "SBH" || input_layout_str == "BNSD" ||
-                input_layout_str == "BSND" || input_layout_str == "TND",
-        "The input_layout should be BSH/SBH/BNSD/BSND/TND(case-insensitive), but got ", input_layout, OPS_ERROR(ErrCode::PARAM));
+    numels *= accum;
+  }
+  at::Tensor format_drop_mask = dropout_gen_mask(
+      format_query,
+      format_key,
+      keep_prob,
+      head_num,
+      input_layout_str,
+      gen_mask_parallel,
+      sync,
+      seed,
+      offset,
+      numels);
 
-    int64_t B = 0;
-    int64_t S0 = 0; // S for query
-    int64_t S1 = 0; // S for key & value
-    int64_t N = 0;
-    int64_t D = 0;
-    int64_t H = 0;
-    int64_t T = 0;
+  at::Tensor softmax_max;
+  at::Tensor softmax_sum;
+  at::Tensor softmax_out;
 
-    if (input_layout_str == "BSH") {
-        B = query.size(0);
-        S0 = query.size(1);
-        S1 = key.size(1);
-        H = query.size(2);
-    } else if (input_layout_str == "SBH") {
-        B = query.size(1);
-        S0 = query.size(0);
-        S1 = key.size(0);
-        H = query.size(2);
-    } else if (input_layout_str == "BNSD") {
-        B = query.size(0);
-        N = query.size(1);
-        S0 = query.size(2);
-        S1 = key.size(2);
-        D = query.size(3);
-    } else if (input_layout_str == "BSND") {
-        B = query.size(0);
-        N = query.size(2);
-        S0 = query.size(1);
-        S1 = key.size(1);
-        D = query.size(3);
-    } else if (input_layout_str == "TND") {
-        T = query.size(0);
-        N = query.size(1);
-        D = query.size(2);
-    }
+  if (input_layout_str != "TND") {
+    softmax_max = OpPreparation::apply_tensor_without_format(
+        {B, head_num, S0, SOFTMAXMAX_LAST_DIMSHAPE},
+        query.options().dtype(at::kFloat)); // [B, N, S0, 8]
+    softmax_sum = OpPreparation::apply_tensor_without_format(
+        {B, head_num, S0, SOFTMAXMAX_LAST_DIMSHAPE},
+        query.options().dtype(at::kFloat)); // [B, N, S0, 8]
+  } else {
+    softmax_max = OpPreparation::apply_tensor_without_format(
+        {T, N, SOFTMAXMAX_LAST_DIMSHAPE},
+        query.options().dtype(at::kFloat)); // [T, N, 8]
+    softmax_sum = OpPreparation::apply_tensor_without_format(
+        {T, N, SOFTMAXMAX_LAST_DIMSHAPE},
+        query.options().dtype(at::kFloat)); // [T, N, 8]
+  }
+  softmax_out = at::empty({0}, query.options());
+  char* input_layout_ptr = const_cast<char*>(input_layout_str.c_str());
+  if (!ac_seq_qlen.empty() && !ac_seq_kvlen.empty()) {
+    EXEC_NPU_CMD(
+        aclnnFlashAttentionVarLenScore,
+        format_query,
+        format_key,
+        format_value,
+        format_pse,
+        format_drop_mask,
+        format_padding_mask,
+        format_atten_mask,
+        prefixN,
+        ac_seq_qlen,
+        ac_seq_kvlen,
+        scale,
+        keep_prob,
+        pre_tockens,
+        next_tockens,
+        head_num,
+        input_layout_ptr,
+        inner_precise,
+        sparse_mode,
+        softmax_max,
+        softmax_sum,
+        softmax_out,
+        attention_score);
+  } else {
+    EXEC_NPU_CMD(
+        aclnnFlashAttentionScore,
+        format_query,
+        format_key,
+        format_value,
+        format_pse,
+        format_drop_mask,
+        format_padding_mask,
+        format_atten_mask,
+        prefixN,
+        scale,
+        keep_prob,
+        pre_tockens,
+        next_tockens,
+        head_num,
+        input_layout_ptr,
+        inner_precise,
+        sparse_mode,
+        softmax_max,
+        softmax_sum,
+        softmax_out,
+        attention_score);
+  }
 
-    double scale_value = scale;
-
-    at::Tensor format_query = format_trans(query);
-    at::Tensor attention_score = OpPreparation::apply_tensor_without_format(format_query);
-    at::Tensor format_key = format_trans(key);
-    at::Tensor format_value = format_trans(value);
-
-    at::Tensor format_pse = format_trans(pse);
-    at::Tensor format_padding_mask = format_trans(padding_mask);
-    at::Tensor format_atten_mask = format_trans(atten_mask);
-
-    int64_t seed;
-    int64_t offset;
-    int64_t numels;
-    if (input_layout_str == "TND" && ac_seq_qlen.size() == ac_seq_kvlen.size()) {
-        numels = N;
-        int64_t accum = ac_seq_qlen[0] * ac_seq_kvlen[0];
-        for (size_t i = 1; i < ac_seq_qlen.size(); i++) {
-            accum += ((ac_seq_qlen[i] - ac_seq_qlen[i - 1]) * (ac_seq_kvlen[i] - ac_seq_kvlen[i - 1]));
-        }
-        numels *= accum;
-    }
-    at::Tensor format_drop_mask = dropout_gen_mask(format_query, format_key, keep_prob, head_num, input_layout_str,
-        gen_mask_parallel, sync, seed, offset, numels);
-
-    at::Tensor softmax_max;
-    at::Tensor softmax_sum;
-    at::Tensor softmax_out;
-
-    if (input_layout_str != "TND") {
-        softmax_max = OpPreparation::apply_tensor_without_format({B, head_num, S0, SOFTMAXMAX_LAST_DIMSHAPE},
-            query.options().dtype(at::kFloat)); // [B, N, S0, 8]
-        softmax_sum = OpPreparation::apply_tensor_without_format({B, head_num, S0, SOFTMAXMAX_LAST_DIMSHAPE},
-            query.options().dtype(at::kFloat)); // [B, N, S0, 8]
-    } else {
-        softmax_max = OpPreparation::apply_tensor_without_format({T, N, SOFTMAXMAX_LAST_DIMSHAPE},
-            query.options().dtype(at::kFloat)); // [T, N, 8]
-        softmax_sum = OpPreparation::apply_tensor_without_format({T, N, SOFTMAXMAX_LAST_DIMSHAPE},
-            query.options().dtype(at::kFloat)); // [T, N, 8]
-    }
-    softmax_out = at::empty({0}, query.options());
-    char* input_layout_ptr = const_cast<char *>(input_layout_str.c_str());
-    if (!ac_seq_qlen.empty() && !ac_seq_kvlen.empty()) {
-        EXEC_NPU_CMD(
-            aclnnFlashAttentionVarLenScore, format_query, format_key, format_value,
-            format_pse, format_drop_mask, format_padding_mask, format_atten_mask, prefixN,
-            ac_seq_qlen, ac_seq_kvlen, scale, keep_prob, pre_tockens, next_tockens, head_num,
-            input_layout_ptr, inner_precise, sparse_mode, softmax_max, softmax_sum,
-            softmax_out, attention_score);
-    } else {
-        EXEC_NPU_CMD(
-            aclnnFlashAttentionScore, format_query, format_key, format_value,
-            format_pse, format_drop_mask, format_padding_mask, format_atten_mask, prefixN,
-            scale, keep_prob, pre_tockens, next_tockens, head_num, input_layout_ptr,
-            inner_precise, sparse_mode, softmax_max, softmax_sum, softmax_out, attention_score);
-    }
-
-    return std::make_tuple(attention_score, softmax_max, softmax_sum, softmax_out,
-        seed, offset, numels);
+  return std::make_tuple(
+      attention_score,
+      softmax_max,
+      softmax_sum,
+      softmax_out,
+      seed,
+      offset,
+      numels);
 }
 
 at::Tensor npu_prompt_flash_attention(
-    const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
-    const c10::optional<at::Tensor> &padding_mask,
-    const c10::optional<at::Tensor> &atten_mask,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const c10::optional<at::Tensor>& padding_mask,
+    const c10::optional<at::Tensor>& atten_mask,
     c10::OptionalIntArrayRef actual_seq_lengths,
-    int64_t num_heads, double scale_value,
-    int64_t pre_tokens, int64_t next_tokens,
-    c10::string_view input_layout, int64_t num_key_value_heads)
-{
-    // construct the output tensor of the NPU
-    auto output = npu_preparation::apply_tensor_without_format(query);
+    int64_t num_heads,
+    double scale_value,
+    int64_t pre_tokens,
+    int64_t next_tokens,
+    c10::string_view input_layout,
+    int64_t num_key_value_heads) {
+  // construct the output tensor of the NPU
+  auto output = npu_preparation::apply_tensor_without_format(query);
 
-    // convert str
-    std::string input_layout_str = std::string(input_layout);
-    char *input_layout_ptr = const_cast<char *>(input_layout_str.c_str());
+  // convert str
+  std::string input_layout_str = std::string(input_layout);
+  char* input_layout_ptr = const_cast<char*>(input_layout_str.c_str());
 
-    auto actSeqLen = (actual_seq_lengths.has_value()) ? actual_seq_lengths.value().vec() : std::vector<at::IntArrayRef::value_type>{};
+  auto actSeqLen = (actual_seq_lengths.has_value())
+      ? actual_seq_lengths.value().vec()
+      : std::vector<at::IntArrayRef::value_type>{};
 
-    // dispatch hostAPI
-    EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnnPromptFlashAttention, query, key, value, padding_mask, atten_mask, actSeqLen,
-                                 num_heads, scale_value, pre_tokens, next_tokens, input_layout_ptr, num_key_value_heads, output);
-    return output;
+  // dispatch hostAPI
+  EXEC_NPU_NO_FORMAT_CHECK_CMD(
+      aclnnPromptFlashAttention,
+      query,
+      key,
+      value,
+      padding_mask,
+      atten_mask,
+      actSeqLen,
+      num_heads,
+      scale_value,
+      pre_tokens,
+      next_tokens,
+      input_layout_ptr,
+      num_key_value_heads,
+      output);
+  return output;
 }
 
 at::Tensor npu_incre_flash_attention(
-    const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
-    const c10::optional<at::Tensor> &padding_mask, const c10::optional<at::Tensor> &atten_mask,
-    c10::OptionalIntArrayRef actual_seq_lengths, const c10::optional<at::Tensor> &antiquant_scale,
-    const c10::optional<at::Tensor> &antiquant_offset, const c10::optional<at::Tensor> &block_table,
-    const c10::optional<at::Tensor> &dequant_scale1, const c10::optional<at::Tensor> &quant_scale1,
-    const c10::optional<at::Tensor> &dequant_scale2, const c10::optional<at::Tensor> &quant_scale2,
-    const c10::optional<at::Tensor> &quant_offset2, const c10::optional<at::Tensor> &kv_padding_size,
-    int64_t num_heads, double scale_value, c10::string_view input_layout, int64_t num_key_value_heads,
-    int64_t block_size, int64_t inner_precise)
-{
-    // construct the output tensor of the NPU
-    at::Tensor output;
-    if (ConvertType(quant_scale2) != nullptr) {
-        output = npu_preparation::apply_tensor_without_format(query.sizes(), c10::dtype(c10::ScalarType::Char));
-    } else if (query.dtype() == at::kChar) {
-        output = npu_preparation::apply_tensor_without_format(query.sizes(), c10::dtype(c10::ScalarType::Half));
-    } else {
-        output = npu_preparation::apply_tensor_without_format(query);
-    }
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const c10::optional<at::Tensor>& padding_mask,
+    const c10::optional<at::Tensor>& atten_mask,
+    c10::OptionalIntArrayRef actual_seq_lengths,
+    const c10::optional<at::Tensor>& antiquant_scale,
+    const c10::optional<at::Tensor>& antiquant_offset,
+    const c10::optional<at::Tensor>& block_table,
+    const c10::optional<at::Tensor>& dequant_scale1,
+    const c10::optional<at::Tensor>& quant_scale1,
+    const c10::optional<at::Tensor>& dequant_scale2,
+    const c10::optional<at::Tensor>& quant_scale2,
+    const c10::optional<at::Tensor>& quant_offset2,
+    const c10::optional<at::Tensor>& kv_padding_size,
+    int64_t num_heads,
+    double scale_value,
+    c10::string_view input_layout,
+    int64_t num_key_value_heads,
+    int64_t block_size,
+    int64_t inner_precise) {
+  // construct the output tensor of the NPU
+  at::Tensor output;
+  if (ConvertType(quant_scale2) != nullptr) {
+    output = npu_preparation::apply_tensor_without_format(
+        query.sizes(), c10::dtype(c10::ScalarType::Char));
+  } else if (query.dtype() == at::kChar) {
+    output = npu_preparation::apply_tensor_without_format(
+        query.sizes(), c10::dtype(c10::ScalarType::Half));
+  } else {
+    output = npu_preparation::apply_tensor_without_format(query);
+  }
 
-    // convert str
-    std::string input_layout_str = std::string(input_layout);
-    char *input_layout_ptr = const_cast<char *>(input_layout_str.c_str());
+  // convert str
+  std::string input_layout_str = std::string(input_layout);
+  char* input_layout_ptr = const_cast<char*>(input_layout_str.c_str());
 
-    at::TensorList keyTensors = key;
-    at::TensorList valueTensors = value;
+  at::TensorList keyTensors = key;
+  at::TensorList valueTensors = value;
 
-    auto actSeqLen = (actual_seq_lengths.has_value()) ? actual_seq_lengths.value().vec() : std::vector<at::IntArrayRef::value_type>{};
+  auto actSeqLen = (actual_seq_lengths.has_value())
+      ? actual_seq_lengths.value().vec()
+      : std::vector<at::IntArrayRef::value_type>{};
 
-    // dispatch hostAPI
-    EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnnIncreFlashAttentionV4, query, keyTensors, valueTensors, padding_mask, atten_mask, actSeqLen,
-        dequant_scale1, quant_scale1, dequant_scale2, quant_scale2, quant_offset2, antiquant_scale, antiquant_offset, block_table,
-        kv_padding_size, num_heads, scale_value, input_layout_ptr, num_key_value_heads, block_size, inner_precise, output);
-    return output;
+  // dispatch hostAPI
+  EXEC_NPU_NO_FORMAT_CHECK_CMD(
+      aclnnIncreFlashAttentionV4,
+      query,
+      keyTensors,
+      valueTensors,
+      padding_mask,
+      atten_mask,
+      actSeqLen,
+      dequant_scale1,
+      quant_scale1,
+      dequant_scale2,
+      quant_scale2,
+      quant_offset2,
+      antiquant_scale,
+      antiquant_offset,
+      block_table,
+      kv_padding_size,
+      num_heads,
+      scale_value,
+      input_layout_ptr,
+      num_key_value_heads,
+      block_size,
+      inner_precise,
+      output);
+  return output;
 }
 } // namespace op_api

--- a/npu/aten/utils/op_api_common.h
+++ b/npu/aten/utils/op_api_common.h
@@ -704,7 +704,7 @@ auto DecodeDevice(Ts&... args) -> at::Device {
         GetOpApiLibName(),                                                   \
         "not found.",                                                        \
         OPS_ERROR(ErrCode::PTR));                                            \
-    auto acl_stream = c10::npu::getCurrentNPUStream().stream();              \
+    auto acl_stream = c10::backend::getCurrentNPUStream().stream();          \
     uint64_t workspace_size = 0;                                             \
     uint64_t* workspace_size_addr = &workspace_size;                         \
     aclOpExecutor* executor = nullptr;                                       \
@@ -792,7 +792,7 @@ auto DecodeDevice(Ts&... args) -> at::Device {
         ", or ",                                                             \
         GetOpApiLibName(),                                                   \
         "not found.");                                                       \
-    auto acl_stream = c10::npu::getCurrentNPUStream().stream(false);         \
+    auto acl_stream = c10::backend::getCurrentNPUStream().stream(false);     \
     uint64_t workspace_size = 0;                                             \
     uint64_t* workspace_size_addr = &workspace_size;                         \
     aclOpExecutor* executor = nullptr;                                       \
@@ -879,7 +879,7 @@ auto DecodeDevice(Ts&... args) -> at::Device {
         GetOpApiLibName(),                                                   \
         "not found.",                                                        \
         OPS_ERROR(ErrCode::PTR));                                            \
-    auto acl_stream = c10::npu::getCurrentNPUStream().stream();              \
+    auto acl_stream = c10::backend::getCurrentNPUStream().stream();          \
     uint64_t workspace_size = 0;                                             \
     uint64_t* workspace_size_addr = &workspace_size;                         \
     aclOpExecutor* executor = nullptr;                                       \
@@ -1036,7 +1036,7 @@ class ConvertedParams {
         GetOpApiLibName(),                                                   \
         "not found.",                                                        \
         OPS_ERROR(ErrCode::PTR));                                            \
-    auto acl_stream = c10::npu::getCurrentNPUStream().stream();              \
+    auto acl_stream = c10::backend::getCurrentNPUStream().stream();          \
     uint64_t workspace_size = 0;                                             \
     uint64_t* workspace_size_addr = &workspace_size;                         \
     aclOpExecutor* executor = nullptr;                                       \

--- a/npu/core/NPUBridge.cpp
+++ b/npu/core/NPUBridge.cpp
@@ -1,6 +1,6 @@
 #include <npu/core/NPUBridge.h>
 
-namespace torch_backend {
+namespace c10::backend {
 
 NPUStorageImpl* NPUBridge::GetNpuStorageImpl(c10::StorageImpl* storageImpl) {
   return static_cast<NPUStorageImpl*>(storageImpl);
@@ -23,4 +23,4 @@ NPUTensorImpl* NPUBridge::GetNpuTensorImpl(const at::Tensor& tensor) {
   return static_cast<NPUTensorImpl*>(tensor.unsafeGetTensorImpl());
 }
 
-} // namespace torch_backend
+} // namespace c10::backend

--- a/npu/core/NPUBridge.h
+++ b/npu/core/NPUBridge.h
@@ -3,7 +3,7 @@
 #include "csrc/backend/NPUStorageImpl.h"
 #include "csrc/backend/NPUTensorImpl.h"
 
-namespace torch_backend {
+namespace c10::backend {
 
 class NPUBridge {
  public:
@@ -22,4 +22,4 @@ class NPUBridge {
   // tensor to NPUTensorImpl
   static NPUTensorImpl* GetNpuTensorImpl(const at::Tensor& tensor);
 };
-} // namespace torch_backend
+} // namespace c10::backend

--- a/npu/core/NPUException.cpp
+++ b/npu/core/NPUException.cpp
@@ -30,7 +30,7 @@ std::unordered_map<ErrCode, std::string> errCodeMap = {
 std::string formatErrorCode(SubModule submodule, ErrCode errorCode) {
   std::ostringstream oss;
   c10::DeviceIndex deviceIndex = -1;
-  c10::npu::GetDevice(&deviceIndex);
+  c10::backend::GetDevice(&deviceIndex);
   auto rank_id = c10::npu::option::OptionsManager::GetRankId();
   oss << "\n[ERROR] " << getCurrentTimestamp() << " (PID:" << getpid()
       << ", Device:" << deviceIndex << ", RankID:" << rank_id << ") ";
@@ -60,7 +60,7 @@ static std::string getCurrentTimestamp() {
   return oss.str();
 }
 
-namespace c10::npu {
+namespace c10::backend {
 
 const char* getDeviceErrorMessage() {
   return aclGetRecentErrMsg();
@@ -75,4 +75,4 @@ const std::string getErrorMessage(int error_code) {
   return "\n[Error]: " + itr->second;
 }
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/npu/core/NPUException.h
+++ b/npu/core/NPUException.h
@@ -15,20 +15,20 @@
 #include "csrc/core/Macros.h"
 #include "npu/core/NPUErrorCodes.h"
 
-#define C10_NPU_SHOW_ERR_MSG()                                   \
-  do {                                                           \
-    std::cout << c10::npu::getDeviceErrorMessage() << std::endl; \
+#define C10_NPU_SHOW_ERR_MSG()                                       \
+  do {                                                               \
+    std::cout << c10::backend::getDeviceErrorMessage() << std::endl; \
   } while (0)
 
-#define NPU_CHECK_WARN(err_code)              \
-  do {                                        \
-    auto Error = err_code;                    \
-    if ((Error) != ACL_ERROR_NONE) {          \
-      TORCH_BACKEND_FORMAT_WARN(              \
-          err_code,                           \
-          c10::npu::getErrorMessage(Error),   \
-          c10::npu::getDeviceErrorMessage()); \
-    }                                         \
+#define NPU_CHECK_WARN(err_code)                  \
+  do {                                            \
+    auto Error = err_code;                        \
+    if ((Error) != ACL_ERROR_NONE) {              \
+      TORCH_BACKEND_FORMAT_WARN(                  \
+          err_code,                               \
+          c10::backend::getErrorMessage(Error),   \
+          c10::backend::getDeviceErrorMessage()); \
+    }                                             \
   } while (0)
 
 #define TORCH_NPU_WARN(...) TORCH_BACKEND_WARN(__VA_ARGS__)
@@ -80,11 +80,11 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
     if ((Error) != ACL_ERROR_NONE) {                  \
       TORCH_BACKEND_FORMAT_ERROR(                     \
           Error,                                      \
-          c10::npu::getErrorMessage(Error),           \
+          c10::backend::getErrorMessage(Error),       \
           " NPU function error: ",                    \
           getErrorFunction(#err_code, ##__VA_ARGS__), \
           PTA_ERROR(ErrCode::ACL),                    \
-          c10::npu::getDeviceErrorMessage());         \
+          c10::backend::getDeviceErrorMessage());     \
     }                                                 \
   } while (0)
 
@@ -94,11 +94,11 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
     if ((Error) != ACL_ERROR_NONE) {                  \
       TORCH_BACKEND_FORMAT_ERROR(                     \
           Error,                                      \
-          c10::npu::getErrorMessage(Error),           \
+          c10::backend::getErrorMessage(Error),       \
           " OPS function error: ",                    \
           getErrorFunction(#err_code, ##__VA_ARGS__), \
           OPS_ERROR(ErrCode::ACL),                    \
-          c10::npu::getDeviceErrorMessage())          \
+          c10::backend::getDeviceErrorMessage())      \
     }                                                 \
   } while (0)
 
@@ -121,15 +121,15 @@ inline const char* getErrorFunction(const char* /* msg */, const char* args) {
       } else {                                                      \
         TORCH_BACKEND_FORMAT_ERROR(                                 \
             Error,                                                  \
-            c10::npu::getErrorMessage(Error),                       \
-            c10::npu::getDeviceErrorMessage());                     \
+            c10::backend::getErrorMessage(Error),                   \
+            c10::backend::getDeviceErrorMessage());                 \
       }                                                             \
     }                                                               \
   } while (0)
-namespace c10::npu {
+namespace c10::backend {
 
 C10_BACKEND_API const char* getDeviceErrorMessage();
 
 C10_BACKEND_API const std::string getErrorMessage(int error_code);
 
-} // namespace c10::npu
+} // namespace c10::backend

--- a/npu/core/NPUFormat.cpp
+++ b/npu/core/NPUFormat.cpp
@@ -29,7 +29,7 @@ int64_t get_npu_format(const at::Tensor& self) {
 std::vector<int64_t> get_npu_storage_sizes(const at::Tensor& self) {
   torch_backend::utils::torch_check_npu(self);
   auto storage_sizes =
-      torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_.storage_sizes_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_.storage_sizes_;
   std::vector<int64_t> vec_storage_sizes(
       storage_sizes.begin(), storage_sizes.end());
   return vec_storage_sizes;

--- a/npu/core/NPUPeerToPeerAccess.cpp
+++ b/npu/core/NPUPeerToPeerAccess.cpp
@@ -14,7 +14,7 @@ namespace at_npu {
 namespace native {
 
 NpuP2pCtrl::NpuP2pCtrl() {
-  num_devices_ = c10::npu::device_count();
+  num_devices_ = c10::backend::device_count();
 
   device_enabled_count_.clear();
   device_enabled_count_.resize(num_devices_, 1);

--- a/npu/core/NPUQueue.cpp
+++ b/npu/core/NPUQueue.cpp
@@ -501,7 +501,7 @@ void StartConsume(Repository* repo, c10::DeviceIndex device_id) {
     ASCEND_LOGE("set thread name failed!");
   }
 
-  aclError ret = c10::npu::SetDevice(device_id);
+  aclError ret = c10::backend::SetDevice(device_id);
   if (ret != 0) {
     C10_NPU_SHOW_ERR_MSG();
     ASCEND_LOGE(

--- a/npu/core/NpuDeviceRAII.cpp
+++ b/npu/core/NpuDeviceRAII.cpp
@@ -4,10 +4,10 @@
 #include "csrc/backend/NPUFunctions.h"
 #include "csrc/backend/NPUStream.h"
 #include "npu/acl/include/acl/acl_op_compiler.h"
-#include "npu/core/NpuVariables.h"
-#include "npu/framework/interface/AclOpCompileInterface.h"
 #include "npu/adapter/acl_device_adapter.h"
+#include "npu/core/NpuVariables.h"
 #include "npu/core/register/OptionRegister.h"
+#include "npu/framework/interface/AclOpCompileInterface.h"
 
 namespace c10::npu {
 
@@ -49,7 +49,7 @@ NPUDeviceRAII::~NPUDeviceRAII() {
   NPUCachingHostAllocator_emptyCache();
   c10::npu::NPUCachingAllocator::emptyCache();
 
-  NPU_CHECK_WARN(c10::npu::DestroyUsedStreams());
+  NPU_CHECK_WARN(c10::backend::DestroyUsedStreams());
   NPU_CHECK_WARN(acl_adapter::ResetUsedDevices());
   // Maintain a basic point of view, who applies for the resource, the
   // resource is released by whom. If aclInit is not a PTA call, then

--- a/npu/core/NpuDeviceRAII.cpp
+++ b/npu/core/NpuDeviceRAII.cpp
@@ -16,6 +16,7 @@ class NPUDeviceRAII {
   virtual ~NPUDeviceRAII();
 
   friend void TryInitDevice();
+
  private:
   NPUDeviceRAII();
   bool need_finalize_;
@@ -25,19 +26,19 @@ void TryInitDevice() {
   static NPUDeviceRAII device;
 }
 
-NPUDeviceRAII::NPUDeviceRAII() : need_finalize_(true){
-  aclError ret = c10::npu::InitDevice();
-  if(ret == ACL_ERROR_REPEAT_INITIALIZE) {
+NPUDeviceRAII::NPUDeviceRAII() : need_finalize_(true) {
+  aclError ret = c10::backend::InitDevice();
+  if (ret == ACL_ERROR_REPEAT_INITIALIZE) {
     need_finalize_ = false;
   }
   // Init allocator
   c10::npu::NPUCachingAllocator::init(c10::backend::CachingAllocator::get());
 
   c10::DeviceIndex device_id;
-  ret = c10::npu::GetDevice(&device_id);
+  ret = c10::backend::GetDevice(&device_id);
   if (ret != ACL_ERROR_NONE) {
     device_id = (device_id == -1) ? 0 : device_id;
-    NPU_CHECK_ERROR(c10::npu::SetDevice(device_id));
+    NPU_CHECK_ERROR(c10::backend::SetDevice(device_id));
   }
 
   // set default jit_Compile value from Get acl defalut value
@@ -45,7 +46,6 @@ NPUDeviceRAII::NPUDeviceRAII() : need_finalize_(true){
 }
 
 NPUDeviceRAII::~NPUDeviceRAII() {
-
   NPUCachingHostAllocator_emptyCache();
   c10::npu::NPUCachingAllocator::emptyCache();
 
@@ -58,7 +58,7 @@ NPUDeviceRAII::~NPUDeviceRAII() {
   // TODO: The order of destruction cannot be guaranteed. Finalize is not
   // performed to ensure that the program runs normally.
   // if (need_finalize_) {
-  //   c10::npu::FinalizeDevice();
+  //   c10::backend::FinalizeDevice();
   // }
 }
 

--- a/npu/core/interface/AsyncTaskQueueInterface.cpp
+++ b/npu/core/interface/AsyncTaskQueueInterface.cpp
@@ -61,7 +61,7 @@ AsyncCopyTask::AsyncCopyTask(
 void AsyncCopyTask::LaunchCopyTask() {
   RECORD_FUNCTION(
       CopyParas::COPY_PARAS_MAP[copyParam_.kind], std::vector<c10::IValue>({}));
-  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
+  c10::backend::NPUStream stream = c10::backend::getCurrentNPUStream();
   NPU_CHECK_ERROR(aclrtMemcpyAsync(
       copyParam_.dst,
       copyParam_.dstLen,

--- a/npu/framework/FormatHelper.cpp
+++ b/npu/framework/FormatHelper.cpp
@@ -1,7 +1,7 @@
 #include "npu/core/npu_log.h"
 
-#include "npu/core/NPUBridge.h"
 #include "npu/core/DeviceUtils.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/core/NPUException.h"
 #include "npu/framework/FormatHelper.h"
 
@@ -119,7 +119,7 @@ std::unordered_map<aclFormat, FormatHelper::FormatInfo> FormatHelper::info = {
 
 bool FormatHelper::IsPadded(const at::Tensor* tensor) {
   auto format =
-      torch_backend::NPUBridge::GetNpuStorageImplDesc(*tensor).npu_format_;
+      c10::backend::NPUBridge::GetNpuStorageImplDesc(*tensor).npu_format_;
   return IsPadded(format);
 }
 
@@ -142,7 +142,8 @@ char* FormatHelper::GetFormatName(aclFormat format) {
 }
 
 char* FormatHelper::GetFormatName(const at::Tensor& tensor) {
-  auto format = torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
+  auto format =
+      c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
   return GetFormatName(format);
 }
 
@@ -161,7 +162,7 @@ aclFormat FormatHelper::GetBaseFormat(aclFormat format) {
 }
 
 aclFormat FormatHelper::GetFormat(const at::Tensor& tensor) {
-  return torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
+  return c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
 }
 
 bool FormatHelper::IsBaseFormatType(aclFormat format) {
@@ -169,12 +170,13 @@ bool FormatHelper::IsBaseFormatType(aclFormat format) {
 }
 
 bool FormatHelper::IsBaseFormatType(const at::Tensor& tensor) {
-  auto format = torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
+  auto format =
+      c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
   return IsBaseFormatType(format);
 }
 
 FormatShape FormatHelper::GetStorageSizes(
-    const torch_backend::NPUStorageDesc& desc) {
+    const c10::backend::NPUStorageDesc& desc) {
   auto ori_size = desc.base_sizes_;
   auto format = desc.npu_format_;
   auto dtype = desc.data_type_;
@@ -186,7 +188,7 @@ bool FormatHelper::IsOpInputBaseFormat(const at::Tensor& tensor) {
     return true;
   }
   const auto format =
-      torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
+      c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor).npu_format_;
   return (format == ACL_FORMAT_ND) || (format == ACL_FORMAT_NCHW) ||
       (format == ACL_FORMAT_NHWC) || (format == ACL_FORMAT_NCDHW);
 }
@@ -566,8 +568,8 @@ at::Tensor& FormatHelper::unsafe_format_cast(
     at::Tensor& self,
     int64_t self_format,
     int64_t result_format) {
-  torch_backend::NPUStorageDesc& self_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
+  c10::backend::NPUStorageDesc& self_desc =
+      c10::backend::NPUBridge::GetNpuStorageImpl(self)->npu_desc_;
   if (self_format == ACL_FORMAT_ND && result_format == ACL_FORMAT_NC1HWC0) {
     auto itemsize = self_desc.data_type_.itemsize();
     self_desc.storage_sizes_ = InferShape4To5(self.sizes(), itemsize);

--- a/npu/framework/FormatHelper.h
+++ b/npu/framework/FormatHelper.h
@@ -41,7 +41,7 @@ class FormatHelper {
       caffe2::TypeMeta dtype);
   // GetStorageSizes used to calculate the storage sizes of op at npu device at
   // different format.
-  static FormatShape GetStorageSizes(const torch_backend::NPUStorageDesc& desc);
+  static FormatShape GetStorageSizes(const c10::backend::NPUStorageDesc& desc);
   static at::Tensor& unsafe_format_cast(
       at::Tensor& self,
       int64_t self_format,

--- a/npu/framework/InferFormat.cpp
+++ b/npu/framework/InferFormat.cpp
@@ -1,6 +1,6 @@
 #include "npu/framework/InferFormat.h"
-#include "npu/core/NPUBridge.h"
 #include "csrc/backend/NPUStorageImpl.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/core/register/OptionsManager.h"
 #include "npu/framework/FormatHelper.h"
 
@@ -9,7 +9,7 @@ namespace native {
 
 aclFormat InferFormat::GuessFormatWhenContiguous(const at::Tensor& tensor) {
   // fix: when input tensor is a FakeTensor without desc.
-  auto tensor_storage_impl = torch_backend::NPUBridge::GetNpuStorageImpl(tensor);
+  auto tensor_storage_impl = c10::backend::NPUBridge::GetNpuStorageImpl(tensor);
   if (tensor_storage_impl->data_ptr() == nullptr) {
     return ACL_FORMAT_ND;
   }
@@ -95,9 +95,9 @@ FormatShape InferFormat::GuessStorageSizeWhenConvertFormat(
     const at::Tensor& tensor) {
   auto format = FormatHelper::GetFormat(tensor);
   auto size =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_.base_sizes_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_.base_sizes_;
   auto dtype =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_.data_type_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_.data_type_;
   // TransData: ND->NZ, ND size < 2, we can expand dimension to 2, the storage
   // have no effect. now, only ND->NZ and NZ->ND will call transdata， so we no
   // need to check other format.

--- a/npu/framework/OpCmdHelper.cpp
+++ b/npu/framework/OpCmdHelper.cpp
@@ -1,6 +1,6 @@
 #include "npu/framework/OpCmdHelper.h"
-#include "npu/core/NPUBridge.h"
 #include "csrc/backend/NPUStorageImpl.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/InferFormat.h"
 #include "npu/framework/OpParamMaker.h"
@@ -16,7 +16,7 @@ std::tuple<aclTensorDesc*, aclDataBuffer*> OpCmdHelper::CovertTensorToAclInput(
   at::ScalarType scalarDataType = tensor.scalar_type();
   aclDataType aclDataType =
       CalcuOpUtil::ConvertToAclDataType(scalarDataType, forceDataType);
-  const auto& npuDesc = torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor);
+  const auto& npuDesc = c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor);
   c10::SmallVector<int64_t, 5> storageDims;
   // if aclDataType is ACL_STRING, storageDims is empty.
   if (aclDataType != ACL_STRING) {
@@ -114,7 +114,7 @@ std::tuple<aclTensorDesc*, aclDataBuffer*> OpCmdHelper::CovertToAclOutput(
     const string& forceDataType) {
   aclDataType aclDataType =
       CalcuOpUtil::ConvertToAclDataType(tensor.scalar_type(), forceDataType);
-  const auto& npuDesc = torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor);
+  const auto& npuDesc = c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor);
   const auto& dims = tensor.sizes();
   auto& storageDims = npuDesc.storage_sizes_;
   AclTensorDescMaker desc;

--- a/npu/framework/OpCommand.cpp
+++ b/npu/framework/OpCommand.cpp
@@ -185,7 +185,7 @@ OpCommand& OpCommand::AddTensorInput(
     tensor = custom_ops::npu_dtype_cast(tensor, commonType.value());
   }
   // as for dim=0, the dtype of tensor can not be `uint16` because of `TBE`
-  if (torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor)
+  if (c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor)
           .storage_sizes_.empty()) {
     if (torch_backend::utils::is_npu(tensor)) {
       res = OpCmdHelper::CovertNPUTensorWithZeroDimToAclInput(tensor, descName);

--- a/npu/framework/OpCommand.cpp
+++ b/npu/framework/OpCommand.cpp
@@ -261,7 +261,7 @@ at::Tensor OpCommand::CopyHostToDevice(
 at::Tensor OpCommand::CopyHostToDevice(const at::Tensor& cpuTensor) {
   at::Tensor cpuPinMemTensor = cpuTensor.pin_memory();
   c10::DeviceIndex deviceIndex = 0;
-  NPU_CHECK_ERROR(c10::npu::GetDevice(&deviceIndex));
+  NPU_CHECK_ERROR(c10::backend::GetDevice(&deviceIndex));
   auto tensor = cpuPinMemTensor.to(
       c10::Device(c10::DeviceType::PrivateUse1, deviceIndex),
       cpuPinMemTensor.scalar_type(),

--- a/npu/framework/OpCommand.cpp
+++ b/npu/framework/OpCommand.cpp
@@ -170,7 +170,7 @@ OpCommand& OpCommand::Sync(c10::SmallVector<int64_t, N>& index) {
 }
 
 OpCommand& OpCommand::Sync() {
-  c10::npu::NPUStream stream = c10::npu::getCurrentNPUStream();
+  c10::backend::NPUStream stream = c10::backend::getCurrentNPUStream();
   NPU_CHECK_ERROR(aclrtSynchronizeStreamWithTimeout(stream, -1));
   return *this;
 }

--- a/npu/framework/OpParamMaker.cpp
+++ b/npu/framework/OpParamMaker.cpp
@@ -89,7 +89,7 @@ void OpAttrMaker::Set(
 }
 
 void OpCommandImpl::SetEnginePriority() {
-  auto stream = c10::npu::getCurrentNPUStream();
+  auto stream = c10::backend::getCurrentNPUStream();
   AddAttr("_performance_prior", true);
   AddAttr<std::string>("_exclude_engines", "AiCore");
 }
@@ -126,7 +126,7 @@ aclError OpCommandImpl::InnerRun(
     c10::SmallVector<int64_t, N>& sync_index,
     c10::SmallVector<at::Tensor, N>& outputTensor) {
   aclError ret;
-  auto stream = c10::npu::getCurrentNPUStream();
+  auto stream = c10::backend::getCurrentNPUStream();
   auto inputSize = params.inBuffer.size();
   auto outputSize = params.outBuffer.size();
   // open the deterministicAlgorithms config

--- a/npu/framework/OpParamMaker.h
+++ b/npu/framework/OpParamMaker.h
@@ -4,8 +4,8 @@
 #include "csrc/backend/NPUStream.h"
 
 #include <thread>
-#include "csrc/core/Macros.h"
 #include "csrc/backend/NPUStorageImpl.h"
+#include "csrc/core/Macros.h"
 #include "npu/acl/include/acl/acl_base.h"
 #include "npu/core/interface/AsyncTaskQueueInterface.h"
 #include "npu/core/register/OptionsManager.h"
@@ -55,7 +55,7 @@ class AclTensorDescMaker {
 
   AclTensorDescMaker& Create(
       aclDataType dataType,
-      torch_backend::NPUStorageDesc storageDesc) {
+      c10::backend::NPUStorageDesc storageDesc) {
     c10::SmallVector<int64_t, 5> dims;
     // if aclDataType is ACL_STRING, storageDims is empty.
     if (dataType != ACL_STRING) {

--- a/npu/framework/StorageDescHelper.cpp
+++ b/npu/framework/StorageDescHelper.cpp
@@ -1,7 +1,7 @@
 #include "npu/framework/StorageDescHelper.h"
 #include <c10/util/accumulate.h>
-#include "npu/core/NPUBridge.h"
 #include "csrc/backend/NPUStorageImpl.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/framework/FormatHelper.h"
 #include "npu/framework/InferFormat.h"
 
@@ -9,15 +9,15 @@ namespace at_npu {
 namespace native {
 
 bool StorageDescHelper::MetaDataAreMatch(const at::Tensor* tensor) {
-  auto& desc = torch_backend::NPUBridge::GetNpuStorageImplDesc(*tensor);
+  auto& desc = c10::backend::NPUBridge::GetNpuStorageImplDesc(*tensor);
   return IsSameSize(desc.base_sizes_, tensor->sizes()) &&
       IsSameSize(desc.base_strides_, tensor->strides());
 }
 
 // copy related
 bool StorageDescHelper::IsSameDesc(
-    const torch_backend::NPUStorageDesc& a,
-    const torch_backend::NPUStorageDesc& b) {
+    const c10::backend::NPUStorageDesc& a,
+    const c10::backend::NPUStorageDesc& b) {
   if ((a.origin_format_ != b.origin_format_) ||
       (a.npu_format_ != b.npu_format_)) {
     if ((!FormatHelper::IsBaseFormatType(a.npu_format_)) ||
@@ -31,8 +31,8 @@ bool StorageDescHelper::IsSameDesc(
 }
 
 bool StorageDescHelper::IsSameDesc(const at::Tensor& a, const at::Tensor& b) {
-  const auto& descA = torch_backend::NPUBridge::GetNpuStorageImplDesc(a);
-  const auto& descB = torch_backend::NPUBridge::GetNpuStorageImplDesc(b);
+  const auto& descA = c10::backend::NPUBridge::GetNpuStorageImplDesc(a);
+  const auto& descB = c10::backend::NPUBridge::GetNpuStorageImplDesc(b);
   return IsSameDesc(descA, descB);
 }
 
@@ -46,7 +46,7 @@ bool StorageDescHelper::IsSameSize(
 }
 
 void StorageDescHelper::UpdateDesc(
-    torch_backend::NPUStorageDesc& npuDesc,
+    c10::backend::NPUStorageDesc& npuDesc,
     const c10::IntArrayRef& new_data_sizes,
     const c10::IntArrayRef& new_shape_sizes) {
   int64_t new_data_numel = c10::multiply_integers(new_data_sizes);
@@ -89,7 +89,7 @@ FormatShape StorageDescHelper::ComputeStrideFromShape(
 }
 
 void StorageDescHelper::SetDesc(at::Tensor& dst) {
-  torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_ =
+  c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_ =
       SetDesc(dst.dtype());
 }
 
@@ -97,7 +97,7 @@ void StorageDescHelper::SetDesc(
     at::Tensor& dst,
     const c10::IntArrayRef& size,
     const c10::IntArrayRef& strides) {
-  torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_ =
+  c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_ =
       SetDesc(dst.dtype(), size, strides);
 }
 
@@ -106,13 +106,13 @@ void StorageDescHelper::SetDesc(
     const c10::IntArrayRef& size,
     const c10::IntArrayRef& strides,
     aclFormat format) {
-  torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_ =
+  c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_ =
       SetDesc(dst.dtype(), size, strides, format);
 }
 
 bool StorageDescHelper::CheckDescInit(const c10::Storage& storage) {
   return ACL_FORMAT_UNDEFINED !=
-      torch_backend::NPUBridge::GetNpuStorageImpl(storage.unsafeGetStorageImpl())
+      c10::backend::NPUBridge::GetNpuStorageImpl(storage.unsafeGetStorageImpl())
           ->npu_desc_.origin_format_;
 }
 
@@ -120,11 +120,11 @@ void StorageDescHelper::GetDescForSerialization(
     const at::Tensor& tensor,
     std::unordered_map<std::string, bool>& desc_map) {
   // fix: when input tensor is a FakeTensor without desc.
-  auto tensor_storage_impl = torch_backend::NPUBridge::GetNpuStorageImpl(tensor);
+  auto tensor_storage_impl = c10::backend::NPUBridge::GetNpuStorageImpl(tensor);
   if (tensor_storage_impl->data_ptr() == nullptr) {
     return;
   }
-  auto& desc = torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor);
+  auto& desc = c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor);
   // Record all NPUStorageDesc information
   // Due to the limitation of pytorch extension, it is decided to store
   // information in the key For example, NPUStorageDesc.base_sizes_ is a vector
@@ -175,9 +175,9 @@ void StorageDescHelper::GetDescForSerialization(
 void StorageDescHelper::SetDescForSerialization(
     const at::Tensor& tensor,
     std::unordered_map<std::string, bool>& desc_map) {
-  auto& cur_desc = torch_backend::NPUBridge::GetNpuStorageImplDesc(tensor);
+  auto& cur_desc = c10::backend::NPUBridge::GetNpuStorageImplDesc(tensor);
   // The NPUStorageDesc object to restore
-  struct torch_backend::NPUStorageDesc load_desc;
+  struct c10::backend::NPUStorageDesc load_desc;
 
   auto str_to_small_vector =
       [](std::string str) -> c10::SmallVector<int64_t, 5> {
@@ -225,42 +225,42 @@ void StorageDescHelper::CopyDesc(at::Tensor& dst, const at::Tensor& src) {
 void StorageDescHelper::CopyDesc(at::Tensor& dst, const c10::Storage& src) {
   CopyDesc(
       dst,
-      torch_backend::NPUBridge::GetNpuStorageImpl(src.unsafeGetStorageImpl())
+      c10::backend::NPUBridge::GetNpuStorageImpl(src.unsafeGetStorageImpl())
           ->npu_desc_);
 }
 
 void StorageDescHelper::CopyDesc(
     const at::Tensor& dst,
-    const torch_backend::NPUStorageDesc& src_desc) {
-  auto& dstDesc = torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
+    const c10::backend::NPUStorageDesc& src_desc) {
+  auto& dstDesc = c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
   dstDesc = src_desc;
 }
 
 void StorageDescHelper::ReflushDescBySelf(const at::Tensor& src) {
-  auto& desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto& desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   desc.base_sizes_ = src.sizes();
   desc.storage_sizes_ = src.sizes();
   desc.base_strides_ = src.strides();
 }
 
-torch_backend::NPUStorageDesc StorageDescHelper::SetDesc(
+c10::backend::NPUStorageDesc StorageDescHelper::SetDesc(
     const caffe2::TypeMeta& dtype) {
   return SetDesc(dtype, {0}, {});
 }
 
-torch_backend::NPUStorageDesc StorageDescHelper::SetDesc(
+c10::backend::NPUStorageDesc StorageDescHelper::SetDesc(
     const caffe2::TypeMeta& dtype,
     const c10::IntArrayRef& size,
     const c10::IntArrayRef& strides) {
   return SetDesc(dtype, size, strides, InferFormat::GuessBaseFormat(size));
 }
 
-torch_backend::NPUStorageDesc StorageDescHelper::SetDesc(
+c10::backend::NPUStorageDesc StorageDescHelper::SetDesc(
     const caffe2::TypeMeta& dtype,
     const c10::IntArrayRef& size,
     const c10::IntArrayRef& strides,
     aclFormat format) {
-  struct torch_backend::NPUStorageDesc npu_desc;
+  struct c10::backend::NPUStorageDesc npu_desc;
   npu_desc.data_type_ = dtype;
   npu_desc.base_sizes_ = size;
   npu_desc.base_strides_ = strides;
@@ -279,13 +279,13 @@ torch_backend::NPUStorageDesc StorageDescHelper::SetDesc(
 }
 
 int64_t StorageDescHelper::GetMemorySize(
-    const torch_backend::NPUStorageDesc& desc) {
+    const c10::backend::NPUStorageDesc& desc) {
   const auto& physical_size = FormatHelper::GetStorageSizes(desc);
   return c10::multiply_integers(physical_size);
 }
 
 int64_t StorageDescHelper::GetMemorySize(const at::Tensor& dst) {
-  auto desc = torch_backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
+  auto desc = c10::backend::NPUBridge::GetNpuStorageImpl(dst)->npu_desc_;
   return GetMemorySize(desc);
 }
 

--- a/npu/framework/StorageDescHelper.h
+++ b/npu/framework/StorageDescHelper.h
@@ -23,8 +23,8 @@ class StorageDescHelper {
 
   // helper function of transdata op.
   static bool IsSameDesc(
-      const torch_backend::NPUStorageDesc& a,
-      const torch_backend::NPUStorageDesc& b);
+      const c10::backend::NPUStorageDesc& a,
+      const c10::backend::NPUStorageDesc& b);
   static bool IsSameDesc(const at::Tensor& a, const at::Tensor& b);
 
   // calculate storage size need by npu memory
@@ -63,10 +63,10 @@ class StorageDescHelper {
   static void CopyDesc(at::Tensor& dst, const c10::Storage& src);
   static void CopyDesc(
       const at::Tensor& dst,
-      const torch_backend::NPUStorageDesc& src_desc);
+      const c10::backend::NPUStorageDesc& src_desc);
 
   static void UpdateDesc(
-      torch_backend::NPUStorageDesc& npuDesc,
+      c10::backend::NPUStorageDesc& npuDesc,
       const c10::IntArrayRef& new_data_sizes,
       const c10::IntArrayRef& new_shape_sizes);
 
@@ -80,14 +80,14 @@ class StorageDescHelper {
   static bool IsSameSize(
       const c10::SmallVector<int64_t, 5>& a,
       const c10::IntArrayRef& b);
-  static int64_t GetMemorySize(const torch_backend::NPUStorageDesc& dst);
+  static int64_t GetMemorySize(const c10::backend::NPUStorageDesc& dst);
   // Set Part
-  static torch_backend::NPUStorageDesc SetDesc(const caffe2::TypeMeta& dtype);
-  static torch_backend::NPUStorageDesc SetDesc(
+  static c10::backend::NPUStorageDesc SetDesc(const caffe2::TypeMeta& dtype);
+  static c10::backend::NPUStorageDesc SetDesc(
       const caffe2::TypeMeta& dtype,
       const c10::IntArrayRef& size,
       const c10::IntArrayRef& strides);
-  static torch_backend::NPUStorageDesc SetDesc(
+  static c10::backend::NPUStorageDesc SetDesc(
       const caffe2::TypeMeta& dtype,
       const c10::IntArrayRef& size,
       const c10::IntArrayRef& strides,

--- a/npu/framework/contiguous/ContiguousOpt.cpp
+++ b/npu/framework/contiguous/ContiguousOpt.cpp
@@ -14,7 +14,7 @@ ContiguousTensorDesc TransContiguous::GetTensorDescInfo(
     const at::Tensor& src,
     const OptimizationCases& opt_cases) {
   auto src_base_info =
-      torch_backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc();
+      c10::backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc();
   c10::SmallVector<int64_t, MAX_DIM> src_size_inferred;
   c10::SmallVector<int64_t, MAX_DIM> src_stride_inferred;
   c10::SmallVector<int64_t, MAX_DIM> src_storage_size_inferred =
@@ -54,7 +54,7 @@ bool TransContiguous::CheckClone(const at::Tensor& src, at::Tensor& self) {
   // 2. full memory copy: size match between src and self
   if (StorageDescHelper::OffsetAreMatch(&self) && self.is_contiguous() &&
       src.sizes().equals(self.sizes()) &&
-      self.sizes().equals(torch_backend::NPUBridge::GetNpuStorageImpl(self)
+      self.sizes().equals(c10::backend::NPUBridge::GetNpuStorageImpl(self)
                               ->get_npu_desc()
                               .base_sizes_)) {
     return true;
@@ -193,7 +193,9 @@ c10::optional<at::Tensor> TransContiguous::ContiguousOptimizeWithAnyFormat(
   auto self = OpPreparation::ApplyTensorWithFormat(
       src.sizes(),
       src.options(),
-      torch_backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc().npu_format_);
+      c10::backend::NPUBridge::GetNpuStorageImpl(src)
+          ->get_npu_desc()
+          .npu_format_);
   ContiguousTensorDesc src_desc = GetTensorDescInfo(src, opt_cases);
   if (cached_contiguous_optimize_with_anyformat_(self, src, src_desc)) {
     return self;

--- a/npu/framework/contiguous/combined_opt.cpp
+++ b/npu/framework/contiguous/combined_opt.cpp
@@ -79,7 +79,7 @@ class CombinedContiguousOpt : public ContiguousOpt {
       OffsetStack& offset_stack) {
     // Record src infos for recovering after trans-contiguous
     auto src_storage_desc =
-        torch_backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc();
+        c10::backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc();
 
     at::Tensor base_tensor =
         at::empty(src_storage_desc.base_sizes_, src.options());
@@ -109,7 +109,7 @@ class CombinedContiguousOpt : public ContiguousOpt {
       return false;
     }
     auto npu_desc =
-        torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->get_npu_desc();
+        c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->get_npu_desc();
     if ((c10::multiply_integers(tensor.sizes()) !=
          c10::multiply_integers(npu_desc.base_sizes_)) ||
         (tensor.storage_offset() != npu_desc.base_offset_)) {
@@ -480,7 +480,7 @@ Inference order: permute, select, slice.
         auto transfer_tensor = OpPreparation::ApplyTensorWithFormat(
             src.sizes(),
             src.options(),
-            torch_backend::NPUBridge::GetNpuStorageImpl(src)
+            c10::backend::NPUBridge::GetNpuStorageImpl(src)
                 ->get_npu_desc()
                 .npu_format_);
         return (

--- a/npu/framework/contiguous/permute_opt.cpp
+++ b/npu/framework/contiguous/permute_opt.cpp
@@ -1,8 +1,8 @@
-#include "npu/core/NPUBridge.h"
 #include "csrc/backend/NPUStorageImpl.h"
+#include "npu/aten/OpInterface.h"
+#include "npu/core/NPUBridge.h"
 #include "npu/framework/contiguous/ContiguousOpt.h"
 #include "npu/framework/utils/OpAdapter.h"
-#include "npu/aten/OpInterface.h"
 
 namespace at_npu {
 namespace native {
@@ -74,8 +74,8 @@ class PermuteContiguousOpt : public ContiguousOpt {
       const c10::SmallVector<int64_t, MAX_DIM>& sizes) {
     // Refresh src Tensor to match output self Tensor
     auto src_desc_stored =
-        torch_backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc();
-    auto& src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+        c10::backend::NPUBridge::GetNpuStorageImpl(src)->get_npu_desc();
+    auto& src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
     src_desc.base_sizes_ = sizes;
     src_desc.base_strides_ = StorageDescHelper::ComputeStrideFromShape(
         static_cast<FormatShape>(sizes));

--- a/npu/framework/utils/CalcuOpUtil.cpp
+++ b/npu/framework/utils/CalcuOpUtil.cpp
@@ -186,7 +186,7 @@ at::Tensor CalcuOpUtil::CopyScalarToDevice(
 at::Tensor CalcuOpUtil::CopyTensorHostToDevice(const at::Tensor& cpu_tensor) {
   at::Tensor cpuPinMemTensor = cpu_tensor.pin_memory();
   c10::DeviceIndex deviceIndex = 0;
-  NPU_CHECK_ERROR(c10::npu::GetDevice(&deviceIndex));
+  NPU_CHECK_ERROR(c10::backend::GetDevice(&deviceIndex));
   return cpuPinMemTensor.to(
       c10::Device(c10::DeviceType::PrivateUse1, deviceIndex),
       cpuPinMemTensor.scalar_type(),

--- a/npu/framework/utils/CalcuOpUtil.cpp
+++ b/npu/framework/utils/CalcuOpUtil.cpp
@@ -277,8 +277,8 @@ int64_t CalcuOpUtil::GetTensorNpuFormat(const at::Tensor& tensor) {
       "device is correct.",
       OPS_ERROR(ErrCode::TYPE));
   if (NpuUtils::check_match(&tensor) || NpuUtils::check_5d_5d_match(tensor)) {
-    const torch_backend::NPUStorageDesc& tensor_desc =
-        torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
+    const c10::backend::NPUStorageDesc& tensor_desc =
+        c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
     return tensor_desc.npu_format_;
   } else if (tensor.data_ptr() == nullptr) {
     // transforming faketensor into realtensor and assigning format ND

--- a/npu/framework/utils/NpuUtils.cpp
+++ b/npu/framework/utils/NpuUtils.cpp
@@ -260,7 +260,7 @@ bool NpuUtils::IsOomError(aclError ret, int index) {
     // free devcie cached memory when return value of the first op execution is
     // oom
     if (index == 1) {
-      NPU_CHECK_ERROR(c10::npu::GetDevice(&deviceId));
+      NPU_CHECK_ERROR(c10::backend::GetDevice(&deviceId));
       c10::npu::NPUCachingAllocator::emptyDeviceCache(deviceId);
       return true;
     }

--- a/npu/framework/utils/NpuUtils.cpp
+++ b/npu/framework/utils/NpuUtils.cpp
@@ -70,8 +70,8 @@ bool NpuUtils::check_5d_5d_match(const at::Tensor& tensor) {
     return false;
   }
 
-  if (torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_.npu_format_ !=
-      ACL_FORMAT_NC1HWC0) {
+  if (c10::backend::NPUBridge::GetNpuStorageImpl(tensor)
+          ->npu_desc_.npu_format_ != ACL_FORMAT_NC1HWC0) {
     return false;
   }
 
@@ -99,9 +99,9 @@ bool NpuUtils::check_5d_5d_match(const at::Tensor& tensor) {
   int64_t c0_len = 16;
   for (const auto i : c10::irange(
            2,
-           torch_backend::NPUBridge::GetNpuStorageImpl(tensor)
+           c10::backend::NPUBridge::GetNpuStorageImpl(tensor)
                ->npu_desc_.base_sizes_.size())) {
-    contiguous_len *= torch_backend::NPUBridge::GetNpuStorageImpl(tensor)
+    contiguous_len *= c10::backend::NPUBridge::GetNpuStorageImpl(tensor)
                           ->npu_desc_.base_sizes_[i];
   }
   bool is_offset_match = (tensor.storage_offset() % contiguous_len == 0);
@@ -112,7 +112,7 @@ bool NpuUtils::check_5d_5d_match(const at::Tensor& tensor) {
 
 void NpuUtils::RefreshFormat(const at::Tensor& tensor) {
   auto& tensor_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
   if (tensor_desc.storage_sizes_.size() == 4 &&
       tensor_desc.npu_format_ == ACL_FORMAT_ND) {
     tensor_desc.npu_format_ = ACL_FORMAT_NCHW;
@@ -151,7 +151,7 @@ at::Tensor metadata_convert_match_without_copy_optimize(const at::Tensor& src) {
       "Expected all tensors to be on the same device. "
       "Expected NPU tensor, please check whether the input tensor device is correct.",
       OPS_ERROR(ErrCode::TYPE));
-  auto& src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto& src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   bool numelEq = (src.numel() == c10::multiply_integers(src_desc.base_sizes_));
   return metadata_convert_match(src, numelEq);
 }
@@ -162,7 +162,7 @@ at::Tensor metadata_convert_match_with_copy_optimize(const at::Tensor& src) {
       "Expected all tensors to be on the same device. "
       "Expected NPU tensor, please check whether the input tensor device is correct.",
       OPS_ERROR(ErrCode::TYPE));
-  auto& src_desc = torch_backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
+  auto& src_desc = c10::backend::NPUBridge::GetNpuStorageImpl(src)->npu_desc_;
   bool numelEq = (src.numel() == c10::multiply_integers(src_desc.base_sizes_));
 
   // For unmatched Tensors with base format, we can:

--- a/npu/framework/utils/OpPreparation.cpp
+++ b/npu/framework/utils/OpPreparation.cpp
@@ -133,7 +133,7 @@ bool OpPreparation::is_scalar_wrapped_to_tensor(const at::Tensor& tensor) {
 
 c10::SmallVector<int64_t, 5> OpPreparation::get_tensor_desc_base_sizes(
     const at::Tensor& tensor) {
-  return torch_backend::NPUBridge::GetNpuStorageImpl(tensor)
+  return c10::backend::NPUBridge::GetNpuStorageImpl(tensor)
       ->get_npu_desc()
       .base_sizes_;
 }
@@ -237,14 +237,14 @@ void OpPreparation::check_memory(
 
 at::Tensor OpPreparation::cast_to_ori_format(const at::Tensor& tensor) {
   auto& tensor_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
   auto ret = custom_ops::npu_format_cast(tensor, tensor_desc.origin_format_);
   return ret;
 }
 
 at::Tensor& OpPreparation::cast_to_ori_format(at::Tensor& tensor) {
   auto& tensor_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
   NPUNativeFunctions::npu_format_cast_(tensor, tensor_desc.origin_format_);
   return tensor;
 }
@@ -406,14 +406,14 @@ void OpPreparation::CheckOut(
 
 at::Tensor OpPreparation::CastBackToOriFormat(const at::Tensor& tensor) {
   auto& tensor_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
   auto ret = custom_ops::npu_format_cast(tensor, tensor_desc.origin_format_);
   return ret;
 }
 
 at::Tensor& OpPreparation::CastBackToOriFormat(at::Tensor& tensor) {
   auto& tensor_desc =
-      torch_backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
+      c10::backend::NPUBridge::GetNpuStorageImpl(tensor)->npu_desc_;
   NPUNativeFunctions::npu_format_cast_(tensor, tensor_desc.origin_format_);
   return tensor;
 }
@@ -459,7 +459,7 @@ at::Tensor OpPreparation::unsafe_empty_workspace(uint64_t workspace_size) {
   ASCEND_LOGD("Alloc workspace %zu bytes unsafely.", workspace_size);
   c10::Allocator* allocator = c10::npu::NPUCachingAllocator::get();
   c10::intrusive_ptr<c10::StorageImpl> storage_impl =
-      c10::make_intrusive<torch_backend::NPUStorageImpl>(
+      c10::make_intrusive<c10::backend::NPUStorageImpl>(
           c10::StorageImpl::use_byte_size_t(),
           workspace_size,
           allocator->allocate(workspace_size),
@@ -467,7 +467,7 @@ at::Tensor OpPreparation::unsafe_empty_workspace(uint64_t workspace_size) {
           true);
   static auto dtype = c10::scalarTypeToTypeMeta(dtype_or_default(at::kByte));
   auto tensor =
-      at::detail::make_tensor<torch_backend::NPUTensorImpl>(storage_impl, dtype);
+      at::detail::make_tensor<c10::backend::NPUTensorImpl>(storage_impl, dtype);
   tensor.unsafeGetTensorImpl()->empty_tensor_restride(
       c10::MemoryFormat::Contiguous);
   return tensor;

--- a/test/cpp/backend/context_test.cpp
+++ b/test/cpp/backend/context_test.cpp
@@ -2,10 +2,10 @@
 #include "csrc/backend/NPUContext.h"
 
 TEST(NPUContextTest, TestGetDeviceProperties) {
-  if (!c10::npu::is_available()) {
+  if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto prop = c10::npu::getDeviceProperties(0);
+  auto prop = c10::backend::getDeviceProperties(0);
   EXPECT_NE(prop->name, " ");
 }

--- a/test/cpp/backend/generator_test.cpp
+++ b/test/cpp/backend/generator_test.cpp
@@ -3,7 +3,7 @@
 #include "csrc/backend/NPUContext.h"
 
 TEST(NPUGeneratorImpl, TestSingletonDefaultGenerator) {
-  if (!c10::npu::is_available()) {
+  if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -13,7 +13,7 @@ TEST(NPUGeneratorImpl, TestSingletonDefaultGenerator) {
 }
 
 TEST(NPUGeneratorImpl, TestCloning) {
-  if (!c10::npu::is_available()) {
+  if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -31,7 +31,7 @@ TEST(NPUGeneratorImpl, TestCloning) {
 }
 
 TEST(NPUGeneratorImpl, TestGetSetCurrentSeed) {
-  if (!c10::npu::is_available()) {
+  if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -47,7 +47,7 @@ TEST(NPUGeneratorImpl, TestDeviceType) {
 }
 
 TEST(NPUGeneratorImpl, TestGetSetOffset) {
-  if (!c10::npu::is_available()) {
+  if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
@@ -58,7 +58,7 @@ TEST(NPUGeneratorImpl, TestGetSetOffset) {
 }
 
 TEST(NPUGeneratorImpl, TestGetSetPhiloxOffset) {
-  if (!c10::npu::is_available()) {
+  if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 

--- a/test/cpp/backend/generator_test.cpp
+++ b/test/cpp/backend/generator_test.cpp
@@ -1,14 +1,14 @@
 #include <gtest/gtest.h>
-#include "csrc/backend/NPUGeneratorImpl.h"
 #include "csrc/backend/NPUContext.h"
+#include "csrc/backend/NPUGeneratorImpl.h"
 
 TEST(NPUGeneratorImpl, TestSingletonDefaultGenerator) {
   if (!c10::backend::is_available()) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto gen = at_npu::detail::getDefaultNPUGenerator();
-  auto other = at_npu::detail::getDefaultNPUGenerator();
+  auto gen = c10::backend::detail::getDefaultNPUGenerator();
+  auto other = c10::backend::detail::getDefaultNPUGenerator();
   EXPECT_EQ(gen, other);
 }
 
@@ -17,12 +17,12 @@ TEST(NPUGeneratorImpl, TestCloning) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto gen1 = at_npu::detail::createNPUGenerator();
-  auto npu_gen1 = at::check_generator<at_npu::NPUGeneratorImpl>(gen1);
+  auto gen1 = c10::backend::detail::createNPUGenerator();
+  auto npu_gen1 = at::check_generator<c10::backend::NPUGeneratorImpl>(gen1);
 
-  auto gen2 = at_npu::detail::createNPUGenerator();
+  auto gen2 = c10::backend::detail::createNPUGenerator();
   gen2 = gen1.clone();
-  auto npu_gen2 = at::check_generator<at_npu::NPUGeneratorImpl>(gen2);
+  auto npu_gen2 = at::check_generator<c10::backend::NPUGeneratorImpl>(gen2);
 
   EXPECT_EQ(npu_gen1->current_seed(), npu_gen2->current_seed());
   EXPECT_EQ(
@@ -35,15 +35,16 @@ TEST(NPUGeneratorImpl, TestGetSetCurrentSeed) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto gen = at_npu::detail::createNPUGenerator();
-  auto npu_gen = at::check_generator<at_npu::NPUGeneratorImpl>(gen);
+  auto gen = c10::backend::detail::createNPUGenerator();
+  auto npu_gen = at::check_generator<c10::backend::NPUGeneratorImpl>(gen);
   npu_gen->set_current_seed(10);
   EXPECT_EQ(npu_gen->current_seed(), 10);
 }
 
 TEST(NPUGeneratorImpl, TestDeviceType) {
   EXPECT_EQ(
-      at_npu::NPUGeneratorImpl::device_type(), c10::DeviceType::PrivateUse1);
+      c10::backend::NPUGeneratorImpl::device_type(),
+      c10::DeviceType::PrivateUse1);
 }
 
 TEST(NPUGeneratorImpl, TestGetSetOffset) {
@@ -51,8 +52,8 @@ TEST(NPUGeneratorImpl, TestGetSetOffset) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto gen = at_npu::detail::createNPUGenerator();
-  auto npu_gen = at::check_generator<at_npu::NPUGeneratorImpl>(gen);
+  auto gen = c10::backend::detail::createNPUGenerator();
+  auto npu_gen = at::check_generator<c10::backend::NPUGeneratorImpl>(gen);
   npu_gen->set_offset(100);
   EXPECT_EQ(npu_gen->get_offset(), 100);
 }
@@ -62,8 +63,8 @@ TEST(NPUGeneratorImpl, TestGetSetPhiloxOffset) {
     GTEST_SKIP() << "NPU is not available";
   }
 
-  auto gen = at_npu::detail::createNPUGenerator();
-  auto npu_gen = at::check_generator<at_npu::NPUGeneratorImpl>(gen);
+  auto gen = c10::backend::detail::createNPUGenerator();
+  auto npu_gen = at::check_generator<c10::backend::NPUGeneratorImpl>(gen);
   npu_gen->set_philox_offset_per_thread(200);
   EXPECT_EQ(npu_gen->philox_offset_per_thread(), 200);
 }

--- a/torch_backend/csrc/backend/Device.cpp
+++ b/torch_backend/csrc/backend/Device.cpp
@@ -18,10 +18,10 @@ namespace torch::backend::device {
 
 void registerDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
-  py::class_<c10::npu::NPUDeviceProp>(m, "_NPUDeviceProperties")
-      .def_readonly("name", &c10::npu::NPUDeviceProp::name)
-      .def_readonly("total_memory", &c10::npu::NPUDeviceProp::totalGlobalMem)
-      .def("__repr__", [](const c10::npu::NPUDeviceProp& prop) {
+  py::class_<c10::backend::NPUDeviceProp>(m, "_NPUDeviceProperties")
+      .def_readonly("name", &c10::backend::NPUDeviceProp::name)
+      .def_readonly("total_memory", &c10::backend::NPUDeviceProp::totalGlobalMem)
+      .def("__repr__", [](const c10::backend::NPUDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_NPUDeviceProperties(name='" << prop.name
                << "', total_memory="
@@ -39,8 +39,8 @@ void bindGetDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   m.def(
       "_npu_getDeviceProperties",
-      [](c10::DeviceIndex deviceid) -> c10::npu::NPUDeviceProp* {
-        return c10::npu::getDeviceProperties(deviceid);
+      [](c10::DeviceIndex deviceid) -> c10::backend::NPUDeviceProp* {
+        return c10::backend::getDeviceProperties(deviceid);
       },
       py::return_value_policy::reference);
 }

--- a/torch_backend/csrc/backend/Device.cpp
+++ b/torch_backend/csrc/backend/Device.cpp
@@ -20,7 +20,8 @@ void registerDeviceProperties(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   py::class_<c10::backend::NPUDeviceProp>(m, "_NPUDeviceProperties")
       .def_readonly("name", &c10::backend::NPUDeviceProp::name)
-      .def_readonly("total_memory", &c10::backend::NPUDeviceProp::totalGlobalMem)
+      .def_readonly(
+          "total_memory", &c10::backend::NPUDeviceProp::totalGlobalMem)
       .def("__repr__", [](const c10::backend::NPUDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_NPUDeviceProperties(name='" << prop.name
@@ -53,7 +54,7 @@ void init(PyObject* module) {
 PyObject* THNPModule_npuSynchronize(PyObject* _unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
   pybind11::gil_scoped_release no_gil;
-  c10::npu::device_synchronize();
+  c10::backend::device_synchronize();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }
@@ -67,7 +68,7 @@ PyObject* THNPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   }
 
   auto device = THPUtils_unpackLong(arg);
-  c10::npu::set_device(static_cast<c10::DeviceIndex>(device));
+  c10::backend::set_device(static_cast<c10::DeviceIndex>(device));
 
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -77,14 +78,14 @@ PyObject* THNPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   torch::utils::device_lazy_init(at::kPrivateUse1);
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
-  auto device = static_cast<int32_t>(c10::npu::current_device());
+  auto device = static_cast<int32_t>(c10::backend::current_device());
   return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THNPModule_getDeviceCount_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  return THPUtils_packUInt64(c10::npu::device_count());
+  return THPUtils_packUInt64(c10::backend::device_count());
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch_backend/csrc/backend/Event.cpp
+++ b/torch_backend/csrc/backend/Event.cpp
@@ -44,7 +44,7 @@ static PyObject* THNPEvent_pynew(
   unsigned int flags = 0;
   flags =
       enable_timing ? (ACL_EVENT_TIME_LINE | ACL_EVENT_SYNC) : ACL_EVENT_SYNC;
-  new (&self->npu_event) c10::npu::NPUEvent(flags);
+  new (&self->npu_event) c10::backend::NPUEvent(flags);
 
   return (PyObject*)ptr.release();
   END_HANDLE_TH_ERRORS

--- a/torch_backend/csrc/backend/Event.h
+++ b/torch_backend/csrc/backend/Event.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <torch/csrc/python_headers.h>
-#include "csrc/core/Macros.h"
 #include "csrc/backend/NPUEvent.h"
+#include "csrc/core/Macros.h"
 
 namespace torch::backend::event {
 
 struct THNPEvent {
-  PyObject_HEAD c10::npu::NPUEvent npu_event;
+  PyObject_HEAD c10::backend::NPUEvent npu_event;
 };
 extern PyObject* THNPEventClass;
 

--- a/torch_backend/csrc/backend/Init.cpp
+++ b/torch_backend/csrc/backend/Init.cpp
@@ -24,10 +24,10 @@ static PyObject* THNPModule_initExtension(PyObject* self, PyObject* noargs) {
       throw python_error();
     }
   };
-  c10::DeviceIndex num_npus = c10::npu::device_count();
+  c10::DeviceIndex num_npus = c10::backend::device_count();
   auto default_npu_generators = PyTuple_New(static_cast<Py_ssize_t>(num_npus));
   for (c10::DeviceIndex i = 0; i < num_npus; i++) {
-    auto gen = at_npu::detail::getDefaultNPUGenerator(i);
+    auto gen = c10::backend::detail::getDefaultNPUGenerator(i);
     auto cast_gen = (THPGenerator*)THPGenerator_initDefaultGenerator(gen);
     // This reference is meant to be given away, so no need to incref here.
     PyTuple_SetItem(default_npu_generators, i, (PyObject*)cast_gen);

--- a/torch_backend/csrc/backend/Lock.cpp
+++ b/torch_backend/csrc/backend/Lock.cpp
@@ -13,7 +13,7 @@ namespace torch::backend::lock {
 static PyGILState_STATE npuMutexGILState;
 
 PyObject* THNPModule_npuLockMutex(PyObject* module, PyObject* noargs) {
-  auto mutex = c10::npu::getFreeMutex();
+  auto mutex = c10::backend::getFreeMutex();
   // This has to be a busy loop because we **absolutely need to** hold the GIL
   // or it's a recipe for a deadlock otherwise (if we let other Python threads
   // run while we have the cudaMutex, but not the GIL, they might try to e.g.
@@ -34,7 +34,7 @@ PyObject* THNPModule_npuLockMutex(PyObject* module, PyObject* noargs) {
 }
 
 PyObject* THNPModule_npuUnlockMutex(PyObject* module, PyObject* noargs) {
-  auto mutex = c10::npu::getFreeMutex();
+  auto mutex = c10::backend::getFreeMutex();
   PyGILState_Release(npuMutexGILState);
   mutex->unlock();
   Py_RETURN_NONE;

--- a/torch_backend/csrc/backend/Stream.cpp
+++ b/torch_backend/csrc/backend/Stream.cpp
@@ -50,16 +50,16 @@ static PyObject* THNPStream_pynew(
     return nullptr;
   }
 
-  c10::npu::NPUStream stream = (stream_id || device_index || device_type)
-      ? c10::npu::NPUStream::unpack3(
+  c10::backend::NPUStream stream = (stream_id || device_index || device_type)
+      ? c10::backend::NPUStream::unpack3(
             stream_id, device_index, static_cast<c10::DeviceType>(device_type))
-      : c10::npu::getStreamFromPool(false);
+      : c10::backend::getStreamFromPool(false);
 
   THNPStream* self = (THNPStream*)ptr.get();
   self->stream_id = static_cast<int64_t>(stream.id());
   self->device_index = static_cast<int64_t>(stream.device_index());
   self->device_type = static_cast<int64_t>(stream.device_type());
-  new (&self->npu_stream) c10::npu::NPUStream(stream);
+  new (&self->npu_stream) c10::backend::NPUStream(stream);
 
   return (PyObject*)ptr.release();
   END_HANDLE_TH_ERRORS
@@ -212,7 +212,7 @@ void init(PyObject* module) {
   }
 }
 
-std::vector<c10::optional<c10::npu::NPUStream>>
+std::vector<c10::optional<c10::backend::NPUStream>>
 THNPUtils_PySequence_to_NPUStreamList(PyObject* obj) {
   if (!PySequence_Check(obj)) {
     throw std::runtime_error(
@@ -224,13 +224,13 @@ THNPUtils_PySequence_to_NPUStreamList(PyObject* obj) {
         "expected PySequence, but got " + std::string(THPUtils_typename(obj)));
   }
 
-  std::vector<c10::optional<c10::npu::NPUStream>> streams;
+  std::vector<c10::optional<c10::backend::NPUStream>> streams;
   Py_ssize_t length = PySequence_Fast_GET_SIZE(seq.get());
   for (Py_ssize_t i = 0; i < length; i++) {
     PyObject* stream = PySequence_Fast_GET_ITEM(seq.get(), i);
 
     if (PyObject_IsInstance(stream, THNPStreamClass)) {
-      streams.emplace_back(c10::npu::NPUStream::unpack3(
+      streams.emplace_back(c10::backend::NPUStream::unpack3(
           (reinterpret_cast<THNPStream*>(stream))->stream_id,
           (reinterpret_cast<THNPStream*>(stream))->device_index,
           static_cast<c10::DeviceType>(
@@ -253,7 +253,7 @@ PyObject* THNPModule_getCurrentStream_wrap(
       THPUtils_checkLong(device_index), "invalid argument to getCurrentStream");
 
   c10::DeviceIndex device = THPUtils_unpackDeviceIndex(device_index);
-  auto stream = c10::npu::getCurrentNPUStream(device);
+  auto stream = c10::backend::getCurrentNPUStream(device);
   PyObject* output_tuple = PyTuple_New(3);
   PyTuple_SetItem(
       output_tuple, 0, THPUtils_packInt64(static_cast<int64_t>(stream.id())));
@@ -277,7 +277,7 @@ PyObject* THNPModule_getDefaultStream_wrap(
       THPUtils_checkLong(device_index), "invalid argument to getDefaultStream");
 
   c10::DeviceIndex device = THPUtils_unpackDeviceIndex(device_index);
-  auto stream = c10::npu::getDefaultNPUStream(device);
+  auto stream = c10::backend::getDefaultNPUStream(device);
   PyObject* output_tuple = PyTuple_New(3);
   PyTuple_SetItem(
       output_tuple, 0, THPUtils_packInt64(static_cast<int64_t>(stream.id())));
@@ -315,7 +315,7 @@ PyObject* THNPModule_setStream_wrap(
           &device_type)) {
   }
 
-  auto stream = c10::npu::NPUStream::unpack3(
+  auto stream = c10::backend::NPUStream::unpack3(
       stream_id,
       static_cast<c10::DeviceIndex>(device_index),
       static_cast<c10::DeviceType>(device_type));
@@ -324,7 +324,7 @@ PyObject* THNPModule_setStream_wrap(
   if (device != stream.device_index()) {
     c10::npu::set_device(stream.device_index());
   }
-  c10::npu::setCurrentNPUStream(stream);
+  c10::backend::setCurrentNPUStream(stream);
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
 }

--- a/torch_backend/csrc/backend/Stream.cpp
+++ b/torch_backend/csrc/backend/Stream.cpp
@@ -16,7 +16,7 @@ static PyObject* THNPStream_pynew(
   HANDLE_TH_ERRORS
 
   c10::DeviceIndex current_device;
-  NPU_CHECK_ERROR(c10::npu::GetDevice(&current_device));
+  NPU_CHECK_ERROR(c10::backend::GetDevice(&current_device));
 
   int priority = 0;
   int64_t stream_id = 0;
@@ -320,9 +320,9 @@ PyObject* THNPModule_setStream_wrap(
       static_cast<c10::DeviceIndex>(device_index),
       static_cast<c10::DeviceType>(device_type));
 
-  auto device = c10::npu::current_device();
+  auto device = c10::backend::current_device();
   if (device != stream.device_index()) {
-    c10::npu::set_device(stream.device_index());
+    c10::backend::set_device(stream.device_index());
   }
   c10::backend::setCurrentNPUStream(stream);
   Py_RETURN_NONE;

--- a/torch_backend/csrc/backend/Stream.h
+++ b/torch_backend/csrc/backend/Stream.h
@@ -8,7 +8,7 @@
 namespace torch::backend::stream {
 
 struct THNPStream : THPStream {
-  c10::npu::NPUStream npu_stream;
+  c10::backend::NPUStream npu_stream;
 };
 
 TORCH_BACKEND_API void init(PyObject* module);

--- a/torch_backend/csrc/core/python_tensor.cpp
+++ b/torch_backend/csrc/core/python_tensor.cpp
@@ -51,7 +51,7 @@ static PyObject* Tensor_new(
   }();
 
   TORCH_CHECK_TYPE(
-      c10::npu::device_count() != 0,
+      c10::backend::device_count() != 0,
       "type ",
       tensor_type.name,
       " not available.")
@@ -186,9 +186,7 @@ static THPObjectPtr get_tensor_dict() {
   }
 
   auto tensor_type = (PyTypeObject*)tensor_class.get();
-  TORCH_CHECK(
-      tensor_type->tp_base,
-      "missing base type for Tensor");
+  TORCH_CHECK(tensor_type->tp_base, "missing base type for Tensor");
 
   auto res = THPObjectPtr(PyDict_New());
   if (!res) {
@@ -299,4 +297,3 @@ PyMethodDef* python_functions() {
 }
 
 } // namespace torch::backend::tensor
-


### PR DESCRIPTION
Based on namespace design in [here](https://docs.google.com/spreadsheets/d/1iYXjSMNsn2BSeFTQ4YuvCCP1Gw98bFANiOSCERLrM3E/edit?gid=0#gid=0), refactor `csrc/backend` namespace